### PR TITLE
Feature : Print Debug Logs

### DIFF
--- a/macrosynergy/download/dataquery.py
+++ b/macrosynergy/download/dataquery.py
@@ -375,9 +375,8 @@ class Interface(object):
         debug_stream_handler.stream.flush()
         debug_stream_handler.stream.seek(0)
         self.msg_errors = debug_stream_handler.stream.getvalue().splitlines()
-        # NOTE: Close the stream to avoid memory leaks.
+        # NOTE: Don't close the stream, as it causes can issues with parent/logging modules.
         # NOTE: DO NOT try and close/delete self or pass it to gc.collect() here.
-        debug_stream_handler.stream.close()
 
     def check_connection(self) -> Tuple[bool, dict]:
         """Check connection (heartbeat) to DataQuery."""

--- a/macrosynergy/download/dataquery.py
+++ b/macrosynergy/download/dataquery.py
@@ -7,7 +7,7 @@ from math import ceil, floor
 from itertools import chain
 import uuid
 import base64
-import os
+import os, io
 import requests
 from typing import List, Optional, Dict, Tuple
 from datetime import datetime
@@ -22,6 +22,14 @@ OAUTH_DQ_RESOURCE_ID: str = "JPMC:URI:RS-06785-DataQueryExternalApi-PROD"
 API_DELAY_PARAM: float = 0.3  # 300ms delay between requests
 
 logger = logging.getLogger(__name__)
