### PR TITLE
Bugfix in business_day_dif

### DIFF
--- a/macrosynergy/management/check_availability.py
+++ b/macrosynergy/management/check_availability.py
@@ -75,18 +75,12 @@ def business_day_dif(df: pd.DataFrame, maxdate: pd.Timestamp):
         series.
 
     """
-    year_df = (maxdate.year - df.apply(lambda x: x.dt.year))
-    year_df *= 52
-
-    week_max = maxdate.week
-    week_df = week_max - df.apply(lambda x: x.dt.isocalendar().week)
-
+    year_df = (maxdate.year - df.apply(lambda x: x.dt.isocalendar().year)) * 52
+    week_df = (maxdate.week - df.apply(lambda x: x.dt.isocalendar().week))
     # Account for difference over a year.
     week_df += year_df
-
     # Account for weekends.
     week_df *= 2
-
     df = (maxdate - df).apply(lambda x: x.dt.days)
     return df - week_df
 


### PR DESCRIPTION
Python Datetime's/Pandas' `isocalender()` represents a date in the form (Year, Week number, Week day). One of the calculations was using an a deprecated form of getting the year for the calculations. Updating the code to use `pd.DatetimeIndex.isocalender()` fixed the issue. Important point to remember is that the `isocalender()` functionality must NOT be confused with `isoformat()`.