### PR TITLE
feature/multiple_signals

### DIFF
--- a/macrosynergy/management/shape_dfs.py
+++ b/macrosynergy/management/shape_dfs.py
@@ -198,7 +198,7 @@ def categories_df(df: pd.DataFrame, xcats: List[str], cids: List[str] = None,
     :param <List[str]> xcat_aggs: exactly two aggregation methods. Default is 'mean' for
         both. The same aggregation method will be used for all explanatory variables.
 
-    :return <pd.Dataframe>: custom DataFrame with category columns. All rows that contain
+    :return <pd.DataFrame>: custom DataFrame with category columns. All rows that contain
     NaNs will be excluded.
 
     N.B.:
@@ -342,9 +342,10 @@ if __name__ == "__main__":
     dfc1 = categories_df(dfd, xcats=['GROWTH', 'CRY'], cids=cids, freq='M', lag=1,
                          xcat_aggs=['mean', 'mean'], start='2000-01-01', blacklist=black)
 
-    dfc2 = categories_df(dfd, xcats=['GROWTH', 'CRY'], cids=cids, freq='M', lag=0,
+    dfc2 = categories_df(dfd, xcats=['INFL', 'GROWTH', 'XR'], cids=cids, freq='M', lag=0,
                          fwin=3, xcat_aggs=['mean', 'mean'],
                          start='2000-01-01', blacklist=black)
+    print(dfc2)
 
     dfc3 = categories_df(dfd, xcats=['GROWTH', 'CRY'], cids=cids, freq='M', lag=0,
                          xcat_aggs=['mean', 'mean'], start='2000-01-01', blacklist=black,

--- a/macrosynergy/management/shape_dfs.py
+++ b/macrosynergy/management/shape_dfs.py
@@ -194,17 +194,18 @@ def categories_df(df: pd.DataFrame, xcats: List[str], cids: List[str] = None,
         as set by freq. Default is 0.
     :param <int> fwin: forward moving average window of first category. Default is 1,
         i.e no average.
-        Note: This parameter is used mainly for target returns as dependent variables.
+        Note: This parameter is used mainly for target returns as dependent variable.
     :param <List[str]> xcat_aggs: exactly two aggregation methods. Default is 'mean' for
-        both. The same aggregation method will be used for all explanatory variables.
+        both. The same aggregation method, the first method in the parameter, will be
+        used for all explanatory variables.
 
     :return <pd.DataFrame>: custom DataFrame with category columns. All rows that contain
     NaNs will be excluded.
 
     N.B.:
     The number of explanatory categories that can be included is not restricted and will
-    be appended column-wise to the returned DataFrame. The return category will always be
-    the left-most column.
+    be appended column-wise to the returned DataFrame. The order of the DataFrame's
+    columns will reflect the order of the categories list.
     """
 
     assert freq in ['D', 'W', 'M', 'Q', 'A']
@@ -218,7 +219,7 @@ def categories_df(df: pd.DataFrame, xcats: List[str], cids: List[str] = None,
     aggs_error = "List of strings, outlining the aggregation methods, expected."
     assert isinstance(xcat_aggs, list), aggs_error
     assert all([isinstance(a, str) for a in xcat_aggs]), aggs_error
-    aggs_len = "Only two aggregation methods required. The first will be used for all" \
+    aggs_len = "Only two aggregation methods required. The first will be used for all " \
                "explanatory category(s)."
     assert len(xcat_aggs) == 2, aggs_len
 
@@ -265,8 +266,9 @@ def categories_df(df: pd.DataFrame, xcats: List[str], cids: List[str] = None,
             dep_col = dep_col.rolling(window=fwin).mean().shift(s)
 
         dfw_xpls[dep] = dep_col
-        # Order such that the dependent variable is the left-most column.
-        dfc = dfw_xpls[[dep] + xpls]
+        # Order such that the return category is the right-most column - will reflect the
+        # order of the categories list.
+        dfc = dfw_xpls[xpls + [dep]]
 
     else:
         s_year = pd.to_datetime(start).year

--- a/macrosynergy/management/shape_dfs.py
+++ b/macrosynergy/management/shape_dfs.py
@@ -153,7 +153,7 @@ def categories_df(df: pd.DataFrame, xcats: List[str], cids: List[str] = None,
     :param <str> end: latest date in ISO 8601 format. Default is None,
         i.e. latest date in DataFrame is used.
     :param <dict> blacklist: cross sections with date ranges that should be excluded from
-        the data frame. If one cross section has several blacklist periods append numbers
+        the DataFrame. If one cross section has several blacklist periods append numbers
         to the cross section code.
     :param <int> years: Number of years over which data are aggregated. Supersedes the
         "freq" parameter and does not allow lags, Default is None, i.e. no multi-year
@@ -175,7 +175,12 @@ def categories_df(df: pd.DataFrame, xcats: List[str], cids: List[str] = None,
     """
 
     assert freq in ['D', 'W', 'M', 'Q', 'A']
-    assert not (years is not None) & (lag != 0), 'Lags cannot be applied to year groups.'
+
+    aggs_error = "List of strings, outlining the aggregation methods, expected."
+    assert isinstance(xcat_aggs, list), aggs_error
+    assert all([isinstance(a, str) for a in xcat_aggs]), aggs_error
+
+    assert not (years is not None) & (lag != 0), "Lags cannot be applied to year groups."
     if years is not None:
         assert isinstance(start, str), "Year aggregation requires a start date."
 
@@ -252,9 +257,7 @@ def categories_df(df: pd.DataFrame, xcats: List[str], cids: List[str] = None,
 
     dfc = pd.concat(df_output)
     # If either of the two variables, explanatory or dependent variable, contain a NaN
-    # value, remove the row: a relationship is not able to be established between a
-    # realised datapoint and a Nan value. Therefore, remove the row from the returned
-    # DataFrame.
+    # value, remove the row.
     dfc = dfc.pivot(index=('cid', 'real_date'), columns='xcat',
                     values=val).dropna()[xcats]
 

--- a/macrosynergy/signal/signal_return.py
+++ b/macrosynergy/signal/signal_return.py
@@ -21,7 +21,9 @@ class SignalReturnRelations:
     :param <str> sig: primary signal category for which detailed relational statistics
         can be calculated.
     :param <str, List[str]> rival_sigs: "rival signals" for which basic relational
-        statistics can be calculated for comparison with the primary signal category.
+        statistics can be calculated for comparison with the primary signal category. The
+        table, if rival signals are defined, will be generated upon instantiation of the
+        object.
         N.B.: parameters set for sig, such as sig_neg, freq, and agg_sig are equally
         applied to all rival signals.
     :param <bool> sig_neg: if set to True puts the signal in negative terms for all
@@ -242,8 +244,9 @@ class SignalReturnRelations:
 
         try:
             df_sigs = self.df_sigs.round(decimals=3)
-        except AttributeError:
-            print("Additional signals have not been defined on the instance.")
+        except Exception:
+            error_msg = "Additional signals have not been defined on the instance."
+            raise AttributeError(error_msg)
         else:
             # Set to all available signals.
             sigs = self.signals if sigs is None else sigs

--- a/macrosynergy/signal/signal_return.py
+++ b/macrosynergy/signal/signal_return.py
@@ -55,6 +55,9 @@ class SignalReturnRelations:
 
         self.dic_freq = {'D': 'daily', 'W': 'weekly', 'M': 'monthly',
                          'Q': 'quarterly', 'A': 'annual'}
+        freq_error = f"Frequency parameter must be one of {list(self.dic_freq.keys())}."
+        assert freq in self.dic_freq.keys(), freq_error
+
         self.metrics = ['accuracy', 'bal_accuracy', 'pos_sigr', "pos_retr",
                         'pos_prec', 'neg_prec', 'pearson', 'pearson_pval',
                         'kendall', 'kendall_pval']
@@ -292,8 +295,7 @@ class SignalReturnRelations:
         Plot bar chart for the overall and balanced accuracy metrics.
 
         :param <str> type: type of segment over which bars are drawn. Either
-            "cross_section" (default), "years" or "panels".
-            # Todo: type should be "signals" not "panels"
+            "cross_section" (default), "years" or "signals".
         :param <str> title: chart header - default will be applied if none is chosen.
         :param <Tuple[float]> size: 2-tuple of width and height of plot - default will be
             applied if none is chosen.
@@ -302,8 +304,7 @@ class SignalReturnRelations:
 
         """
 
-        assert type in ['cross_section', 'years', 'panel']
-        # Todo: "panel" rather than "panels"
+        assert type in ["cross_section", "years", "signals"]
 
         if type == "cross_section":
             df_xs = self.df_cs
@@ -315,7 +316,7 @@ class SignalReturnRelations:
         dfx = df_xs[~df_xs.index.isin(['PosRatio'])]
 
         if title is None:
-            refsig = "various signals" if type == "panel" else self.sig
+            refsig = "various signals" if type == "signals" else self.sig
             title = f"Accuracy for sign prediction of {self.ret} based on {refsig} " \
                     f"at {self.dic_freq[self.freq]} frequency."
         if size is None:
@@ -355,8 +356,7 @@ class SignalReturnRelations:
         Plot correlation coefficients and significance.
 
         :param <str> type: type of segment over which bars are drawn. Either
-            "cross_section" (default), "years" or "panels".
-            # Todo: type should be "signals" not "panels"
+            "cross_section" (default), "years" or "signals".
         :param <str> title: chart header. Default will be applied if none is chosen.
         :param <Tuple[float]> size: 2-tuple of width and height of plot.
             Default will be applied if none is chosen.
@@ -364,8 +364,7 @@ class SignalReturnRelations:
             See matplotlib.pyplot.legend.
 
         """
-        assert type in ["cross_section", "years", "panel"]
-        # Todo: "panel" rather than "panels"
+        assert type in ["cross_section", "years", "signals"]
 
         if type == "cross_section":
             df_xs = self.df_cs
@@ -385,9 +384,9 @@ class SignalReturnRelations:
         kprobs[kprobs == 0] = 0.01
 
         if title is None:
-            refsig = "various signals" if type == "panel" else self.sig
-            title = f"Positive correlation probability of {refsig} " \
-                    f"and lagged {self.sig} at {self.dic_freq[self.freq]} frequency."
+            refsig = "various signals" if type == "signals" else self.sig
+            title = f"Positive correlation probability of {self.ret} " \
+                    f"and lagged {refsig} at {self.dic_freq[self.freq]} frequency."
         if size is None:
             size = (np.max([dfx.shape[0]/2, 8]), 6)
 
@@ -491,12 +490,6 @@ if __name__ == "__main__":
 
     dfd = make_qdf(df_cids, df_xcats, back_ar=0.75)
 
-    # srr = SignalReturnRelations(dfd, sig='CRY', ret='XR',
-    #                             rival_sigs=["GROWTH", "INFL"],
-    #                             freq='D', blacklist=black)
-    #
-    # srr.accuracy_bars(type="years")
-
     # Additional signals.
     srn = SignalReturnRelations(dfd, sig='CRY', rival_sigs=['INFL', 'GROWTH'],
                                 sig_neg=False, ret='XR', freq='D', blacklist=black)
@@ -504,11 +497,9 @@ if __name__ == "__main__":
     df_sigs = srn.signals_table(sigs=['CRY', 'INFL'])
     df_sigs_all = srn.signals_table()
 
-    srn.accuracy_bars(type="panel", title="Accuracy measure between target return, XR, "
-                                          "and the respective signals, ['CRY', 'INFL', "
-                                          "'GROWTH'].")
-    srn.accuracy_bars(type="panel")
-    srn.correlation_bars(type="panel", title="Positive correlation probability between "
-                                             "XR and the respective signals, ['CRY', "
-                                             "'INFL', 'GROWTH'].")
-    srn.correlation_bars(type="panel")
+    srn.accuracy_bars(type="signals", title="Accuracy measure between target return, XR,"
+                                            " and the respective signals, ['CRY', 'INFL'"
+                                            ", 'GROWTH'].")
+    srn.accuracy_bars(type="signals")
+
+    srn.correlation_bars(type="signals")

--- a/tests/unit/management/test_shape_dfs.py
+++ b/tests/unit/management/test_shape_dfs.py
@@ -163,7 +163,7 @@ class TestAll(unittest.TestCase):
 
         # Test the aggregator parameter 'last': as the name suggests, 'last' will isolate
         # the terminal value of each time-period. Therefore, check the returned value, in
-        # the dataframe, confirms the above logic.
+        # the DataFrame, confirms the above logic.
         dfc = categories_df(self.dfd, xcats=['XR', 'CRY'],
                             cids=['AUD', 'CAD'], xcat_aggs=['last', 'mean'],
                             start='2005-01-01', years=6)
@@ -176,8 +176,9 @@ class TestAll(unittest.TestCase):
         aud = aud['value'].to_numpy()[0]
         cad = cad['value'].to_numpy()[0]
 
-        aud_xr = dfc.iloc[0][0]
-        cad_xr = dfc.iloc[2][0]
+        # Isolate the first value for both cross-sectional series: '2011 - 2016'.
+        aud_xr = dfc['XR'].loc['AUD'][0]
+        cad_xr = dfc['XR'].loc['CAD'][0]
         self.assertTrue(aud == aud_xr)
         self.assertTrue(cad == cad_xr)
 

--- a/tests/unit/signal/test_signal_return.py
+++ b/tests/unit/signal/test_signal_return.py
@@ -91,7 +91,7 @@ class TestAll(unittest.TestCase):
         test_index = list(srr.df_cs.index)[3:]
         self.assertTrue(sorted(self.cids) == sorted(test_index))
 
-    def test_df_isolator(self):
+    def test___slice_df__(self):
 
         self.dataframe_generator()
         # Method used to confirm that the segmentation of the original DataFrame is
@@ -106,7 +106,7 @@ class TestAll(unittest.TestCase):
         # First, test cross-sectional basis.
         # Choose a "random" cross-section.
 
-        df_cs = srr.df_isolator(df=df, cs='GBP', cs_type='cids')
+        df_cs = srr.__slice_df__(df=df, cs='GBP', cs_type='cids')
 
         # Test the values on a fixed date.
         fixed_date = '2010-01-04'
@@ -118,7 +118,7 @@ class TestAll(unittest.TestCase):
 
         # Test the yearly segmentation.
         df['year'] = np.array(df.reset_index(level=1)['real_date'].dt.year)
-        df_cs = srr.df_isolator(df=df, cs='2013', cs_type='years')
+        df_cs = srr.__slice_df__(df=df, cs='2013', cs_type='years')
 
         # Confirm that the year column contains exclusively '2013'. If so, able to deduce
         # that the segmentation works correctly for yearly type.
@@ -126,7 +126,7 @@ class TestAll(unittest.TestCase):
         df_cs_year = np.array(list(map(lambda y: str(y), df_cs_year)))
         self.assertTrue(np.all(df_cs_year == '2013'))
 
-    def test_panel_relations(self):
+    def test__output_table__(self):
 
         self.dataframe_generator()
         # Test the method responsible for producing the table of metrics assessing the
@@ -139,7 +139,7 @@ class TestAll(unittest.TestCase):
         return_ = 'XR'
         srr = SignalReturnRelations(self.dfd, sig=signal, ret=return_,
                                     freq='D', blacklist=self.blacklist)
-        df_cs = srr.panel_relations(cs_type='cids')
+        df_cs = srr.__output_table__(cs_type='cids')
 
         # The lagged signal & returns have been reduced to[-1, 1] which are interpreted
         # as indicator random variables.
@@ -215,7 +215,7 @@ class TestAll(unittest.TestCase):
 
         # Lastly, confirm that 'Mean' row is computed using exclusively the respective
         # segmentation types. Test on yearly data and balanced accuracy.
-        df_ys = srr.panel_relations(cs_type='years')
+        df_ys = srr.__output_table__(cs_type='years')
         df_ys_mean = df_ys.loc['Mean', 'bal_accuracy']
 
         dfx = df_ys[~df_ys.index.isin(['Panel', 'Mean', 'PosRatio'])]
@@ -223,7 +223,7 @@ class TestAll(unittest.TestCase):
         condition = np.abs(np.mean(dfx_balance) - df_ys_mean)
         self.assertTrue(condition < 0.00001)
 
-    def test_yaxis_lim(self):
+    def test__yaxis_lim__(self):
 
         self.dataframe_generator()
 
@@ -231,7 +231,7 @@ class TestAll(unittest.TestCase):
         return_ = 'XR'
         srr = SignalReturnRelations(self.dfd, sig=signal, ret=return_,
                                     freq='D', blacklist=self.blacklist)
-        df_cs = srr.panel_relations(cs_type='cids')
+        df_cs = srr.__output_table__(cs_type='cids')
         dfx = df_cs[~df_cs.index.isin(['PosRatio'])]
         dfx_acc = dfx.loc[:, ['accuracy', 'bal_accuracy']]
         arr_acc = dfx_acc.to_numpy()
@@ -240,7 +240,7 @@ class TestAll(unittest.TestCase):
         # Flatten the array - only concerned with the minimum across both dimensions. If
         # the minimum value is less than 0.45, use the minimum value to initiate the
         # range. Test the above logic.
-        ylim = srr.yaxis_lim(accuracy_df=dfx_acc)
+        ylim = srr.__yaxis_lim__(accuracy_df=dfx_acc)
 
         min_value = min(arr_acc)
         if min_value < 0.45:


### PR DESCRIPTION
Todo: add method .rival_sigs(sigs, sig_neg: bool = False)
In this case a comparative output table is returned with the Panel
row of the original table only, but for the original signal and
all rival categories.