### PR TITLE
Make integration tests run on the test branch

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -5,9 +5,9 @@ name: Python Integration tests
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [main, test, develop]
   pull_request:
-    branches: [ main, develop ]
+    branches: [main, test, develop]
 
 jobs:
   build:
@@ -23,11 +23,13 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install flake8 pytest sphinx pytest-cov
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        
     - name: Run integration tests with pytest
       env:
         DQ_CLIENT_ID: ${{ secrets.DQ_CLIENT_ID }}


### PR DESCRIPTION
The integration test needed to be run on push/pull events for the `test` branch as well.