### PR TITLE
DQ API add optional proxy server function

### DIFF
--- a/tests/unit/dataquery/test_api.py
+++ b/tests/unit/dataquery/test_api.py
@@ -64,7 +64,8 @@ class TestDataQueryInterface(unittest.TestCase):
             self.assertTrue(clause)
             mock_p_request.assert_called_with(
                 url=dq.access.base_url +"/services/heartbeat",
-                params={'data': 'NO_REFERENCE_DATA'}
+                params={'data': 'NO_REFERENCE_DATA'},
+                proxy=None,
             )
 
         mock_p_request.assert_called_once()
@@ -87,7 +88,8 @@ class TestDataQueryInterface(unittest.TestCase):
             self.assertTrue(not clause)
             mock_p_fail.assert_called_with(
                 url=dq.access.base_url + "/services/heartbeat",
-                params={"data": "NO_REFERENCE_DATA"}
+                params={"data": "NO_REFERENCE_DATA"},
+                proxy=None,
             )
 
         mock_p_fail.assert_called_once()


### PR DESCRIPTION
Add optionality to modify the BASE URL's and to use a proxy server for connecting to JPMorgan DataQuery.