### PR TITLE
DataQuery Unittest and Integration test examples

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,13 +1,13 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Python package Ubuntu
+name: Python Integration tests
 
 on:
   push:
-    branches: [ main, dev, test, prod, develop, release ]
+    branches: [ main, develop ]
   pull_request:
-    branches: [ main, dev, test, prod, develop, release ]
+    branches: [ main, develop ]
 
 jobs:
   build:
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest  # Alternative: windows-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]  # For multiple: [3.7, 3.8]
+        python-version: [3.8]  # For multiple: [3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2
@@ -28,13 +28,9 @@ jobs:
         python -m pip install --upgrade pip
         pip install flake8 pytest sphinx pytest-cov
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Lint with flake8
+    - name: Run integration tests with pytest
+      env:
+        DQ_CLIENT_ID: ${{ secrets.DQ_CLIENT_ID }}
+        DQ_CLIENT_SECRET: ${{ secrets.DQ_CLIENT_SECRET }}
       run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
-      run: |
-        # Options: --ignore=tests/specific.py --ignore-glob=tests/ignore-pattern
-        pytest -rEf tests/unit/ --cov macrosynergy -p no:warnings --verbose
+        pytest tests/integration/

--- a/macrosynergy/dataquery/api.py
+++ b/macrosynergy/dataquery/api.py
@@ -458,7 +458,7 @@ class Interface(object):
     def valid_ticker(self, _dict, suppress_warning):
         """
         Iterates through each Ticker and determines whether the Ticker is held in the
-        DataBase or not. The validation mechanism will isolate each column, in all the
+        Database or not. The validation mechanism will isolate each column, in all the
         Tickers held in the dictionary, where the columns reflect the metrics passed,
         and validates that each value is not a NoneType Object. If all values are
         NoneType Objects, the Ticker is not valid, and it will be popped from the
@@ -482,7 +482,7 @@ class Interface(object):
                     condition = self.column_check(v, i)
                     if not condition:
                         if self.debug:
-                            warnings.warn("Error has occurred in the DataBase.")
+                            warnings.warn("Error has occurred in the Database.")
 
                 if not suppress_warning:
                     print(f"The ticker, {k}), does not exist in the Database.")
@@ -490,7 +490,7 @@ class Interface(object):
             else:
                 continue
 
-        print(f"Number of missing time-series from the DataBase: {ticker_missing}.")
+        print(f"Number of missing time-series from the Database: {ticker_missing}.")
         return dict_copy
 
     @staticmethod

--- a/macrosynergy/dataquery/api.py
+++ b/macrosynergy/dataquery/api.py
@@ -63,29 +63,9 @@ class Interface(object):
 
     def check_connection(self) -> bool:
         """Check connect (heartbeat) to DataQuery"""
-        r: requests.Response = self.access.get_dq_api_result(
-            url=self.access.base_url + "/services/heartbeat"
-        )
+        js: dict = self.access.get_dq_api_result(url=self.access.base_url + "/services/heartbeat")
 
-        # TODO additional authentication responses...
-        if r.status_code == 401:
-            raise RuntimeError(
-                f"Authentication error - unable to access DataQuery:\n{r.text}"
-            )
-        elif self.access.last_response[0] != "{":
-            # TODO deprecated check if deprecated and already caught by the above 401
-            # Authentication check
-            condition: str = self.last_response.split('-')[1].strip().split('<')[0]
-            if condition == 'Authentication Failure':
-                raise RuntimeError(
-                    condition + " - unable to access DataQuery. Password expired."
-                )
-
-        assert r.ok, f"Access issue status code {r.status_code} for {r.text}"
-
-        response: dict = r.json()
-        results: dict = response["info"]
-
+        results: dict = js["info"]
         if int(results["code"]) != 200:
             print(
                 f"DataQuery response {results['message']:s}"
@@ -143,29 +123,27 @@ class Interface(object):
             try:
                 # The required fields will already be instantiated on the instance of the
                 # Class.
-                r = self.access.get_dq_api_result(url=url, params=params)
+                response: dict = self.access.get_dq_api_result(url=url, params=params)
             except ConnectionResetError:
                 counter += 1
                 time.sleep(0.05)
                 print(f"Server error: will retry. Attempt number: {counter}.")
                 continue
-            else:
-                response = r.json()
 
-                count = 0
-                while not self.server_retry(response, select):
-                    count += 1
-                    if count > 5:
-                        raise RuntimeError("All servers are down.")
+            count = 0
+            while not self.server_retry(response, select):
+                count += 1
+                if count > 5:
+                    raise RuntimeError("All servers are down.")
 
-                if select in response.keys():
-                    results.extend(response[select])
+            if select in response.keys():
+                results.extend(response[select])
 
-                if response["links"][1]["next"] is None:
-                    break
+            if response["links"][1]["next"] is None:
+                break
 
-                url = f"{self.access.base_url:s}{response['links'][1]['next']:s}"
-                params = {}
+            url = f"{self.access.base_url:s}{response['links'][1]['next']:s}"
+            params = {}
 
         if isinstance(results, list):
             return results

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 # pytest.ini
 [pytest]
-addopts = -rEf --cov macrosynergy -p no:warnings --verbose --cov macrosynergy
+addopts = -rEf -p no:warnings --verbose --cov macrosynergy
 
 
 testpaths =

--- a/tests/integration/dataquery/__init__.py
+++ b/tests/integration/dataquery/__init__.py
@@ -1,0 +1,1 @@
+"""DataQuery integration tests"""

--- a/tests/integration/dataquery/test_dataquery.py
+++ b/tests/integration/dataquery/test_dataquery.py
@@ -1,6 +1,7 @@
 import unittest
 import os
 import pandas as pd
+import datetime
 from macrosynergy.dataquery.api import Interface
 
 
@@ -28,7 +29,10 @@ class TestDataQueryOAuth(unittest.TestCase):
             client_id=os.getenv("DQ_CLIENT_ID"),
             client_secret=os.getenv("DQ_CLIENT_SECRET")
         ) as dq:
-            data = dq.download(tickers="EUR_FXXR_NSA", start_date="2022-01-01")
+            data = dq.download(
+                tickers="EUR_FXXR_NSA",
+                start_date=(datetime.date.today() - datetime.timedelta(days=10)).isoformat()
+            )
         self.assertIsInstance(data, pd.DataFrame)
 
         self.assertFalse(data.empty)

--- a/tests/integration/dataquery/test_dataquery.py
+++ b/tests/integration/dataquery/test_dataquery.py
@@ -7,8 +7,8 @@ class TestDataQuery(unittest.TestCase):
     def test_connection(self):
         with Interface(
             oauth=True,
-            client_id=os.getenv("dq_client_id"),
-            client_secret=os.getenv("dq_client_secret")
+            client_id=os.getenv("DQ_CLIENT_ID"),
+            client_secret=os.getenv("DQ_CLIENT_SECRET")
         ) as dq:
             self.assertTrue(dq.check_connection())
 

--- a/tests/integration/dataquery/test_dataquery.py
+++ b/tests/integration/dataquery/test_dataquery.py
@@ -1,9 +1,10 @@
 import unittest
 import os
+import pandas as pd
 from macrosynergy.dataquery.api import Interface
 
 
-class TestDataQuery(unittest.TestCase):
+class TestDataQueryOAuth(unittest.TestCase):
     def test_connection(self):
         with Interface(
             oauth=True,
@@ -11,6 +12,28 @@ class TestDataQuery(unittest.TestCase):
             client_secret=os.getenv("DQ_CLIENT_SECRET")
         ) as dq:
             self.assertTrue(dq.check_connection())
+
+    def test_authentication_error(self):
+        with Interface(
+            oauth=True,
+            client_id="WRONG_CLIENT_ID",
+            client_secret="NOT_A_SECRET"
+        ) as dq:
+            with self.assertRaises(RuntimeError, msg="Authentication error - unable to access DataQuery:"):
+                self.assertFalse(dq.check_connection())
+
+    def test_download_jpmaqs_data(self):
+        with Interface(
+            oauth=True,
+            client_id=os.getenv("DQ_CLIENT_ID"),
+            client_secret=os.getenv("DQ_CLIENT_SECRET")
+        ) as dq:
+            data = dq.download(tickers="EUR_FXXR_NSA", start_date="2022-01-01")
+        self.assertIsInstance(data, pd.DataFrame)
+
+        self.assertFalse(data.empty)
+
+        self.assertGreater(data.shape[0], 0)
 
 
 if __name__ == '__main__':

--- a/tests/integration/dataquery/test_dataquery.py
+++ b/tests/integration/dataquery/test_dataquery.py
@@ -1,0 +1,17 @@
+import unittest
+import os
+from macrosynergy.dataquery.api import Interface
+
+
+class TestDataQuery(unittest.TestCase):
+    def test_connection(self):
+        with Interface(
+            oauth=True,
+            client_id=os.getenv("dq_client_id"),
+            client_secret=os.getenv("dq_client_secret")
+        ) as dq:
+            self.assertTrue(dq.check_connection())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/dataquery/test_api.py
+++ b/tests/unit/dataquery/test_api.py
@@ -1,0 +1,34 @@
+import unittest
+from unittest import mock
+from macrosynergy.dataquery.api import Interface
+
+
+class TestDataQueryInterface(unittest.TestCase):
+    def test_check_connection(self):
+        with mock.patch(
+            "macrosynergy.dataquery.auth.OAuth.get_dq_api_result",
+            return_value={"info": {"code": 200}}  # TODO check exact response from DataQuery Swagger docs
+        ) as p_request:
+            with Interface(client_id="client1", client_secret="123", oauth=True) as dq:
+                self.assertTrue(dq.check_connection())
+                p_request.assert_called_with(url=dq.access.base_url + "/services/heartbeat")
+
+            p_request.assert_called_once()
+
+    def test_check_connection_fail(self):
+        with mock.patch(
+            "macrosynergy.dataquery.auth.OAuth.get_dq_api_result",
+            # TODO check exact response from DataQuery Swagger docs
+            return_value={
+                "info": {"code": 400, "message": "TODO check message from DQ", "description": "description here."}
+            }
+        ) as p_request:
+            with Interface(client_id="client1", client_secret="123", oauth=True) as dq:
+                self.assertFalse(dq.check_connection())
+                p_request.assert_called_with(url=dq.access.base_url + "/services/heartbeat")
+
+            p_request.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
* Simplified the DataQuery requests GET and POST structure to allow for easier `mock.patch` in the unittests
*  Added an example integration test

Need to use the below example for unit and integration test to build out proper coverage for the DataQuery interfrace.