### PR TITLE
Updated call to sns.lineplot to use "estimator" instead of "ci"

### DIFF
--- a/macrosynergy/panel/basket.py
+++ b/macrosynergy/panel/basket.py
@@ -603,7 +603,7 @@ class Basket(object):
                                     hue=df_stack['value'].isna().cumsum(),
                                     palette=["blue"] *
                                             df_stack['value'].isna().cumsum().nunique(),
-                                    ci=None, markers=True)
+                                    estimator=None, markers=True)
 
                 equal_value = (1 / no_contracts)
                 fg.map(plt.axhline, y=equal_value, linestyle='--', color='gray', lw=0.5)


### PR DESCRIPTION
Updated the call to sns.lineplot; same reasons as Pull Request https://github.com/macrosynergy/macrosynergy/pull/524.

TLDR - changed arguments to use a non-deprecated, backward compatible one.