### PR TITLE
reestimation frequency historic vol

### DIFF
--- a/macrosynergy/panel/historic_vol.py
+++ b/macrosynergy/panel/historic_vol.py
@@ -71,7 +71,7 @@ def flat_std(x: np.ndarray, remove_zeros: bool = True):
     mabs = np.mean(np.abs(x))
     return mabs
 
-def group_by_freq(df: pd.DataFrame, freq: str = "m", agg : str = "mean"):
+def agg_by_cycle(df: pd.DataFrame, freq: str = "m", agg : str = "mean") -> pd.DataFrame:
     """Returns a DataFrame with values aggregated by the frequency specified.
 
     :param <pd.DataFrame>  df: standardized DataFrame with the following necessary columns:
@@ -83,62 +83,41 @@ def group_by_freq(df: pd.DataFrame, freq: str = "m", agg : str = "mean"):
     :param <str> agg: Aggregation method. Options are 'mean' and 'sum'. Default is 'mean'.
         'last' means that the last value in the period is used.
     """
-    def months_btwn_dates(start_date : pd.Timestamp, end_date : pd.Timestamp):
-        """Returns the number of months between two dates."""
-        return (end_date.year - start_date.year) * 12 + (end_date.month - start_date.month)
+        
+    def years_btwn_dates(start_date : pd.Timestamp, end_date : pd.Timestamp):
+        """Returns the number of years between two dates."""
+        return end_date.year - start_date.year
 
     def quarters_btwn_dates(start_date : pd.Timestamp, end_date : pd.Timestamp):
         """Returns the number of quarters between two dates."""
         return (end_date.year - start_date.year) * 4 + (end_date.quarter - start_date.quarter)
 
-    def years_btwn_dates(start_date : pd.Timestamp, end_date : pd.Timestamp):
-        """Returns the number of years between two dates."""
-        return end_date.year - start_date.year
+    def months_btwn_dates(start_date : pd.Timestamp, end_date : pd.Timestamp):
+        """Returns the number of months between two dates."""
+        return (end_date.year - start_date.year) * 12 + (end_date.month - start_date.month)
+    
 
     def weeks_btwn_dates(start_date : pd.Timestamp, end_date : pd.Timestamp):
         """Returns the number of business weeks between two dates."""
-        # start date is any date. the next business day is the next Monday
-        next_monday = start_date + pd.offsets.BDay(7 - start_date.weekday())
-        return abs((end_date - next_monday).days) // 7
+        next_monday = start_date + pd.offsets.Week(weekday=0)
+        return (end_date - next_monday).days // 7 + 1
     
     # should these be lambdas?
         
-    freq = freq.lower()
+    freq, agg = freq.lower(), agg.lower()
     dfc = df.copy()
-    
     start_date = dfc['real_date'].min()
-    group_func = {'m': months_btwn_dates,
+    group_func = {  
+                    'y': years_btwn_dates,
                     'q': quarters_btwn_dates,
-                    'a': years_btwn_dates,
+                    'm': months_btwn_dates,
                     'w': weeks_btwn_dates,
                     'd': lambda x, y: (y - x).days}[freq]
     dfc['cycleCount'] = dfc['real_date'].apply(lambda x: group_func(start_date, x))
     
-    # dfh = dfc[['cycleCount', 'real_date']]
-    # dfh = dfh.groupby('cycleCount').agg({'real_date': 'last'})
-    # dfc.drop(['real_date'], axis=1, inplace=True)
-        
-    
-    if agg == "mean":
-        # don't apply mean to 'cycleCount' or 'real_date'
-        dfc = dfc.groupby('cycleCount').mean()
-    elif agg == "sum":
-        dfc = dfc.groupby('cycleCount').sum()
-    elif agg == "last":
-        dfc = dfc.groupby('cycleCount').last()
-    
-    # dfc['real_date'] = dfh['real_date']
-    # set index
-        
+    dfc = dfc.groupby(['cycleCount', 'cid', 'xcat']).agg({'real_date': 'last', 'value': agg}).reset_index()
+    dfc.drop(columns=['cycleCount'], inplace=True)
     return dfc
-        
-    
-                                        
-
-        
-    
-
-    
 
 
 def historic_vol(df: pd.DataFrame, xcat: str = None, cids: List[str] = None,
@@ -196,6 +175,9 @@ def historic_vol(df: pd.DataFrame, xcat: str = None, cids: List[str] = None,
     df = reduce_df(
         df, xcats=[xcat], cids=cids, start=start, end=end, blacklist=blacklist
     )
+
+    df = agg_by_cycle(df, freq=est_freq, agg='last')
+    
     dfw = df.pivot(index='real_date', columns='cid', values='value')
 
     # The pandas in-built method df.rolling() will account for NaNs and start from the


### PR DESCRIPTION
This branch changes how the historic volatility function runs. 
Till now, the historic volatility was being calculated on every date in the input dataframe. 