### PR TITLE
Changed L11 to avoid an extra '/' in the API URLs

### DIFF
--- a/macrosynergy/dataquery/auth.py
+++ b/macrosynergy/dataquery/auth.py
@@ -8,7 +8,7 @@ from datetime import datetime
 
 CERT_BASE_URL: str = "https://platform.jpmorgan.com/research/dataquery/api/v2"
 OAUTH_BASE_URL: str = (
-    "https://api-developer.jpmorgan.com/research/dataquery-authe/api/v2/"
+    "https://api-developer.jpmorgan.com/research/dataquery-authe/api/v2"
 )
 OAUTH_TOKEN_URL: str = "https://authe.jpmchase.com/as/token.oauth2"
 OAUTH_DQ_RESOURCE_ID: str = "JPMC:URI:RS-06785-DataQueryExternalApi-PROD"


### PR DESCRIPTION
Changed the base URL for `OAUTH_BASE_URL` so it matches `CERT_BASE_URL`.
This avoids the issue of an extra forward-slash in the generated DataQuery Heartbeat URLs