### PR TITLE
Changed DataQuery API batch size from 10 to 20

### DIFF
--- a/macrosynergy/dataquery/api.py
+++ b/macrosynergy/dataquery/api.py
@@ -36,7 +36,7 @@ class Interface(object):
         oauth: bool = False,
         debug: bool = False,
         concurrent: bool = True,
-        batch_size: int = 10,
+        batch_size: int = 20,
         **kwargs
     ):
 


### PR DESCRIPTION
Changed the DataQuery API batch size from 10 to 20 requests; as per @lsimonsen 