### PR TITLE
updated version number to v0.0.21

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ Development Status :: 4 - Beta
 
 MAJOR = 0
 MINOR = 0
-MICRO = 20
+MICRO = 21
 ISRELEASED = True
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 


### PR DESCRIPTION
Updating version number to 0.0.21.
[Issue #590 (Ralph adds just one letter)](https://github.com/macrosynergy/macrosynergy/pull/590) will not merge without version number update.