### PR TITLE
Bugfix/basket_class

### DIFF
--- a/macrosynergy/management/shape_dfs.py
+++ b/macrosynergy/management/shape_dfs.py
@@ -171,6 +171,10 @@ def categories_df(df: pd.DataFrame, xcats: List[str], cids: List[str] = None,
     df_output = []
     if years is None:
         for i in range(2):
+            # If the aggregation method is "last", a separate workflow is not required
+            # given the aggregation is applied to a pivoted dataframe. However, if the
+            # "years" condition is satisfied, the usage of groupby() requires additional
+            # steps to handle the "last" aggregator as a redundant column is included.
             dfw = df[df['xcat'] == xcats[i]].pivot(index='real_date', columns='cid',
                                                    values=val)
             dfw = dfw.resample(freq).agg(xcat_aggs[i])

--- a/macrosynergy/management/shape_dfs.py
+++ b/macrosynergy/management/shape_dfs.py
@@ -207,8 +207,10 @@ def categories_df(df: pd.DataFrame, xcats: List[str], cids: List[str] = None,
         df['custom_date'] = df['real_date'].dt.year.apply(translate_)
         for i in range(2):
             dfx = df[df['xcat'] == xcats[i]]
-            dfx = dfx.groupby(['xcat', 'cid',
-                               'custom_date']).agg(xcat_aggs[i]).reset_index()
+            dfx = dfx.groupby(['xcat', 'cid', 'custom_date'])
+            dfx = dfx.agg(xcat_aggs[i]).reset_index()
+            if 'real_date' in dfx.columns:
+                dfx = dfx.drop(['real_date'], axis = 1)
             dfx = dfx.rename(columns={"custom_date": "real_date"})
             df_output.append(dfx[col_names])
 

--- a/macrosynergy/panel/basket_performance.py
+++ b/macrosynergy/panel/basket_performance.py
@@ -222,7 +222,8 @@ def basket_performance(df: pd.DataFrame, contracts: List[str], ret: str = "XR_NS
     """
 
     assert isinstance(ret, str), "return category must be a <str>."
-    assert isinstance(cry, str), "carry category must be a <str>."
+    if cry is not None:
+        assert isinstance(cry, str), "carry category must be a <str>."
     assert isinstance(contracts, list) and all(isinstance(c, str) for c in contracts), \
         "contracts must be string list."
     assert 0.0 < max_weight <= 1.0
@@ -241,8 +242,16 @@ def basket_performance(df: pd.DataFrame, contracts: List[str], ret: str = "XR_NS
                                                "value."
 
     date_error = "Expected form of string: '%Y-%m-%d'."
-    assert pd.Timestamp(start).strftime("%Y-%m-%d"), date_error
-    assert pd.Timestamp(end).strftime("%Y-%m-%d"), date_error
+    if start is not None:
+        try:
+            pd.Timestamp(start).strftime("%Y-%m-%d")
+        except ValueError:
+            raise AssertionError(date_error)
+    elif end is not None:
+        try:
+            pd.Timestamp(start).strftime("%Y-%m-%d")
+        except ValueError:
+            raise AssertionError(date_error)
 
     # A. Extract relevant data
 

--- a/macrosynergy/panel/basket_performance.py
+++ b/macrosynergy/panel/basket_performance.py
@@ -40,7 +40,7 @@ def equal_weight(df_ret: pd.DataFrame) -> pd.DataFrame:
 def fixed_weight(df_ret: pd.DataFrame, weights: List[float]):
     """
     Calculates fixed weights based on a single list of values and a corresponding return
-    panel dataframe
+    panel dataframe.
 
     :param <pd.DataFrame> df_ret: Return series matrix. Multidimensional.
     :param <List[float]> weights: List of floats determining weight allocation.
@@ -67,7 +67,7 @@ def fixed_weight(df_ret: pd.DataFrame, weights: List[float]):
 def inverse_weight(dfw_ret: pd.DataFrame, lback_meth: str = "xma",
                    lback_periods: int = 21, remove_zeros: bool = True):
     """
-    Calculates weights inversely proportionate to recent return standard deviations
+    Calculates weights inversely proportionate to recent return standard deviations.
 
     :param <pd.DataFrame> dfw_ret: panel dataframe of returns.
     :param <str> lback_meth: Lookback method for "invsd" weighting method. Default is
@@ -222,9 +222,27 @@ def basket_performance(df: pd.DataFrame, contracts: List[str], ret: str = "XR_NS
     """
 
     assert isinstance(ret, str), "return category must be a <str>."
+    assert isinstance(cry, str), "carry category must be a <str>."
     assert isinstance(contracts, list) and all(isinstance(c, str) for c in contracts), \
         "contracts must be string list."
     assert 0.0 < max_weight <= 1.0
+    assert weight_meth in ['equal', 'fixed', 'values', 'inv_values']
+    if weight_meth == 'fixed':
+        error_message = "Expects a List of floating point values."
+        assert all([isinstance(elem, float) for elem in weights]), error_message
+    else:
+        assert weights is None, "The weights parameter should only be defined if the " \
+                                "weight method is 'fixed'."
+    if weight_meth == 'invsd':
+        error_message = "The two lookback options for the inverse-weighting method are" \
+                        "Moving Average, 'ma', and Exponential Moving Average, 'xma'."
+        assert lback_meth in ["xma", "ma"], error_message
+        assert isinstance(lback_periods, int), "The lookback period must be an Integer " \
+                                               "value."
+
+    date_error = "Expected form of string: '%Y-%m-%d'."
+    assert pd.Timestamp(start).strftime("%Y-%m-%d"), date_error
+    assert pd.Timestamp(end).strftime("%Y-%m-%d"), date_error
 
     # A. Extract relevant data
 
@@ -379,6 +397,8 @@ if __name__ == "__main__":
     dfd_4 = basket_performance(dfd, contracts, ret='XR_NSA', cry=None,
                                weight_meth='equal', wgt=None, max_weight=0.41,
                                return_weights=True)
-    print(dfd_4)
 
+    dfd_5 = basket_performance(dfd, contracts, ret='XR_NSA', cry='CRY_NSA',
+                               weight_meth='invsd', wgt=None, max_weight=0.41,
+                               return_weights=False)
 

--- a/macrosynergy/panel/basket_performance.py
+++ b/macrosynergy/panel/basket_performance.py
@@ -376,7 +376,7 @@ def basket_performance(df: pd.DataFrame, contracts: List[str], ret: str = "XR_NS
         contracts_ = list(map(func, w["cid"].to_numpy()))
         contracts_ = np.array(contracts_)
         w["ticker"] = contracts_
-        w = w.sort_values(['ticker', 'real_date'])[['ticker', 'real_date', 'value']]
+        # w = w.sort_values(['ticker', 'real_date'])[['ticker', 'real_date', 'value']]
         w = w.loc[w.value > 0, select]
         store.append(w)
 
@@ -436,3 +436,4 @@ if __name__ == "__main__":
     dfd_5 = basket_performance(dfd, contracts, ret='XR_NSA', cry='CRY_NSA',
                                weight_meth='invsd', wgt=None, max_weight=0.41,
                                return_weights=False)
+    print(dfd_5)

--- a/macrosynergy/panel/basket_performance.py
+++ b/macrosynergy/panel/basket_performance.py
@@ -376,6 +376,7 @@ def basket_performance(df: pd.DataFrame, contracts: List[str], ret: str = "XR_NS
         contracts_ = list(map(func, w["cid"].to_numpy()))
         contracts_ = np.array(contracts_)
         w["ticker"] = contracts_
+        w = w.sort_values(['ticker', 'real_date'])[['ticker', 'real_date', 'value']]
         w = w.loc[w.value > 0, select]
         store.append(w)
 
@@ -430,6 +431,7 @@ if __name__ == "__main__":
     dfd_4 = basket_performance(dfd, contracts, ret='XR_NSA', cry=None,
                                weight_meth='equal', wgt=None, max_weight=0.41,
                                return_weights=True)
+    print(dfd_4)
 
     dfd_5 = basket_performance(dfd, contracts, ret='XR_NSA', cry='CRY_NSA',
                                weight_meth='invsd', wgt=None, max_weight=0.41,

--- a/macrosynergy/panel/basket_performance.py
+++ b/macrosynergy/panel/basket_performance.py
@@ -300,7 +300,7 @@ def basket_performance(df: pd.DataFrame, contracts: List[str], ret: str = "XR_NS
         assert weights is None, "The weights parameter should only be defined if the " \
                                 "weight method is 'fixed'."
     if weight_meth == 'invsd':
-        error_message = "The two lookback options for the inverse-weighting method are" \
+        error_message = "The two lookback options for the inverse-weighting method are " \
                         "Moving Average, 'ma', and Exponential Moving Average, 'xma'."
         assert lback_meth in ["xma", "ma"], error_message
         assert isinstance(lback_periods, int), "The lookback period must be an Integer " \
@@ -318,7 +318,7 @@ def basket_performance(df: pd.DataFrame, contracts: List[str], ret: str = "XR_NS
         except ValueError:
             raise AssertionError(date_error)
 
-    # A. Extract relevant data
+    # A. Extract relevant data.
 
     ticks_ret = [c + ret for c in contracts]
     tickers = ticks_ret.copy()  # Initiates general tickers list.
@@ -341,7 +341,7 @@ def basket_performance(df: pd.DataFrame, contracts: List[str], ret: str = "XR_NS
     dfx = reduce_df_by_ticker(df, start=start, end=end, ticks=tickers,
                               blacklist=blacklist)
 
-    # B. Pivot relevant data
+    # B. Pivot relevant data.
 
     dfx_ticks_ret = dfx[dfx["ticker"].isin(ticks_ret)]
     dfw_ret = dfx_ticks_ret.pivot(index="real_date", columns="ticker", values="value")
@@ -359,7 +359,7 @@ def basket_performance(df: pd.DataFrame, contracts: List[str], ret: str = "XR_NS
 
     # F. Calculate and store weighted average returns.
     select = ["ticker", "real_date", "value"]
-    dfxr = (dfw_ret.multiply(dfw_wgs)).sum(axis=1)  # calculate weighted averages
+    dfxr = (dfw_ret.multiply(dfw_wgs)).sum(axis=1)  # calculate weighted averages.
     dfxr = dfxr.to_frame("value").reset_index()
     dfxr = dfxr.assign(ticker=basket_tik + "_" + ret)[select]
     store = [dfxr]
@@ -372,7 +372,8 @@ def basket_performance(df: pd.DataFrame, contracts: List[str], ret: str = "XR_NS
     if return_weights:
         dfw_wgs.columns.name = "cid"
         w = dfw_wgs.stack().to_frame("value").reset_index()
-        contracts_ = list(map(lambda c: c[:-len(ret)] + "WGT", w["cid"].to_numpy()))
+        func = lambda c: c[:-len(ret)] + "WGT"
+        contracts_ = list(map(func, w["cid"].to_numpy()))
         contracts_ = np.array(contracts_)
         w["ticker"] = contracts_
         w = w.loc[w.value > 0, select]
@@ -433,4 +434,3 @@ if __name__ == "__main__":
     dfd_5 = basket_performance(dfd, contracts, ret='XR_NSA', cry='CRY_NSA',
                                weight_meth='invsd', wgt=None, max_weight=0.41,
                                return_weights=False)
-

--- a/macrosynergy/panel/basket_performance_class.py
+++ b/macrosynergy/panel/basket_performance_class.py
@@ -1,0 +1,46 @@
+
+import numpy as np
+import pandas as pd
+import random
+from typing import List
+from macrosynergy.panel.historic_vol import expo_weights, expo_std, flat_std
+from macrosynergy.management.shape_dfs import reduce_df_by_ticker
+from macrosynergy.panel.converge_row import ConvergeRow
+from macrosynergy.management.simulate_quantamental_data import make_qdf
+
+class Basket(object):
+
+    def __init__(self, df:pd.DataFrame, contracts: List[str], ret: str = "XR_NSA",
+                 weight_meth: str = 'equal', cry: str = None,
+                 start: str = None, end: str = None, blacklist: dict = None,
+                 wgt: str = None, basket_tik: str = "GLB_ALL"):
+
+
+        self.dfx = reduce_df_by_ticker(df, start=start, end=end, ticks=self.tickers,
+                                       blacklist=blacklist)
+        self.contract = contracts
+        self.tickers = self.ticker_list(self)
+        self.ret = ret
+        self.cry = cry
+        self.cry_flag = (cry is not None)
+        self.wgt_flag = (wgt is not None) and (weight_meth in ["values", "inv_values"])
+        self.wgt = wgt
+        self.basket_tik = basket_tik
+
+    def ticker_list(self):
+
+        ticks_ret = [c + self.ret for c in self.contracts]
+        tickers = ticks_ret.copy()  # Initiates general tickers list.
+
+        # Boolean for carry being used.
+        if self.cry_flag:
+            self.__dict__['ticks_cry'] = [c + self.cry for c in self.contracts]
+            tickers += self.ticks_cry
+
+        if self.wgt_flag:
+            error = f"'wgt' must be a string and not a {type(self.wgt)}."
+            assert isinstance(self.wgt, str), error
+            self.__dict__['ticks_wgt'] = [c + self.wgt for c in self.contracts]
+            tickers += self.ticks_wgt
+
+        return tickers

--- a/macrosynergy/panel/basket_performance_class.py
+++ b/macrosynergy/panel/basket_performance_class.py
@@ -15,7 +15,6 @@ class Basket(object):
                  start: str = None, end: str = None, blacklist: dict = None,
                  wgt: str = None, basket_tik: str = "GLB_ALL"):
 
-
         self.dfx = reduce_df_by_ticker(df, start=start, end=end, ticks=self.tickers,
                                        blacklist=blacklist)
         self.contract = contracts
@@ -30,17 +29,241 @@ class Basket(object):
     def ticker_list(self):
 
         ticks_ret = [c + self.ret for c in self.contracts]
-        tickers = ticks_ret.copy()  # Initiates general tickers list.
+        tickers = ticks_ret.copy()
 
         # Boolean for carry being used.
         if self.cry_flag:
-            self.__dict__['ticks_cry'] = [c + self.cry for c in self.contracts]
-            tickers += self.ticks_cry
+            ticks_cry = [c + self.cry for c in self.contracts]
+            self.__dict__['ticks_cry'] = ticks_cry
+            tickers += ticks_cry
 
         if self.wgt_flag:
-            error = f"'wgt' must be a string and not a {type(self.wgt)}."
+            error = f"'wgt' must be a string. Received: {type(self.wgt)}."
             assert isinstance(self.wgt, str), error
-            self.__dict__['ticks_wgt'] = [c + self.wgt for c in self.contracts]
-            tickers += self.ticks_wgt
+            ticks_wgt = [c + self.wgt for c in self.contracts]
+            self.__dict__['ticks_wgt'] = ticks_wgt
+            tickers += ticks_wgt
 
         return tickers
+
+    @staticmethod
+    def check_weights(weight: pd.DataFrame):
+        check = weight.sum(axis=1)
+        c = ~((abs(check - 1) < 1e-6) | (abs(check) < 1e-6))
+        assert not any(c), f"weights must sum to one (or zero), not: {check[c]}"
+
+    def equal_weight(self, df_ret: pd.DataFrame) -> pd.DataFrame:
+        """
+        Equal weight function: receives the pivoted return DataFrame and determines the
+        number of non-NA cross-sections per timestamp, and subsequently distribute the weight
+        evenly across non-NA cross-sections.
+
+        :param <pd.DataFrame> df_ret: data-frame with returns.
+
+        :return <pd.DataFrame> : dataframe of weights.
+        """
+
+        act_cross = (~df_ret.isnull())  # df with 1s/0s for non-NA/NA returns
+        uniform = (1 / act_cross.sum(axis=1)).values  # single equal value
+        uniform = uniform[:, np.newaxis]
+        # Apply equal value to all cross sections
+        broadcast = np.repeat(uniform, df_ret.shape[1], axis=1)
+
+        weight = act_cross.multiply(broadcast)
+        self.check_weights(weight=weight)
+
+        return weight
+
+    def fixed_weight(self, df_ret: pd.DataFrame, weights: List[float]):
+        """
+        Calculates fixed weights based on a single list of values and a corresponding return
+        panel dataframe.
+
+        :param <pd.DataFrame> df_ret: Return series matrix. Multidimensional.
+        :param <List[float]> weights: List of floats determining weight allocation.
+
+        :return <pd.DataFrame>: panel of weights
+        """
+
+        act_cross = (~df_ret.isnull())
+
+        weights = np.array(weights, dtype=np.float32)
+        rows = act_cross.shape[0]
+        broadcast = np.tile(weights, (rows, 1))  # Constructs Array by row repetition.
+
+        # Replaces weight factors with zeroes if concurrent return unavailable.
+        weight = act_cross.multiply(broadcast)
+        weight_arr = weight.to_numpy()  # convert df to np array
+        weight[weight.columns] = weight_arr / np.sum(weight_arr, axis=1)[:, np.newaxis]
+        self.check_weights(weight)
+
+        return weight
+
+    def inverse_weight(self, dfw_ret: pd.DataFrame, lback_meth: str = "xma",
+                       lback_periods: int = 21, remove_zeros: bool = True):
+        """
+        Calculates weights inversely proportionate to recent return standard deviations.
+
+        :param <pd.DataFrame> dfw_ret: panel dataframe of returns.
+        :param <str> lback_meth: Lookback method for "invsd" weighting method. Default is
+            "xma".
+        :param <int> lback_periods: Lookback periods. Default is 21.  Half-time for "xma"
+            and full lookback period for "ma".
+        :param <Bool> remove_zeros: Any returns that are exact zeros will not be included in
+            the lookback window and prior non-zero values are added to the window instead.
+
+        :return <pd.DataFrame>: Dataframe of weights.
+
+        N.B.: The rolling standard deviation will be calculated either using the standard
+        moving average (ma) or the exponential moving average (xma). Both will require
+        returns before a first weight can be computed.
+        """
+
+        if lback_meth == "ma":
+            dfwa = dfw_ret.rolling(window=lback_periods).agg(flat_std, remove_zeros)
+            dfwa *= np.sqrt(252)
+
+        else:
+
+            half_life = lback_periods
+            weights = expo_weights(lback_periods * 2, half_life)
+            dfwa = dfw_ret.rolling(window=lback_periods * 2).agg(expo_std, w=weights,
+                                                                 remove_zeros=remove_zeros)
+
+        df_isd = 1 / dfwa
+        df_wgts = df_isd / df_isd.sum(axis=1).values[:, np.newaxis]
+        self.check_weights(df_wgts)
+
+        return df_wgts
+
+    def values_weight(self, dfw_ret: pd.DataFrame, dfw_wgt: pd.DataFrame,
+                      weight_meth: str):
+        """
+        Returns weights based on an external weighting category.
+
+        :param <pd.DataFrame> dfw_ret: Standard wide dataframe of returns across time and
+            contracts.
+        :param <pd.DataFrame> dfw_wgt: Standard wide dataframe of weight category values
+            across time and contracts.
+        :param <str> weight_meth: Weighting method. must be one of "values" or "inv_values".
+
+        :return <pd.DataFrame>: Dataframe of weights.
+        """
+
+        negative_condition = np.any((dfw_wgt < 0).to_numpy())
+        if negative_condition:
+            dfw_wgt[dfw_wgt < 0] = 0.0
+            print("Negative values in the weight matrix set to zero.")
+
+        exo_array = dfw_wgt.to_numpy()
+        df_bool = ~dfw_ret.isnull()
+
+        weights_df = df_bool.multiply(exo_array)
+        cols = weights_df.columns
+
+        # Zeroes treated as NaNs.
+        weights_df[cols] = weights_df[cols].replace({'0': np.nan, 0: np.nan})
+
+        if weight_meth != "values":
+            weights_df = 1 / weights_df
+
+        weights = weights_df.divide(weights_df.sum(axis=1), axis=0)
+        self.check_weights(weights)
+
+        return weights
+
+    @staticmethod
+    def max_weight_func(weights: pd.DataFrame, max_weight: float):
+        """
+        Enforces maximum weight caps or - if impossible applies equal weight.
+
+        :param <pd.DataFrame> weights: Corresponding weight matrix. Multidimensional.
+        :param <float> max_weight: Upper-bound on the weight allowed for each cross-section.
+
+        :return <pd.DataFrame>: Will return the modified weight DataFrame.
+
+        N.B.: If the maximum weight is less than the equal weight weight, this replaces the
+        computed weight with the equal weight. For instance,
+        [np.nan, 0.63, np.nan, np.nan, 0.27] becomes [np.nan, 0.5, np.nan, np.nan, 0.5].
+        Otherwise, the function calls the ConvergeRow Class to ensure all weights "converge"
+        to a value within the upper-bound. Allow for a margin of error set to 0.001.
+        """
+
+        dfw_wgs = weights.to_numpy()
+
+        for i, row in enumerate(dfw_wgs):
+            row = ConvergeRow.application(row, max_weight)
+            weights.iloc[i, :] = row
+
+        return weights
+
+    def weight_dateframe(self, weight_meth: str, weights: List[float],
+                         lback_meth: str = "xma", lback_periods: int = 21,
+                         max_weight: float = 1.0, remove_zeros: bool = True):
+
+        """
+        Subroutine used to compute the weights for the basket of returns.
+
+        :param <str> weight_meth:
+        :param <List[float]> weights:
+        :param <str> lback_meth:
+        :param <int> lback_periods:
+        :param <float> max_weight:
+        :param <bool> remove_zeros:
+
+        :return <pd.DataFrame>: Will return the weight DataFrame.
+        """
+
+        # C. Apply the appropriate weighting method.
+        if not self.wgt_flag:
+            dfx_ticks_wgt = self.dfx[self.dfx["ticker"].isin(self.tickers)]
+        else:
+            dfx_ticks_wgt = self.dfx[self.dfx["ticker"].isin(self.ticks_wgt)]
+
+        dfw_ret = dfx_ticks_wgt.pivot(index="real_date", columns="ticker",
+                                      values="value")
+
+        if weight_meth == "equal":
+            dfw_wgs = self.equal_weight(df_ret=dfw_ret)
+
+        elif weight_meth == "fixed":
+            message = "Expects a list of weights."
+            message_2 = "List of weights must be equal to the number of contracts."
+            assert isinstance(weights, list), message
+            assert dfw_ret.shape[1] == len(weights), message_2
+            for w in weights:
+                try:
+                    int(w)
+                except ValueError:
+                    print(f"List, {weights}, must be all numerical values.")
+                    raise
+
+            dfw_wgs = self.fixed_weight(df_ret=dfw_ret, weights=weights)
+
+        elif weight_meth == "invsd":
+            dfw_wgs = self.inverse_weight(dfw_ret=dfw_ret, lback_meth=lback_meth,
+                                          lback_periods=lback_periods,
+                                          remove_zeros=remove_zeros)
+
+        elif weight_meth in ["values", "inv_values"]:
+            dfw_wgt = dfw_ret.shift(1)  # Lag by one day to be used as weights.
+            cols = sorted(dfw_wgt.columns)
+            dfw_ret = dfw_wgt.reindex(cols, axis=1)
+            dfw_wgt = dfw_wgt.reindex(cols, axis=1)
+            dfw_wgs = self.values_weight(dfw_ret, dfw_wgt, weight_meth)
+
+        else:
+            raise NotImplementedError(f"Weight method unknown {weight_meth}")
+
+        # D. Remove leading NA rows.
+
+        fvi = max(dfw_wgs.first_valid_index(), dfw_ret.first_valid_index())
+        dfw_wgs, dfw_ret = dfw_wgs[fvi:], dfw_ret[fvi:]
+
+        # E. Impose cap on cross-section weight.
+
+        if max_weight < 1.0:
+            dfw_wgs = self.max_weight_func(weights=dfw_wgs, max_weight=max_weight)
+
+        self.__dict__['dfw_wgs'] = dfw_wgs
+        return dfw_wgs

--- a/macrosynergy/panel/basket_performance_class.py
+++ b/macrosynergy/panel/basket_performance_class.py
@@ -385,11 +385,9 @@ class Basket(object):
                   return_weights: bool = False):
 
         """
-        Helper function. The parameter, "weight_meth", will delimit the weighting method
-        used to compute the basket returns, as each potential weight dataframe will be
-        held as a field on the instance. Further, the basket_performance method can be
-        called individually for every weighting method, and the corresponding output
-        dataframe will be stored as an instance with the handle "basket_<weight_meth>".
+        Helper function hosting the source code. The parameter, "weight_meth", will
+        delimit the weighting method used to compute the basket returns, as each
+        potential weight dataframe will be held as a field on the instance.
 
         :param <str> weight_meth:
         :param <pd.DataFrame> dfw_wgs: weight dataframe used in computation.

--- a/macrosynergy/panel/basket_performance_class.py
+++ b/macrosynergy/panel/basket_performance_class.py
@@ -383,7 +383,10 @@ class Basket(object):
         Produces a full dataframe of all basket performance categories (inclusive of both
         returns and carries). The parameter, "weight_meth", will delimit the
         weighting method used to compute the basket returns, as each potential weight
-        dataframe will be held as a field on the instance.
+        dataframe will be held as a field on the instance. Further, the
+        basket_performance method can be called individually for every weighting method,
+        and the corresponding output dataframe will be stored as an instance with the
+        handle "basket_<weight_meth>".
 
         :param <pd.DataFrame> weight_meth:
         :param <str> basket_tik: name of basket base ticker (analogous to contract name)
@@ -397,7 +400,8 @@ class Basket(object):
             'real_date' and 'value'.
         """
         assert isinstance(weight_meth, str), "Expects <str>."
-        assertion_error = "The method, weight_dataframe(), must be called prior to " \
+        assertion_error = f"The method, weight_dataframe(), must be called, using the" \
+                          f"associated weight method {weight_meth}, prior to " \
                           "basket_performance()."
         assert weight_meth in self.__dict__.keys(), assertion_error
         dfw_wgs = self.__dict__[weight_meth]
@@ -427,4 +431,7 @@ class Basket(object):
         # Concatenate along the date index, and subsequently drop to restore natural
         # index.
         df = pd.concat(store, axis=0, ignore_index=True)
+        key = "basket_" + weight_meth
+        self.__dict__[key] = df
+
         return df

--- a/macrosynergy/panel/basket_performance_class.py
+++ b/macrosynergy/panel/basket_performance_class.py
@@ -14,7 +14,8 @@ class Basket(object):
                  blacklist: dict = None, wgt: str = None):
 
         """
-        Class' Constructor.
+        Class' Constructor. The Class' purpose is to calculate the returns and carries of
+        baskets of financial contracts using various weight methods.
 
         :param <pd.Dataframe> df: standardized DataFrame with following columns: 'cid',
             'xcats', 'real_date' and 'value'.
@@ -105,6 +106,12 @@ class Basket(object):
 
     @staticmethod
     def check_weights(weight: pd.DataFrame):
+        """
+        Validates that the weights computed on each timestamp sum to one accounting for
+        floating point error.
+
+        :param <pd.DataFrame> weight: weight dataframe.
+        """
         check = weight.sum(axis=1)
         c = ~((abs(check - 1) < 1e-6) | (abs(check) < 1e-6))
         assert not any(c), f"weights must sum to one (or zero), not: {check[c]}"
@@ -117,7 +124,7 @@ class Basket(object):
 
         :param <pd.DataFrame> df_ret: data-frame with returns.
 
-        :return <pd.DataFrame> : dataframe of weights.
+        :return <pd.DataFrame>: dataframe of weights.
         """
 
         act_cross = (~df_ret.isnull())
@@ -340,15 +347,15 @@ class Basket(object):
         if max_weight < 1.0:
             dfw_wgs = self.max_weight_func(weights=dfw_wgs, max_weight=max_weight)
 
-        self.__dict__['dfw_wgs'] = dfw_wgs
+        self.__dict__[weight_meth] = dfw_wgs
         return dfw_wgs
 
     def basket_performance(self, dfw_wgs: pd.DataFrame, basket_tik: str = "GLB_ALL",
                            return_weights: bool = False):
 
         """
-        Basket performance returns a single approximate return and - optionally - carry
-        series for the basket of underlying contracts.
+        Returns a full dataframe of all basket performance categories which is inclusive
+        of both returns and carries.
 
         :param <pd.DataFrame> dfw_wgs: Weight DataFrame for the basket's constituents.
         :param <str> basket_tik: name of basket base ticker (analogous to contract name)

--- a/macrosynergy/panel/basket_performance_class.py
+++ b/macrosynergy/panel/basket_performance_class.py
@@ -10,10 +10,34 @@ from macrosynergy.management.simulate_quantamental_data import make_qdf
 
 class Basket(object):
 
-    def __init__(self, df:pd.DataFrame, contracts: List[str], ret: str = "XR_NSA",
+    def __init__(self, df: pd.DataFrame, contracts: List[str], ret: str = "XR_NSA",
                  weight_meth: str = 'equal', cry: str = None,
                  start: str = None, end: str = None, blacklist: dict = None,
                  wgt: str = None, basket_tik: str = "GLB_ALL"):
+
+        """
+        Class' Constructor.
+
+        :param <pd.Dataframe> df: standardized DataFrame with following columns: 'cid',
+            'xcats', 'real_date' and 'value'.
+        :param <List[str]> contracts: base tickers (combinations of cross-sections and
+            base categories) denoting contracts that go into the basket.
+        :param <str> ret: return category postfix; default is "XR_NSA".
+        :param <str> cry: carry category postfix; default is None.
+        :param <str> start: earliest date in ISO 8601 format. Default is None.
+        :param <str> end: latest date in ISO 8601 format. Default is None.
+        :param <dict> blacklist: cross-sections with date ranges that should be excluded
+            from the dataframe. If one cross-section has several blacklist periods append
+            numbers to the cross-section code.
+
+        """
+
+        assert isinstance(contracts, list)
+        error = "contracts must be string list."
+        assert all(isinstance(c, str) for c in contracts), error
+        assert isinstance(ret, str), "return category must be a <str>."
+        if cry is not None:
+            assert isinstance(cry, str), "carry category must be a <str>."
 
         self.dfx = reduce_df_by_ticker(df, start=start, end=end, ticks=self.tickers,
                                        blacklist=blacklist)
@@ -21,14 +45,34 @@ class Basket(object):
         self.tickers = self.ticker_list(self)
         self.ret = ret
         self.cry = cry
+        self.start = self.date_check(start)
+        self.end = self.date_check(end)
         self.cry_flag = (cry is not None)
         self.wgt_flag = (wgt is not None) and (weight_meth in ["values", "inv_values"])
+        self.dfw_ret = self.pivot_dateframe(self.ticks_ret)
+        if self.cry_flag:
+            self.dfw_cry = self.pivot_dateframe(self.ticks_cry)
         self.wgt = wgt
         self.basket_tik = basket_tik
+
+    def pivot_dataframe(self, tick_list):
+        dfx_ticks_list = self.dfx[self.dfx["ticker"].isin(tick_list)]
+        dfw = dfx_ticks_list.pivot(index="real_date", columns="ticker", values="value")
+        return dfw
+
+    @staticmethod
+    def date_check(date_string):
+        date_error = "Expected form of string: '%Y-%m-%d'."
+        if date_string is not None:
+            try:
+                pd.Timestamp(date_string).strftime("%Y-%m-%d")
+            except ValueError:
+                raise AssertionError(date_error)
 
     def ticker_list(self):
 
         ticks_ret = [c + self.ret for c in self.contracts]
+        self.__dict__['ticks_ret'] == ticks_ret
         tickers = ticks_ret.copy()
 
         # Boolean for carry being used.
@@ -55,18 +99,18 @@ class Basket(object):
     def equal_weight(self, df_ret: pd.DataFrame) -> pd.DataFrame:
         """
         Equal weight function: receives the pivoted return DataFrame and determines the
-        number of non-NA cross-sections per timestamp, and subsequently distribute the weight
-        evenly across non-NA cross-sections.
+        number of non-NA cross-sections per timestamp, and subsequently distribute the
+        weight evenly across non-NA cross-sections.
 
         :param <pd.DataFrame> df_ret: data-frame with returns.
 
         :return <pd.DataFrame> : dataframe of weights.
         """
 
-        act_cross = (~df_ret.isnull())  # df with 1s/0s for non-NA/NA returns
-        uniform = (1 / act_cross.sum(axis=1)).values  # single equal value
+        act_cross = (~df_ret.isnull())
+        uniform = (1 / act_cross.sum(axis=1)).values
         uniform = uniform[:, np.newaxis]
-        # Apply equal value to all cross sections
+        # Apply equal value to all cross sections.
         broadcast = np.repeat(uniform, df_ret.shape[1], axis=1)
 
         weight = act_cross.multiply(broadcast)
@@ -76,8 +120,8 @@ class Basket(object):
 
     def fixed_weight(self, df_ret: pd.DataFrame, weights: List[float]):
         """
-        Calculates fixed weights based on a single list of values and a corresponding return
-        panel dataframe.
+        Calculates fixed weights based on a single list of values and a corresponding
+        return panel dataframe.
 
         :param <pd.DataFrame> df_ret: Return series matrix. Multidimensional.
         :param <List[float]> weights: List of floats determining weight allocation.
@@ -109,8 +153,9 @@ class Basket(object):
             "xma".
         :param <int> lback_periods: Lookback periods. Default is 21.  Half-time for "xma"
             and full lookback period for "ma".
-        :param <Bool> remove_zeros: Any returns that are exact zeros will not be included in
-            the lookback window and prior non-zero values are added to the window instead.
+        :param <Bool> remove_zeros: Any returns that are exact zeros will not be included
+            in the lookback window and prior non-zero values are added to the window
+            instead.
 
         :return <pd.DataFrame>: Dataframe of weights.
 
@@ -145,7 +190,8 @@ class Basket(object):
             contracts.
         :param <pd.DataFrame> dfw_wgt: Standard wide dataframe of weight category values
             across time and contracts.
-        :param <str> weight_meth: Weighting method. must be one of "values" or "inv_values".
+        :param <str> weight_meth: Weighting method. must be one of "values" or
+            "inv_values".
 
         :return <pd.DataFrame>: Dataframe of weights.
         """
@@ -178,15 +224,17 @@ class Basket(object):
         Enforces maximum weight caps or - if impossible applies equal weight.
 
         :param <pd.DataFrame> weights: Corresponding weight matrix. Multidimensional.
-        :param <float> max_weight: Upper-bound on the weight allowed for each cross-section.
+        :param <float> max_weight: Upper-bound on the weight allowed for each
+            cross-section.
 
         :return <pd.DataFrame>: Will return the modified weight DataFrame.
 
-        N.B.: If the maximum weight is less than the equal weight weight, this replaces the
-        computed weight with the equal weight. For instance,
+        N.B.: If the maximum weight is less than the equal weight weight, this replaces
+        the computed weight with the equal weight. For instance,
         [np.nan, 0.63, np.nan, np.nan, 0.27] becomes [np.nan, 0.5, np.nan, np.nan, 0.5].
-        Otherwise, the function calls the ConvergeRow Class to ensure all weights "converge"
-        to a value within the upper-bound. Allow for a margin of error set to 0.001.
+        Otherwise, the function calls the ConvergeRow Class to ensure all weights
+        "converge" to a value within the upper-bound. Allow for a margin of error set to
+        0.001.
         """
 
         dfw_wgs = weights.to_numpy()
@@ -200,19 +248,35 @@ class Basket(object):
     def weight_dateframe(self, weight_meth: str, weights: List[float],
                          lback_meth: str = "xma", lback_periods: int = 21,
                          max_weight: float = 1.0, remove_zeros: bool = True):
-
         """
         Subroutine used to compute the weights for the basket of returns.
 
-        :param <str> weight_meth:
-        :param <List[float]> weights:
-        :param <str> lback_meth:
+        :param <str> weight_meth: method used for weighting constituent returns and carry.
+            Options are as follows:
+        [1] "equal": all constituents with non-NA returns have the same weight.
+            This is the default.
+        [2] "fixed": weights are proportionate to single list of values (corresponding to
+            contracts) provided passed to argument `weights`.
+        [3] "invsd": weights based on inverse to standard deviations of recent returns.
+        [4] "values": weights proportionate to a panel of values of exogenous weight
+            category.
+        [5] "inv_values": weights are inversely proportionate to of values of exogenous
+            weight category.
+        :param <List[float]> weights: single list of weights corresponding to the base
+            tickers in `contracts` argument. This is only relevant for the fixed weight
+            method.
+        :param <str> lback_meth: lookback method for "invsd" weighting method. Default is
+            Exponential MA, "ema". The alternative is simple moving average, "ma".
         :param <int> lback_periods:
-        :param <float> max_weight:
-        :param <bool> remove_zeros:
+        :param <float> max_weight: maximum weight of a single contract. Default is 1, i.e
+            zero restrictions. The purpose of the restriction is to limit concentration
+            within the basket.
+        :param <bool> remove_zeros: removes the zeros. Default is set to True.
 
         :return <pd.DataFrame>: Will return the weight DataFrame.
         """
+        assert 0.0 < max_weight <= 1.0
+        assert weight_meth in ['equal', 'fixed', 'values', 'inv_values', 'invsd']
 
         # C. Apply the appropriate weighting method.
         if not self.wgt_flag:
@@ -241,6 +305,10 @@ class Basket(object):
             dfw_wgs = self.fixed_weight(df_ret=dfw_ret, weights=weights)
 
         elif weight_meth == "invsd":
+            error_message = "Two options for the inverse-weighting method are 'ma' and " \
+                            "'xma'."
+            assert lback_meth in ["xma", "ma"], error_message
+            assert isinstance(lback_periods, int), "Expects <int>."
             dfw_wgs = self.inverse_weight(dfw_ret=dfw_ret, lback_meth=lback_meth,
                                           lback_periods=lback_periods,
                                           remove_zeros=remove_zeros)
@@ -267,3 +335,49 @@ class Basket(object):
 
         self.__dict__['dfw_wgs'] = dfw_wgs
         return dfw_wgs
+
+    def basket_performance(self, dfw_wgs: pd.DataFrame, basket_tik: str = "GLB_ALL",
+                           return_weights: bool = False):
+
+        """
+        Basket performance returns a single approximate return and - optionally - carry
+        series for the basket of underlying contracts.
+
+        :param <pd.DataFrame> dfw_wgs: Weight DataFrame for the basket's constituents.
+        :param <str> basket_tik: name of basket base ticker (analogous to contract name)
+            to be used for return and (possibly) carry are calculated. Default is
+            "GLB_ALL".
+        :param <bool> return_weights: if True add cross-section weights to output
+            dataframe with 'WGT' postfix. Default is False.
+
+        :return <pd.Dataframe>: standardized DataFrame with the basket return and
+            (possibly) carry data in standard form, i.e. columns 'cid', 'xcats',
+            'real_date' and 'value'.
+        """
+
+        # F. Calculate and store weighted average returns.
+        select = ["ticker", "real_date", "value"]
+        dfxr = self.dfw_ret.multiply(dfw_wgs).sum(axis=1)
+        dfxr = dfxr.to_frame("value").reset_index()
+        dfxr = dfxr.assign(ticker=basket_tik + "_" + self.ret)[select]
+        store = [dfxr]
+
+        if self.cry_flag:
+            dfcry = self.dfw_cry.multiply(dfw_wgs).sum(axis=1)
+            dfcry = dfcry.to_frame("value").reset_index()
+            dfcry = dfcry.assign(ticker=basket_tik + "_" + self.cry)[select]
+            store.append(dfcry)
+        if return_weights:
+            dfw_wgs.columns.name = "cid"
+            w = dfw_wgs.stack().to_frame("value").reset_index()
+            func = lambda c: c[:-len(self.ret)] + "WGT"
+            contracts_ = list(map(func, w["cid"].to_numpy()))
+            contracts_ = np.array(contracts_)
+            w["ticker"] = contracts_
+            w = w.loc[w.value > 0, select]
+            store.append(w)
+            
+        # Concatenate along the date index, and subsequently drop to restore natural
+        # index.
+        df = pd.concat(store, axis=0, ignore_index=True)
+        return df

--- a/macrosynergy/panel/category_relations.py
+++ b/macrosynergy/panel/category_relations.py
@@ -371,19 +371,21 @@ if __name__ == "__main__":
     dfd = make_qdf(df_cids, df_xcats, back_ar=0.75)
     black = {'AUD': ['2000-01-01', '2003-12-31'], 'GBP': ['2018-01-01', '2100-01-01']}
 
-    filt1 = (dfd['xcat'] == 'GROWTH') & (dfd['cid'] == 'AUD')  # all AUD GROWTH locations
-    filt2 = (dfd['xcat'] == 'INFL') & (dfd['cid'] == 'NZD')  # all NZD INFL locations
-    dfdx = dfd[~(filt1 | filt2)]  # reduced dataframe
+    # All AUD GROWTH locations.
+    filt1 = (dfd['xcat'] == 'GROWTH') & (dfd['cid'] == 'AUD')
+    filt2 = (dfd['xcat'] == 'INFL') & (dfd['cid'] == 'NZD')  # All NZD INFL locations.
+    # Reduced dataframe.
+    dfdx = dfd[~(filt1 | filt2)]
 
     cidx = ['AUD', 'CAD', 'GBP', 'USD']
 
-    cr = CategoryRelations(dfdx, xcats=['GROWTH', 'INFL'],
-                           cids=cidx, xcat_aggs=['last', 'mean'],
-                           start='2005-01-01', blacklist=black,
-                           years=3)
+    # cr = CategoryRelations(dfdx, xcats=['GROWTH', 'INFL'],
+                           # cids=cidx, xcat_aggs=['last', 'mean'],
+                           # start='2005-01-01', blacklist=black,
+                           # years=3)
 
     cr = CategoryRelations(dfdx, xcats=['GROWTH', 'INFL'], cids=cidx, freq='M',
-                           xcat_aggs=['mean', 'mean'], lag=1,
+                           xcat_aggs=['last', 'mean'], lag=1,
                            start='2000-01-01', years=None, blacklist=black,
                            xcat1_chg=None, xcat_trims=[2, 2])
 

--- a/macrosynergy/signal/target_positions.py
+++ b/macrosynergy/signal/target_positions.py
@@ -132,10 +132,14 @@ def basket_handler(df: pd.DataFrame, df_mods_w: pd.DataFrame, contracts: List[st
 
     dfw_wgs = basket.weight_dateframe(weight_meth="equal", weights=None, max_weight=1.0,
                                       remove_zeros=True)
+    dfw_wgs = dfw_wgs.reindex(sorted(dfw_wgs.columns), axis=1)
+
     # Reduce to the cross-sections held in the respective basket.
     df_mods_w = df_mods_w[cross_sections]
+    df_mods_w = df_mods_w.reindex(sorted(df_mods_w.columns), axis=1)
+
     # Adjust the target positions to reflect the weighting method.
-    df_mods_w = df_mods_w.multiply(dfw_wgs)
+    df_mods_w = df_mods_w.multiply(dfw_wgs.to_numpy())
 
     return df_mods_w
 
@@ -301,7 +305,7 @@ def target_positions(df: pd.DataFrame, cids: List[str], xcat_sig: str, ctypes: L
             contracts = baskets[k]
             df_mods_copy = basket_handler(df, df_mods_copy, contracts=contracts,
                                           ret=ret, start=start, end=end)
-            
+
         # Allows for the signal being applied to the basket constituents on the original
         # dataframe.
         df_mods_copy *= v  # modified signal x sigrel = post-VT position.

--- a/macrosynergy/signal/target_positions.py
+++ b/macrosynergy/signal/target_positions.py
@@ -157,13 +157,18 @@ def consolidation_help(panel_df: pd.DataFrame, basket_df: pd.DataFrame):
     basket_cids = basket_df['cid'].unique()
     panel_cids = panel_df['cid'].unique()
 
-    basket_df_c = basket_df.copy()
     for cid in basket_cids:
         if cid in panel_cids:
             basket_indices = basket_df['cid'] == cid
-            df_1 = basket_df[basket_indices]
+            b_values = basket_df[basket_indices]['value'].to_numpy()
             indices = panel_df['cid'] == cid
-            panel_df[indices]['value'] += df_1['value']
+            panel_values = panel_df[indices]['value'].to_numpy()
+            consolidation = panel_values + b_values
+
+            start = indices.index[0]
+            end = indices.index[-1]
+            panel_df[indices]['value'] = consolidation
+
             basket_indices = ~basket_indices
             basket_df = basket_df[basket_indices]
         else:
@@ -438,4 +443,3 @@ if __name__ == "__main__":
                                    sigrels=[1, -1, -0.5], ret='XR_NSA',
                                    start='2010-01-01', end='2020-12-31',
                                    scale='prop', cs_vtarg=None, posname='POS')
-    print(position_df)

--- a/macrosynergy/signal/target_positions.py
+++ b/macrosynergy/signal/target_positions.py
@@ -2,10 +2,11 @@
 import numpy as np
 import pandas as pd
 from typing import List
-from macrosynergy.panel.make_zn_scores import *
 from macrosynergy.management.shape_dfs import reduce_df
-from macrosynergy.panel.historic_vol import historic_vol
 from macrosynergy.management.simulate_quantamental_data import make_qdf
+from macrosynergy.panel.historic_vol import historic_vol
+from macrosynergy.panel.make_zn_scores import *
+from macrosynergy.panel.basket_performance import weight_dateframe
 import random
 
 
@@ -193,8 +194,6 @@ def target_positions(df: pd.DataFrame, cids: List[str], xcat_sig: str, ctypes: L
         "defined in ctypes."
     assert isinstance(min_obs, int), \
         "Minimum observation parameter must be an integer."
-
-    # Todo: asserts for other argument types and permissible values
 
     cols = ['cid', 'xcat', 'real_date', 'value']
     assert set(cols) <= set(df.columns), f"df columns must contain {cols}."

--- a/macrosynergy/signal/target_positions.py
+++ b/macrosynergy/signal/target_positions.py
@@ -80,8 +80,8 @@ def cs_unit_returns(df: pd.DataFrame, contract_returns: List[str],
 
     """
 
-    assert len(contract_returns) == len(sigrels), \
-        "Each individual contract requires an associated signal."
+    error_message = "Each individual contract requires an associated signal."
+    assert len(contract_returns) == len(sigrels), error_message
 
     for i, c_ret in enumerate(contract_returns):
 
@@ -125,11 +125,11 @@ def target_positions(df: pd.DataFrame, cids: List[str], xcat_sig: str, ctypes: L
         appended. Examples are 'FX' or 'EQ'.
     :param <Dict[Any, Dict]> baskets: dictionary of basket dictionaries. The inner
         dictionary takes a string of form <cross_section>_<contract_type> as key and a
-        list of string of the same form as value. The key labels the basket. The value
-        defines the contracts that are used for forming the basket. Pe default the
-        contract have equal weights. An example would be:
-        {{'APC_FX' : ['AUD_FX', ''NZD_FX', 'JPY_FX']},
-         {'APC_EQ' : ['AUD_EQ', ''CNY_EQ', 'INR_EQ', 'JPY_EQ']}}
+        list of string of the same form. The key labels the basket. The value
+        defines the contracts that are used for forming the basket. The default weighting
+        method is for equal weights. An example would be:
+        {'APC_FX' : ['AUD_FX', 'NZD_FX', 'JPY_FX'],
+        'APC_EQ' : ['AUD_EQ', 'CNY_EQ', 'INR_EQ', 'JPY_EQ']}
         # Todo: has yet to be implemented
     :param <List[float]> sigrels: values that translate the single signal into contract
         type and basket signals in the order defined by keys.
@@ -223,7 +223,7 @@ def target_positions(df: pd.DataFrame, cids: List[str], xcat_sig: str, ctypes: L
         # D.1. Composite signal-related positions as basis for volatility targeting.
 
         df_csurs = cs_unit_returns(dfx, contract_returns=contract_returns,
-                                     sigrels=sigrels)  # gives cross-section returns
+                                     sigrels=sigrels)  # Gives cross-section returns.
         df_csurs = df_csurs[cols]
 
         # D.2. Calculate volatility adjustment ratios.
@@ -232,7 +232,7 @@ def target_positions(df: pd.DataFrame, cids: List[str], xcat_sig: str, ctypes: L
                               lback_periods=lback_periods, lback_meth=lback_meth,
                               half_life=half_life, start=start, end=end,
                               remove_zeros=True,
-                              postfix="")  # gives unit position vols.
+                              postfix="")  # Gives unit position vols.
 
         dfw_vol = df_vol.pivot(index="real_date", columns="cid", values="value")
         dfw_vol = dfw_vol.sort_index(axis=1)

--- a/tests/unit/management/test_shape_dfs.py
+++ b/tests/unit/management/test_shape_dfs.py
@@ -137,14 +137,13 @@ class TestAll(unittest.TestCase):
         start_bucket = int(floor(s_year - start) / years)
 
         self.dfd['real_date'] = pd.to_datetime(self.dfd['real_date'], errors='coerce')
-        # dfc = categories_df(dfd, xcats=['XR', 'CRY'], cids=['CAD'],
-                            # freq='M', lag=0, xcat_aggs=['mean', 'mean'],
-                            # start='2000-01-01', years=years)
+        dfc = categories_df(dfd, xcats=['XR', 'CRY'], cids=['CAD'],
+                            freq='M', lag=0, xcat_aggs=['mean', 'mean'],
+                            start='2000-01-01', years=years)
 
         realised_buckets = no_buckets - start_bucket
-        # filter_df = dfc.loc['CAD', :]
-
-        # self.assertTrue(realised_buckets == filter_df.shape[0])
+        filter_df = dfc.loc['CAD', :]
+        self.assertTrue(realised_buckets == filter_df.shape[0])
 
         # Apply the same logic but to a different testcase.
         years = 4
@@ -153,14 +152,33 @@ class TestAll(unittest.TestCase):
         # Adjust for the formal start date.
         start_bucket = int(floor(s_year - start) / years)
 
-        # dfc = categories_df(dfd, xcats=['XR', 'CRY'], cids=['CAD'],
-                            # freq='M', lag=0, xcat_aggs=['mean', 'mean'],
-                            # start='2000-01-01', years=years)
+        dfc = categories_df(dfd, xcats=['XR', 'CRY'], cids=['CAD'],
+                            freq='M', lag=0, xcat_aggs=['mean', 'mean'],
+                            start='2000-01-01', years=years)
 
         realised_buckets = no_buckets - start_bucket
-        # filter_df = dfc.loc['CAD', :]
+        filter_df = dfc.loc['CAD', :]
+        self.assertTrue(realised_buckets == filter_df.shape[0])
 
-        # self.assertTrue(realised_buckets == filter_df.shape[0])
+        # Test the aggregator parameter 'last': as the name suggests, 'last' will isolate
+        # the terminal value of each time-period. Therefore, check the returned value, in
+        # the dataframe, confirms the above logic.
+        dfc = categories_df(self.dfd, xcats=['XR', 'CRY'],
+                            cids=['AUD', 'CAD'], xcat_aggs=['last', 'mean'],
+                            start='2005-01-01', years=6)
+
+        # Manual check.
+        reduced_df = self.dfd[self.dfd['xcat'] == 'XR']
+        reduced_df = reduced_df[reduced_df['real_date'] == '2016-12-30']
+        aud = reduced_df[reduced_df['cid'] == 'AUD']
+        cad = reduced_df[reduced_df['cid'] == 'CAD']
+        aud = aud['value'].to_numpy()[0]
+        cad = cad['value'].to_numpy()[0]
+
+        aud_xr = dfc.iloc[0][0]
+        cad_xr = dfc.iloc[2][0]
+        self.assertTrue(aud == aud_xr)
+        self.assertTrue(cad == cad_xr)
 
     def test_categories_df_lags(self):
         self.dataframe_constructor()

--- a/tests/unit/panel/test_basket_performance.py
+++ b/tests/unit/panel/test_basket_performance.py
@@ -276,6 +276,22 @@ class TestAll(unittest.TestCase):
                                            weights=gdp_figures, max_weight=0.4,
                                            basket_tik="GLB_ALL", return_weights=False)
 
+        # Testing the assertions enforced on the "start" & "end" parameters.
+        with self.assertRaises(AssertionError):
+            df_return = basket_performance(dfd_test, contracts=c, ret="XR_NSA",
+                                           cry="CRY_NSA", start = "Janary 1st, 2020",
+                                           weight_meth="equal", wgt=None, max_weight=0.4,
+                                           basket_tik="GLB_ALL", return_weights=False)
+
+        # Testing the assertion that the "weights" parameter is always equal to None
+        # unless the weighting method is 'fixed'. Important to prevent confusion over
+        # parameter names: 'weight_meth', 'weights', 'wgt' etc.
+        with self.assertRaises(AssertionError):
+            df_return = basket_performance(dfd_test, contracts=c, ret="XR_NSA",
+                                           cry="CRY_NSA", weights="invsd", wgt=None,
+                                           max_weight=0.4, basket_tik="GLB_ALL",
+                                           return_weights=False)
+
         df_return = basket_performance(dfd_test, contracts=c, ret="XR_NSA", cry=None,
                                        blacklist=black, weight_meth="equal",
                                        max_weight=1.0, basket_tik="GLB_ALL",


### PR DESCRIPTION
BugFix to categories relations regarding the "last" parameter. Regards the function call copied below:

cr = CategoryRelations(dfdx, xcats=['GROWTH', 'INFL'], cids=cidx, xcat_aggs=['last', 'mean'], start='2005-01-01', blacklist=black, years=3)

Believe only applicable if the "years" parameter is activated.