+debug_stream_handler = logging.StreamHandler(io.StringIO())
+debug_stream_handler.setLevel(logging.NOTSET)
+debug_stream_handler.setFormatter(
+    logging.Formatter(
+        "%(asctime)s - %(levelname)s - %(module)s - %(funcName)s :: %(message)s"
+    )
+)
+logger.addHandler(debug_stream_handler)
 
 
 def valid_response(
@@ -330,6 +338,7 @@ class Interface(object):
 
         self.proxy = kwargs.pop("proxy", kwargs.pop("proxies", None))
         self.heartbeat = heartbeat
+        self.msg_errors: List[str] = []
 
         if oauth:
             self.access: OAuth = OAuth(
@@ -362,8 +371,11 @@ class Interface(object):
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
         if exc_type:
-            print(f"Execution {exc_type} with value (exc_value):\n\t {exc_value}")
+            # print(f"Execution {exc_type} with value (exc_value):\n\t {exc_value}")
             logger.error(f"Execution {exc_type} with value (exc_value): {exc_value}")
+        debug_stream_handler.stream.flush()
+        debug_stream_handler.stream.seek(0)
+        self.msg_errors = debug_stream_handler.stream.getvalue().splitlines()
 
     def check_connection(self) -> Tuple[bool, dict]:
         """Check connection (heartbeat) to DataQuery."""
@@ -725,7 +737,7 @@ class Interface(object):
         results = None
 
         print(datetime.utcnow().isoformat(), " UTC")
-
+        logger.info(f"Starting request for {len(expressions)} expressions.")
         while results is None:
             results = self._request(
                 endpoint="/expressions/time-series",
@@ -737,6 +749,7 @@ class Interface(object):
             c_delay += 0.1
 
         results, error_tickers, error_messages = results
+        logger.info(f"Finished request for {len(expressions)} expressions.")
 
         unavailable_expressions: List[Tuple(str, str)] = []
         unavailable_expressions = [
@@ -766,6 +779,8 @@ class Interface(object):
                 "Some expressions were unavailable, and were not returned.\n"
                 "Check logger output for more details."
             )
+        else:
+            logger.info(f"All requested expressions were available.")
 
         if error_tickers:
             logger.warning(f"Request failed for tickers: {', '.join(error_tickers)}.")

--- a/macrosynergy/download/dataquery.py
+++ b/macrosynergy/download/dataquery.py
@@ -375,6 +375,9 @@ class Interface(object):
         debug_stream_handler.stream.flush()
         debug_stream_handler.stream.seek(0)
         self.msg_errors = debug_stream_handler.stream.getvalue().splitlines()
+        # NOTE: Close the stream to avoid memory leaks.
+        # NOTE: DO NOT try and close/delete self or pass it to gc.collect() here.
+        debug_stream_handler.stream.close()
 
     def check_connection(self) -> Tuple[bool, dict]:
         """Check connection (heartbeat) to DataQuery."""

--- a/macrosynergy/download/dataquery.py
+++ b/macrosynergy/download/dataquery.py
@@ -371,7 +371,6 @@ class Interface(object):
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
         if exc_type:
-            # print(f"Execution {exc_type} with value (exc_value):\n\t {exc_value}")
             logger.error(f"Execution {exc_type} with value (exc_value): {exc_value}")
         debug_stream_handler.stream.flush()
         debug_stream_handler.stream.seek(0)

--- a/macrosynergy/download/jpmaqs.py
+++ b/macrosynergy/download/jpmaqs.py
@@ -105,7 +105,6 @@ class JPMaQSDownload(object):
                 if len(m.strip()) > 0:
                     print(m.strip())
             print(("-" * 60 + "\n") * 2)
-            
 
         if exc_type:
             logger.error(e_str)
@@ -511,7 +510,6 @@ class JPMaQSDownload(object):
                     debug=debug,
                 )
             dq_msg_errors = dq.msg_errors
-            # debug_stream_handler.stream.flush()
             debug_stream_handler.stream.write("\n".join(dq_msg_errors))
             logger.info("Download complete. DataQuery interface closed.")
 

--- a/macrosynergy/download/jpmaqs.py
+++ b/macrosynergy/download/jpmaqs.py
@@ -99,11 +99,10 @@ class JPMaQSDownload(object):
             debug_stream_handler.stream.flush()
             debug_stream_handler.stream.seek(0)
             self.msg_errors += debug_stream_handler.stream.readlines()
-            print("-" * 24, " DEBUG DATA ", "-" * 24)
+            print("-" * 23, " DEBUG DATA ", "-" * 23)
             print("-" * 60)
             for m in self.msg_errors:
-                if len(m.strip()) > 0:
-                    print(m.strip())
+                print(m.strip())
             print(("-" * 60 + "\n") * 2)
 
         if exc_type:
@@ -416,7 +415,9 @@ class JPMaQSDownload(object):
         :return <pd.Dataframe> df: standardized dataframe with columns 'cid', 'xcats',
             'real_date' and chosen metrics.
         """
-        self.print_debug_data = print_debug_data
+        self.debug = self.debug or debug
+        self.print_debug_data = self.print_debug_data or print_debug_data
+        
         if self.suppress_warning != suppress_warning:
             self.suppress_warning = suppress_warning
 
@@ -510,7 +511,7 @@ class JPMaQSDownload(object):
                     debug=debug,
                 )
             dq_msg_errors = dq.msg_errors
-            debug_stream_handler.stream.write("\n".join(dq_msg_errors))
+            debug_stream_handler.stream.write("\n".join(dq_msg_errors) + "\n")
             logger.info("Download complete. DataQuery interface closed.")
 
         except ConnectionError:

--- a/macrosynergy/download/jpmaqs.py
+++ b/macrosynergy/download/jpmaqs.py
@@ -591,7 +591,7 @@ class JPMaQSDownload(object):
                     _dict=results_dict, no_metrics=no_metrics, original_metrics=metrics
                 )
             logger.info(
-                "Data validation complete. Starting to create and validate dataframe"
+                "Data validation complete. Creating and validating dataframe."
             )
 
             if (not isinstance(df, pd.DataFrame)) or (df.empty):

--- a/macrosynergy/download/jpmaqs.py
+++ b/macrosynergy/download/jpmaqs.py
@@ -8,9 +8,17 @@ import warnings
 from macrosynergy.download import dataquery
 from macrosynergy.download.exceptions import *
 import logging
-import sys
+import io
 
 logger = logging.getLogger(__name__)
+debug_stream_handler = logging.StreamHandler(io.StringIO())
+debug_stream_handler.setLevel(logging.NOTSET)
+debug_stream_handler.setFormatter(
+    logging.Formatter(
+        "%(asctime)s - %(levelname)s - %(module)s - %(funcName)s :: %(message)s"
+    )
+)
+logger.addHandler(debug_stream_handler)
 
 
 class JPMaQSDownload(object):
@@ -34,13 +42,15 @@ class JPMaQSDownload(object):
         oauth: bool = True,
         client_id: Optional[str] = None,
         client_secret: Optional[str] = None,
-        debug: bool = False,
         suppress_warning: bool = True,
+        debug: bool = False,
+        print_debug_data: bool = False,
         check_connection: bool = False,
         **kwargs,
     ):
-
         self.debug = debug
+        self.print_debug_data = print_debug_data
+        self.msg_errors: List[str] = []
         self.suppress_warning = suppress_warning
         self.proxy = kwargs.pop("proxy", kwargs.pop("proxies", None))
         self.unavailable_tickers = []
@@ -82,8 +92,22 @@ class JPMaQSDownload(object):
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
+        e_str = f"{exc_type} {exc_value} {traceback}"
+        if self.print_debug_data or (self.debug and exc_type):
+            if exc_type:
+                logger.error(e_str)
+            debug_stream_handler.stream.flush()
+            debug_stream_handler.stream.seek(0)
+            self.msg_errors += debug_stream_handler.stream.readlines()
+            print("-" * 24, " DEBUG DATA ", "-" * 24)
+            print("-" * 60)
+            for m in self.msg_errors:
+                if len(m.strip()) > 0:
+                    print(m.strip())
+            print(("-" * 60 + "\n") * 2)
+            
+
         if exc_type:
-            e_str = f"{exc_type} {exc_value} {traceback}"
             logger.error(e_str)
             raise exc_type(exc_value)
         else:
@@ -371,6 +395,7 @@ class JPMaQSDownload(object):
         end_date=None,
         suppress_warning=True,
         debug=False,
+        print_debug_data=False,
     ):
         """
         Downloads and returns a standardised DataFrame of the specified base tickers and metrics.
@@ -392,6 +417,7 @@ class JPMaQSDownload(object):
         :return <pd.Dataframe> df: standardized dataframe with columns 'cid', 'xcats',
             'real_date' and chosen metrics.
         """
+        self.print_debug_data = print_debug_data
         if self.suppress_warning != suppress_warning:
             self.suppress_warning = suppress_warning
 
@@ -469,8 +495,8 @@ class JPMaQSDownload(object):
         expressions = self.jpmaqs_indicators(metrics=metrics, tickers=tickers)
 
         logger.info(
-            f"Downloading {len(expressions)} expressions from JPMaQS"
-            f"for {len(tickers)} tickers & {len(metrics)} metrics."
+            f"Downloading {len(expressions)} expressions from JPMaQS "
+            f"for {len(tickers)} tickers & {len(metrics)} metrics. "
             f"Start date: {start_date}. End date: {end_date}."
         )
 
@@ -484,6 +510,11 @@ class JPMaQSDownload(object):
                     suppress_warning=suppress_warning,
                     debug=debug,
                 )
+            dq_msg_errors = dq.msg_errors
+            # debug_stream_handler.stream.flush()
+            debug_stream_handler.stream.write("\n".join(dq_msg_errors))
+            logger.info("Download complete. DataQuery interface closed.")
+
         except ConnectionError:
             logger.error("Failed to download data. ConnectionError.")
             logger.error("Appending error messages to JPMaQSDownload.download_output")
@@ -515,6 +546,7 @@ class JPMaQSDownload(object):
                 "Failed to download data for some tickers. See log for details."
             )
         else:
+            logger.info("No error tickers; Starting to data parse.")
             results_dict, output_dict, s_list = self.isolate_timeseries(
                 list_=results, metrics=metrics, debug=debug, sequential=True
             )  #
@@ -532,15 +564,17 @@ class JPMaQSDownload(object):
                     )
                 else:
                     logger.warning(
-                        f"Debug mode is on; adding download ouput to JPMaQSDownload.download_output"
-                        f"Debug mode is on; adding parsed output to JPMaQSDownload.parsed_output"
+                        f"Debug mode is off; adding download ouput to JPMaQSDownload.download_output"
+                        f"Debug mode is off; adding parsed output to JPMaQSDownload.parsed_output"
                     )
-                    self.download_output = dq_result_dict
-                    self.parsed_output = {
-                        "results": results_dict,
-                        "results_nested_dictionary": output_dict,
-                        "missing_tickers": s_list,
-                    }
+                self.download_output = dq_result_dict
+                self.parsed_output = {
+                    "results": results_dict,
+                    "results_nested_dictionary": output_dict,
+                    "missing_tickers": s_list,
+                }
+
+            logger.info("Data parse complete. Starting data validation.")
 
             results_dict = self.valid_ticker(results_dict, suppress_warning, self.debug)
 
@@ -558,6 +592,9 @@ class JPMaQSDownload(object):
                 df = self.dataframe_wrapper(
                     _dict=results_dict, no_metrics=no_metrics, original_metrics=metrics
                 )
+            logger.info(
+                "Data validation complete. Starting to create and validate dataframe"
+            )
 
             if (not isinstance(df, pd.DataFrame)) or (df.empty):
                 logger.error("No data returned from DataQuery")
@@ -578,4 +615,6 @@ class JPMaQSDownload(object):
                 )
             else:
                 df = df.sort_values(["cid", "xcat", "real_date"]).reset_index(drop=True)
+                logger.info("Dataframe created and validated.")
+                logger.info("Returning dataframe and exiting JPMaQSDownload.download.")
                 return df

--- a/macrosynergy/download/jpmaqs.py
+++ b/macrosynergy/download/jpmaqs.py
@@ -93,9 +93,9 @@ class JPMaQSDownload(object):
 
     def __exit__(self, exc_type, exc_value, traceback):
         e_str = f"{exc_type} {exc_value} {traceback}"
-        if self.print_debug_data or (self.debug and exc_type):
-            if exc_type:
-                logger.error(e_str)
+        if exc_type:
+            logger.error(e_str)
+        if self.print_debug_data or exc_type:
             debug_stream_handler.stream.flush()
             debug_stream_handler.stream.seek(0)
             self.msg_errors += debug_stream_handler.stream.readlines()
@@ -106,7 +106,6 @@ class JPMaQSDownload(object):
             print(("-" * 60 + "\n") * 2)
 
         if exc_type:
-            logger.error(e_str)
             raise exc_type(exc_value)
         else:
             return True
@@ -417,7 +416,7 @@ class JPMaQSDownload(object):
         """
         self.debug = self.debug or debug
         self.print_debug_data = self.print_debug_data or print_debug_data
-        
+
         if self.suppress_warning != suppress_warning:
             self.suppress_warning = suppress_warning
 
@@ -591,9 +590,7 @@ class JPMaQSDownload(object):
                 df = self.dataframe_wrapper(
                     _dict=results_dict, no_metrics=no_metrics, original_metrics=metrics
                 )
-            logger.info(
-                "Data validation complete. Creating and validating dataframe."
-            )
+            logger.info("Data validation complete. Creating and validating dataframe.")
 
             if (not isinstance(df, pd.DataFrame)) or (df.empty):
                 logger.error("No data returned from DataQuery")


### PR DESCRIPTION
In case there is an unhandled exception or a failure when downloading/parsing/returning DF from JPMaQS.download, entire log stream (only from ms.download.jpmaqs.py and ...dataquery.py) will be printed to the users console.
In case there are errors with dataquery, these logs can be used as is to show the complete error.

By design, in case of an error all the logs are printed. However, if the user still needs debug logs, these can be printed by adding a `print_debug_data=True` param in the JPMaQS object init, or to JPMaQS.download.
eg:
```
with JPMaQSDownload(client_id=client_id, client_secret=client_secret, 
    print_debug_data=True,) as JPMaQS:
    start = timer()
    df = JPMaQS.download(
        tickers=tickers,
        start_date="2000-01-01",
        metrics=["value"],)
    end = timer()
 ```
 ...
 or...
 ```
       df = JPMaQS.download(
          tickers=tickers,
          metrics=["value"],...)
 
 
 eg output  (<XYZ>s are place holders) :

 
 Number of expressions requested : 10
Number of missing time-series from the Database: 0.
-----------------------  DEBUG DATA  -----------------------
------------------------------------------------------------
2023-01-11 19:05:43,501 - INFO - jpmaqs - __init__ :: JPMaQSDownload object created.
2023-01-11 19:05:43,501 - INFO - jpmaqs - download :: Downloading 10 expressions from JPMaQS for 10 tickers & 1 metrics. Start date: 2000-01-01. End date: None.
2023-01-11 19:05:43,502 - INFO - dataquery - get_ts_expression :: Starting request for 10 expressions.
2023-01-11 19:05:43,502 - INFO - dataquery - _request :: Number of expressions requested : 10
2023-01-11 19:05:43,504 - INFO - dataquery - _fetch_threading :: Requesting ... <DQ URL and params> --track_id=8f647123-29b2-4ae7-aea4-54532ab048eb
2023-01-11 19:05:43,505 - INFO - dataquery - dq_request :: Requesting URL: <OAUTH TOKEN URL> , track_id: get_oauth_token
2023-01-11 19:05:44,949 - INFO - dataquery - dq_request :: Requesting URL: <Formed url form DQ URL and params> , track_id: --track_id=8f647123-29b2-4ae7-aea4-54532ab048eb
2023-01-11 19:05:53,929 - INFO - dataquery - _fetch_threading :: Request successful. --track_id=8f647123-29b2-4ae7-aea4-54532ab048eb
2023-01-11 19:05:53,930 - INFO - dataquery - get_ts_expression :: Finished request for 10 expressions.
2023-01-11 19:05:53,930 - INFO - dataquery - get_ts_expression :: All requested expressions were available.
2023-01-11 19:05:53,930 - INFO - jpmaqs - download :: Download complete. DataQuery interface closed.
2023-01-11 19:05:53,930 - INFO - jpmaqs - download :: No error tickers; Starting to data parse.
2023-01-11 19:05:53,957 - INFO - jpmaqs - download :: Data parse complete. Starting data validation.
2023-01-11 19:05:54,077 - INFO - jpmaqs - download :: Data validation complete. Starting to create and validate dataframe
2023-01-11 19:05:54,105 - INFO - jpmaqs - download :: Dataframe created and validated.
2023-01-11 19:05:54,105 - INFO - jpmaqs - download :: Returning dataframe and exiting JPMaQSDownload.download.
------------------------------------------------------------
------------------------------------------------------------

Download time from DQ: 0:00:10.609653
Last updated: 2023-01-11
   cid       xcat  real_date     value
0	.			.		.			.
1	.			.		.			.
```