### PR TITLE
develop -> test

### DIFF
--- a/.github/workflows/python-test-pypi-package.yml
+++ b/.github/workflows/python-test-pypi-package.yml
@@ -30,6 +30,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -58,7 +59,7 @@ jobs:
       run: |
         pip install twine
         twine check dist/*
-        twine upload dist/*
+        twine upload -r testpypi dist/*
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.TWINE_TEST_TOKEN }}

--- a/.github/workflows/python-test-pypi-package.yml
+++ b/.github/workflows/python-test-pypi-package.yml
@@ -62,7 +62,7 @@ jobs:
         twine upload -r testpypi dist/*
       env:
         TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.TWINE_TEST_TOKEN }}
+        TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
         TWINE_REPOSITORY: testpypi
 
 


### PR DESCRIPTION
Correcting token names used by the Test PyPI workflow;
 `TWINE_TEST_TOKEN` → `TEST_PYPI_API_TOKEN` 