### PR TITLE
Ralph mainly modifies target_positions for further work

### DIFF
--- a/macrosynergy/panel/make_zn_scores.py
+++ b/macrosynergy/panel/make_zn_scores.py
@@ -90,6 +90,7 @@ def pan_neutral(df: pd.DataFrame, neutral: str = 'zero', sequential: bool = Fals
 
     return ar_neutral
 
+
 def first_value(column: pd.Series):
     """
     Returns the integer index at which the series' first realised value occurs.
@@ -127,6 +128,7 @@ def index_info(df_row_no: int, column: pd.Series, min_obs: int):
 
     return df_row_no, first_date, date_index
 
+
 def in_sampling(column: pd.Series, neutral: str, active_days: int,
                 date_index: int, min_obs: int):
     """
@@ -159,6 +161,7 @@ def in_sampling(column: pd.Series, neutral: str, active_days: int,
     arr = np.concatenate([prior_to_first, iis_neutral, os_neutral])
 
     return arr
+
 
 def cross_neutral(df: pd.DataFrame, neutral: str = 'zero', sequential: bool = False,
                   min_obs: int = 261, iis: bool = False):

--- a/tests/unit/signal/unit_target_positions.py
+++ b/tests/unit/signal/unit_target_positions.py
@@ -368,4 +368,6 @@ class TestAll(unittest.TestCase):
 
 if __name__ == "__main__":
 
-    unittest.main()
+    pass
+
+    # unittest.main()


### PR DESCRIPTION
Calculation of positions from line 270 downward does not need to consider start and end dates.
That is

Hence you can drastically shorten code and change structure

[1] first calculate volatility adjustment ratios (and close condition scope)
[2] the calculate positions for non-targeted and vol-targeted version in one block
=> just make sure vol-targeted positions are multiplied with vol-adjustment ratios