### PR TITLE
Feature : Change default plot size in visual paneldates

### DIFF
--- a/macrosynergy/management/check_availability.py
+++ b/macrosynergy/management/check_availability.py
@@ -113,7 +113,7 @@ def visual_paneldates(df: pd.DataFrame, size: Tuple[float] = None):
         header = "Start years of quantamental indicators."
 
     if size is None:
-        size = (max(df.shape[0] / 2, 15), max(1, df.shape[1]/ 2))
+        size = (max(df.shape[0] / 2, 18), max(1, df.shape[1]/ 2))
 
     sns.set(rc={'figure.figsize': size})
     sns.heatmap(df.T, cmap='YlOrBr', center=df.stack().mean(), annot=True, fmt='.0f',


### PR DESCRIPTION
### CAUTION : This PR changes the default behaviour for a common function. Merge with caution.

Changed default size of visual_pandeldates plot from [15, 2] → [18, 2].

Closes : https://github.com/macrosynergy/macrosynergy/issues/585