### PR TITLE
updated GH-actions versions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,9 +18,9 @@ jobs:
         python-version: [3.8]  # For multiple: [3.7, 3.8]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,9 +18,9 @@ jobs:
         python-version: ['3.7', '3.8', '3.9', '3.10']  # For multiple: [3.7, 3.8]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/pythons-docs.yml
+++ b/.github/workflows/pythons-docs.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest  # Alternative: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - name: Install dependencies


### PR DESCRIPTION
- Problem:
Github raised the following warning:

![image](https://user-images.githubusercontent.com/23239946/207599920-6a906a40-6115-478e-9d2b-afd5db3ac555.png)


- Fix:
Updated actions to use the the latest versions actions/checkout(v2→v3) and actions/setup-python(v2&3→v4).