### PR TITLE
fixed legend for non-faceted graphs; added shared-axis-label feature

### DIFF
--- a/macrosynergy/pnl/naive_pnl.py
+++ b/macrosynergy/pnl/naive_pnl.py
@@ -431,9 +431,11 @@ class NaivePnL:
                   facet: bool = False,
                   ncol: int = 3, same_y: bool = True,
                   title: str = "Cumulative Naive PnL", xcat_labels: List[str] = None,
+                  x_axis_label: str = "Year", y_axis_label: str = ("% of risk capital"
+                  ", no compounding"), share_axis_labels: bool = True,
                   figsize: Tuple = (12, 7), aspect: float = 1.7,
                   height: float = 3, label_adj: float = 0.05,
-                  title_adj: float = 0.95):
+                  title_adj: float = 0.95, y_label_adj: float = 0.95,) -> None:
         """
         Plot line chart of cumulative PnLs, single PnL, multiple PnL types per
         cross section, or multiple cross sections per PnL type.
@@ -456,6 +458,12 @@ class NaivePnL:
         :param <bool> same_y: if True (default) all plots in facet grid share same y axis.
         :param <str> title: allows entering text for a custom chart header.
         :param <List[str]> xcat_labels: custom labels to be used for the PnLs.
+        :param <str> x_axis_label: label for x-axis of the plot (or subplots if faceted),
+            default is 'Year'.
+        :param <str> y_axis_label: label for y-axis of the plot (or subplots if faceted),
+            default is '% of risk capital, no compounding'.
+        :param <bool> share_axis_labels: if True (default) the axis labels are shared by
+            all subplots in the facet grid.
         :param <tuple> figsize: tuple of plot width and height. Default is (12 , 7).
         :param <float> aspect: width-height ratio for plots in facet. Default is 1.7.
         :param <float> height: height of plots in facet. Default is 3.
@@ -463,6 +471,7 @@ class NaivePnL:
             Default is 0.05.
         :param <float> title_adj: parameter that sets top of figure to accommodate title.
             Default is 0.95.
+        :param <float> y_label_adj: parameter that sets left of figure to fit the y-label.
         """
 
         if pnl_cats is None:
@@ -531,9 +540,9 @@ class NaivePnL:
                 data=dfx, col=plot_by, col_wrap=ncol, sharey=same_y, aspect=aspect,
                 height=height, col_order=col_order, legend_out=True
             )
-            fg.fig.suptitle(title, fontsize=20, x=0.4)
+            fg.fig.suptitle(title, fontsize=20,)
 
-            fg.fig.subplots_adjust(top=title_adj)
+            fg.fig.subplots_adjust(top=title_adj, bottom=label_adj, left=y_label_adj)
 
             fg.map_dataframe(
                 sns.lineplot, x="real_date", y="cum_value", hue=plot_by,
@@ -547,9 +556,16 @@ class NaivePnL:
             if no_cids > 1:
                 fg.set_titles(row_template='', col_template='{col_name}')
             
+            # fg.set_axis_labels(x_var="Year", y_var="% of risk capital, no compounding", 
             
-            fg.set_axis_labels(x_var="Year", y_var="% of risk capital, no compounding")
-        
+            if share_axis_labels:
+                fg.set_axis_labels("", "")
+                fg.fig.supxlabel(x_axis_label)
+                fg.fig.supylabel(y_axis_label)
+            else:
+                fg.set_axis_labels(x_axis_label, y_axis_label)
+            
+
         else:
             fg = sns.lineplot(data=dfx, x="real_date", y="cum_value", hue=plot_by, 
                                 hue_order=col_order, estimator=None, lw=1)
@@ -560,11 +576,16 @@ class NaivePnL:
             plt.xlabel("Year")
             plt.ylabel("% of risk capital, no compounding")
 
+        # TODO : Legend for FacetGrid graphs. Is there any use cases for it?
         if no_cids == 1:
             if facet:
                 labels = labels[::-1]
+        
+        # set axis labels for the whole figure using plt
+        # fg.supxlabel(x_axis_label)
+        # fg.supylabel(y_axis_label)
+        
             
-            # TODO : Legend for facetgrid is not working
             
         plt.axhline(y=0, color='black', linestyle='--', lw=1)
         plt.show()
@@ -889,11 +910,24 @@ if __name__ == "__main__":
     )
     pnl.plot_pnls(
         pnl_cats=["PNL_GROWTH_NEG", "Long"], facet=True, xcat_labels=["S_1", "S_2"]
+    )    
+    pnl.plot_pnls(
+        pnl_cats=["PNL_GROWTH_NEG", "Long"], facet=True,
     )
 
     pnl.plot_pnls(  pnl_cats=["PNL_GROWTH_NEG"], 
                     pnl_cids=cids,
                     facet=True,
                     xcat_labels=None
-                    
                     )
