### PR TITLE
Fixed bug arising due to a type error

### DIFF
--- a/macrosynergy/management/check_availability.py
+++ b/macrosynergy/management/check_availability.py
@@ -107,7 +107,10 @@ def visual_paneldates(df: pd.DataFrame, size: Tuple[float] = None):
         # in the DataFrame.
         maxdate = df.max().max()
         df = business_day_dif(df=df, maxdate=maxdate)
-        df = df.astype(int)
+
+        df = df.astype(float)
+        # Ideally the data type should be int, but Pandas cannot represent NaN as int.
+        # -- https://pandas.pydata.org/pandas-docs/stable/user_guide/gotchas.html#support-for-integer-na
 
         header = f"Missing days prior to {maxdate.strftime('%Y-%m-%d')}"
 


### PR DESCRIPTION
The error was due to NaN types in pandas dataframes. 
The code requires the dataframe values to be converted to numerical types. However, NaN cannot be represented in integers, as numpy (a core pandas dependency) does not provide this functionality. Therefore, we cast the values to floating-point numbers (floats) which provide functionality for NaN (as well as inf.).
This is a documented [pandas "gotcha"](https://pandas.pydata.org/pandas-docs/stable/user_guide/gotchas.html).

Refs: 
https://pandas.pydata.org/pandas-docs/stable/user_guide/gotchas.html#support-for-integer-na
and
https://stackoverflow.com/a/21290084/4417821