### PR TITLE
pinning sphinx (and sphinx themes') version

### DIFF
--- a/.github/workflows/pythons-docs.yml
+++ b/.github/workflows/pythons-docs.yml
@@ -24,7 +24,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
 
-        pip install flake8 pytest sphinx pytest-cov sphinx_book_theme sphinx_rtd_theme
+        pip install flake8 pytest pytest-cov sphinx==5.3.0 sphinx_book_theme==0.3.3 sphinx_rtd_theme==1.1.1
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |

--- a/.github/workflows/pythons-docs.yml
+++ b/.github/workflows/pythons-docs.yml
@@ -24,7 +24,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
 
-        pip install flake8 pytest pytest-cov sphinx==5.3.0 sphinx_book_theme==0.3.3 sphinx_rtd_theme==1.1.1
+        pip install flake8 pytest pytest-cov sphinx==5.3.0 sphinx_rtd_theme==1.1.1
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |


### PR DESCRIPTION
Pinning Sphnix and sphinx RTD theme versions in documentation build workflows. This is recommended practice : https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html#pinning-dependencies
Also removed sphinx book theme as it is not being used