### PR TITLE
added show_progress functionality for download

### DIFF
--- a/macrosynergy/download/jpmaqs.py
+++ b/macrosynergy/download/jpmaqs.py
@@ -393,6 +393,7 @@ class JPMaQSDownload(object):
         suppress_warning=True,
         debug=False,
         print_debug_data=False,
+        show_progress=False,
     ):
         """
         Downloads and returns a standardised DataFrame of the specified base tickers and metrics.
@@ -410,6 +411,9 @@ class JPMaQSDownload(object):
         :param <str> start_date: first date in ISO 8601 string format.
         :param <bool> suppress_warning: used to suppress warning of any invalid
             ticker received by DataQuery.
+        :param <bool> debug: used to print out the tickers that are being downloaded.
+        :param <bool> print_debug_data: used to print out debug information.
+        :param <bool> show_progress: used to show progress bar. Default is False.
 
         :return <pd.Dataframe> df: standardized dataframe with columns 'cid', 'xcats',
             'real_date' and chosen metrics.
@@ -508,6 +512,7 @@ class JPMaQSDownload(object):
                     end_date=end_date,
                     suppress_warning=suppress_warning,
                     debug=debug,
+                    show_progress=show_progress,
                 )
             dq_msg_errors = dq.msg_errors
             debug_stream_handler.stream.write("\n".join(dq_msg_errors) + "\n")

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ statsmodels >= 0.13.2
 scikit-learn >= 1.0.2
 numpy >= 1.21.6
 requests >= 2.27.1
+tqdm >= 4.62


### PR DESCRIPTION
Now shows ETAs and progress bars for 
```python
with JPMaQSDownload(...) as client:
    df = client.download(... show_progress=True)
```
(default is `False`).
eg. : 
```
2023-01-18T01:34:43.620624  UTC
Number of expressions requested : 1000
Requesting data :  44%|███████████              | 22/50 [00:08<00:13,  2.11it/s]
```
↓
```
2023-01-18T01:34:43.620624  UTC
Number of expressions requested : 1000
Requesting data : 100%|█████████████████████████| 50/50 [00:17<00:00,  2.83it/s]
Downloading data :  34%|████████▏               | 17/50 [00:30<00:23,  1.43it/s]
```
↓
```
2023-01-18T01:34:43.620624  UTC
Number of expressions requested : 1000
Requesting data : 100%|█████████████████████████| 50/50 [00:17<00:00,  2.83it/s]
Downloading data : 100%|████████████████████████| 50/50 [00:50<00:00,  1.04it/s] 
```