### PR TITLE
Bugfixes in macrosynergy/download/dataquery.py

### DIFF
--- a/macrosynergy/download/dataquery.py
+++ b/macrosynergy/download/dataquery.py
@@ -84,10 +84,13 @@ def dq_request(
             last_url: str = r.url
             js, success, msg = valid_response(r=r, track_id=track_id)
     except requests.exceptions.ChunkedEncodingError as e:
-        logger.error(f"ChunkedEncodingError: {e}")
+        logger.error(
+            f"ChunkedEncodingError: {e}," f"URL: {log_url}, track_id: {track_id}"
+        )
         js, success, msg = None, False, None
         raise InvalidResponseError(
-            e, f"at URL: {last_url} , thread track-d: {track_id}"
+            e,
+            f"URL : {log_url}",
         )
 
     if not success:


### PR DESCRIPTION
 - Addressing and catching `requests.exceptions.ChunkedEncodingError` in `ms.download.dataquery.dq_request()`. The code will still break and raise `ms.download.exceptions.InvalidResponseError`.
 - Changed function that calculates DQ API delay parameter. (https://github.com/macrosynergy/macrosynergy/issues/619). Now the delay is 200ms for requests with num. tickers<1000, and 300ms for requests with num. tickers>1000.
