### PR TITLE
small changes and todos for hedge ratio

### DIFF
--- a/tests/unit/panel/test_hedge_ratio.py
+++ b/tests/unit/panel/test_hedge_ratio.py
@@ -134,6 +134,8 @@ class TestAll(unittest.TestCase):
 
         return refreq_buckets
 
+    # Todo: add test of correct hedge ratio by comparing one or more ratio with a
+    #  regression result generated outside the functions.
 
 if __name__ == '__main__':
 


### PR DESCRIPTION
hedge_ratio seems mostly fine, but please check out the todos in the pull request

Some clean-up for efficiency and transparency is needed in hedge_calculator.
Pandas offers functions to solve some custom problems quickly.
I suggest the following for getting hedge ratios into a frame:
[1] fill pre-allocated df with estimates on days of estimation
[2] upsample to original businness day frame with asfreq() and 'ffill'
[3] then use .shift(1)
You would need neither date_weekend nor the lambda function date_adjustment.


In the test file you should add test of correct hedge ratio by comparing one or more ratio with a
regression result generated outside the functions.