### PR TITLE
missing base dependency `requests`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pandas
 statsmodels
 sklearn
 numpy
+requests


### PR DESCRIPTION
It looks like you are missing the dependency `requests` in your `requirements.txt` file

```bash
🌵 >python3 -m venv venv
🌵 >source venv/bin/activate
(venv) 🌵 >pip install --upgrade pip
(venv) 🌵 >pip install macrosynergy
(venv) 🌵 >python
Python 3.8.3 (v3.8.3:6f8c8320e9, May 13 2020, 16:29:34)
[Clang 6.0 (clang-600.0.57)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from macrosynergy.panel.converge_row import ConvergeRow
...
ergy/management/dq.py", line 8, in <module>
    import requests
ModuleNotFoundError: No module named 'requests'
```