### PR TITLE
changed  "ci" keyword to "estimator" in sns.lineplot calls in view_timelines.py

### DIFF
--- a/macrosynergy/panel/view_timelines.py
+++ b/macrosynergy/panel/view_timelines.py
@@ -74,7 +74,7 @@ def view_timelines(df: pd.DataFrame, xcats: List[str] = None,  cids: List[str] =
     if len(cids) == 1:
         sns.set(rc={'figure.figsize': size})
         ax = sns.lineplot(data=df, x='real_date', y=val,
-                          hue='xcat', ci=None, sizes=size)
+                          hue='xcat', estimator=None, sizes=size)
 
         plt.axhline(y=0, c=".5")
         handles, labels = ax.get_legend_handles_labels()
@@ -92,7 +92,7 @@ def view_timelines(df: pd.DataFrame, xcats: List[str] = None,  cids: List[str] =
                            sharey=same_y, aspect=aspect,
                            height=height, col_order=cids)
         fg.map_dataframe(sns.lineplot, x='real_date', y=val,
-                         hue='xcat', hue_order=xcats, ci=None)
+                         hue='xcat', hue_order=xcats, estimator=None)
 
         if cs_mean:
             axes = fg.axes.flatten()


### PR DESCRIPTION
The "ci" (confidence interval) argument/keyword specifies a method for creating error-bars in lineplots  `seaborn` (up to and incl. version 11.2).
In `seaborn` version 12 onwards, this has been deprecated, and replaced by the `estimator` keyword, which allows the user to specify which estimator to use. 
The implication is that seaborn ignores the argument, and goes on to run error-bar estimation calculations on the data.
It is does not cause a single lineplot to be significantly slower, however when using a panel with multiple lineplots (seaborn.FacetGrid), the output takes much longer.

The issue is documented on the seaborn repository issues here : https://github.com/mwaskom/seaborn/issues/3006
To which the solution (implemented in this commit) is also provided by repo. owner : https://github.com/mwaskom/seaborn/issues/3006#issuecomment-1241318307. 

The solution is backward compatible and needs to be implemented in other functions of the macrosynergy package that may use "ci" arguments for lineplots. It is compatible down to (and incl.) seaborn version 0.9.0 (July 2018).