+    
+    pnl.plot_pnls(  pnl_cats=["PNL_GROWTH_NEG"], 
+                    same_y=True,
+                    pnl_cids=cids,
+                    facet=True,
+                    xcat_labels=None,
+                    share_axis_labels=False,
+                    x_axis_label='Date',
+                    y_axis_label='PnL',
+                    y_label_adj=0.1,)
+

--- a/macrosynergy/pnl/naive_pnl.py
+++ b/macrosynergy/pnl/naive_pnl.py
@@ -539,30 +539,31 @@ class NaivePnL:
                 sns.lineplot, x="real_date", y="cum_value", hue=plot_by,
                 hue_order=col_order, estimator=None, lw=1
             )
-            for ax in fg.axes.flat:
+            for ix, ax in enumerate(fg.axes.flat):
                 ax.axhline(y=0, color="black", linestyle='--', linewidth=1)
-
-            # TODO: find a better legend solution
-            # fg.add_legend(
-            #     legend_data={pb : lbl for pb, lbl in zip((pnl_cids if len(pnl_cids) > 1 else pnl_cats), labels)},
-            # )
-            # if no_cids == 1:
-            #     fg.add_legend()
-
-            fg.set_titles(row_template='', col_template='{col_name}')
+                if no_cids == 1:
+                    ax.set_title(xcat_labels[ix])
+            
+            if no_cids > 1:
+                fg.set_titles(row_template='', col_template='{col_name}')
+            
+            
             fg.set_axis_labels(x_var="Year", y_var="% of risk capital, no compounding")
         
         else:
             fg = sns.lineplot(data=dfx, x="real_date", y="cum_value", hue=plot_by, 
                                 hue_order=col_order, estimator=None, lw=1)
 
-            leg = fg.axes.get_legend()
-            leg.set_title(legend_title)
             plt.title(title, fontsize=20)
 
             plt.xlabel("Year")
             plt.ylabel("% of risk capital, no compounding")
 
+        if no_cids == 1:
+            if facet:
+                labels = labels[::-1]
+            plt.legend(title=legend_title, loc='center right', labels=labels,)
+            
         plt.axhline(y=0, color='black', linestyle='--', lw=1)
         plt.show()
 

--- a/macrosynergy/pnl/naive_pnl.py
+++ b/macrosynergy/pnl/naive_pnl.py
@@ -553,7 +553,8 @@ class NaivePnL:
         else:
             fg = sns.lineplot(data=dfx, x="real_date", y="cum_value", hue=plot_by, 
                                 hue_order=col_order, estimator=None, lw=1)
-
+            leg = fg.axes.get_legend()
+            leg.set_title(legend_title)
             plt.title(title, fontsize=20)
 
             plt.xlabel("Year")
@@ -562,7 +563,8 @@ class NaivePnL:
         if no_cids == 1:
             if facet:
                 labels = labels[::-1]
-            plt.legend(title=legend_title, loc='center right', labels=labels,)
+            
+            # TODO : Legend for facetgrid is not working
             
         plt.axhline(y=0, color='black', linestyle='--', lw=1)
         plt.show()


### PR DESCRIPTION
The new behaviour implies that faceted graphs will not have a legend printed; since they would have only 1 XCAT with multiple CIDS, or vice-versa.

To understand the shared-axis-labels behaviour, view the last two example calls to `pnl.plot_pnls()` in `naive_pnl.py`:

```python

pnl.plot_pnls(  pnl_cats=["PNL_GROWTH_NEG"], 
                pnl_cids=cids,
                facet=True,
                xcat_labels=None
                )
# new options : 
pnl.plot_pnls(  pnl_cats=["PNL_GROWTH_NEG"], 
                same_y=True,
                pnl_cids=cids,
                facet=True,
                xcat_labels=None,
                share_axis_labels=False,
                x_axis_label='Date',
                y_axis_label='PnL',
                y_label_adj=0.1,)
                    
```