### PR TITLE
Feature : View timelines, reset index to standardize input DF

### DIFF
--- a/macrosynergy/panel/view_timelines.py
+++ b/macrosynergy/panel/view_timelines.py
@@ -69,8 +69,8 @@ def view_timelines(df: pd.DataFrame, xcats: List[str] = None,  cids: List[str] =
                 fail_str
 
             df = dft.copy()
-        except:
-            raise ValueError(fail_str)
+        except Exception as e:
+            raise e(f"Exception message: {e}")
 
     df["real_date"] = pd.to_datetime(df["real_date"], format="%Y-%m-%d")
 

--- a/macrosynergy/panel/view_timelines.py
+++ b/macrosynergy/panel/view_timelines.py
@@ -70,7 +70,7 @@ def view_timelines(df: pd.DataFrame, xcats: List[str] = None,  cids: List[str] =
 
             df = dft.copy()
         except Exception as e:
-            raise e(f"Exception message: {e}")
+            raise Exception(f"Exception message: {e}", fail_str)
 
     df["real_date"] = pd.to_datetime(df["real_date"], format="%Y-%m-%d")
 

--- a/macrosynergy/panel/view_timelines.py
+++ b/macrosynergy/panel/view_timelines.py
@@ -57,6 +57,18 @@ def view_timelines(df: pd.DataFrame, xcats: List[str] = None,  cids: List[str] =
     :param <float> height: height of plots in facet. Default is 3.
 
     """
+    
+    if not set(df.columns).issuperset({'cid', 'xcat', 'real_date', val}):
+        fail_str :str =(f"Error : Tried to standardize DataFrame but failed."
+                f"DataFrame not in the correct format. Please ensure " \
+                f"that the DataFrame has the following columns: " 
+                f"'cid', 'xcat', 'real_date' and column='{val}'.")
+        try:
+            dft = df.reset_index()
+            assert set(dft.columns).issuperset({'cid', 'xcat', 'real_date', val})
+            df = dft.copy()
+        except:
+            raise ValueError(fail_str)
 
     df["real_date"] = pd.to_datetime(df["real_date"], format="%Y-%m-%d")
 
@@ -240,6 +252,7 @@ if __name__ == "__main__":
     view_timelines(dfd, xcats=['XR'], cids=cids, ncol=2,
                    cumsum=True, same_y=False, aspect=2)
     
+    dfd = dfd.set_index('real_date')    
     view_timelines(dfd, xcats=['XR'], cids=cids, ncol=2,
                 cumsum=True, same_y=False, aspect=2, single_chart=True)
 

--- a/macrosynergy/panel/view_timelines.py
+++ b/macrosynergy/panel/view_timelines.py
@@ -65,7 +65,9 @@ def view_timelines(df: pd.DataFrame, xcats: List[str] = None,  cids: List[str] =
                 f"'cid', 'xcat', 'real_date' and column='{val}'.")
         try:
             dft = df.reset_index()
-            assert set(dft.columns).issuperset({'cid', 'xcat', 'real_date', val})
+            assert set(dft.columns).issuperset({'cid', 'xcat', 'real_date', val}),\
+                fail_str
+
             df = dft.copy()
         except:
             raise ValueError(fail_str)

--- a/tests/unit/panel/test_view_timelines.py
+++ b/tests/unit/panel/test_view_timelines.py
@@ -110,7 +110,7 @@ class TestAll(unittest.TestCase):
                 title='AUD Return, Carry & Inflation', 
                 single_chart=True, xcat_grid=True) # (xcat_grid && single_chart) must be False
             
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(Exception):
             dfdr = dfd.copy().set_index('real_date').drop('cid', axis=1)
             view_timelines(dfdr, xcats=xcats, cids=cids[0],
                 title_adj=0.8, same_y=True,

--- a/tests/unit/panel/test_view_timelines.py
+++ b/tests/unit/panel/test_view_timelines.py
@@ -53,6 +53,19 @@ class TestAll(unittest.TestCase):
             view_timelines(dfd, xcats=[xcats[0]], cids=cids, ncol=2,
                         cumsum=True, same_y=False, aspect=2, single_chart=True)
             
+            # test that any indexing of the  works
+            for c in dfd.columns:
+                dfdr = dfd.copy().set_index(c)
+                view_timelines(dfdr, xcats=[xcats[0]], cids=cids, ncol=2,
+                            cumsum=True, same_y=False, aspect=2, single_chart=True)
+            
+            dfdr = dfd.copy().set_index('real_date')
+            # rename column 'value' to 'qwerty'
+            dfdr = dfdr.rename(columns={'value': 'qwerty'})
+            view_timelines(dfdr, xcats=[xcats[0]], cids=cids, ncol=2,
+                        cumsum=True, same_y=False, aspect=2, single_chart=True,
+                        val='qwerty')
+                        
         except Exception as e:
             self.fail(e)
             

--- a/tests/unit/panel/test_view_timelines.py
+++ b/tests/unit/panel/test_view_timelines.py
@@ -109,6 +109,15 @@ class TestAll(unittest.TestCase):
                 xcat_labels=['Return', 'Carry', 'Inflation'],
                 title='AUD Return, Carry & Inflation', 
                 single_chart=True, xcat_grid=True) # (xcat_grid && single_chart) must be False
+            
+        with self.assertRaises(AssertionError):
+            dfdr = dfd.copy().set_index('real_date').drop('cid', axis=1)
+            view_timelines(dfdr, xcats=xcats, cids=cids[0],
+                title_adj=0.8, same_y=True,
+                xcat_labels=['Return', 'Carry', 'Inflation'],
+                title='AUD Return, Carry & Inflation',
+                xcat_grid=True) # df must have a column named 'cid'
+
 
         
 if __name__ == '__main__':


### PR DESCRIPTION
Closes #685.

Added a simple code block to check if the input DF has the necessary columns of a standard DF.
If not, `df.reset_index` is attempted; if that works, good - continue. Else raises exception.