### PR TITLE
Bugfix : corrected exception handling in retry routine

### DIFF
--- a/macrosynergy/download/dataquery.py
+++ b/macrosynergy/download/dataquery.py
@@ -665,14 +665,18 @@ class Interface(object):
                             return None
 
                     except Exception as exc:
-                        error_tickers.extend(futures[i][1])
-                        logger.warning(
-                            f"Error in requestion tickers: {', '.join(futures[i][1])}."
-                            f"Error accessing {self.access.base_url + endpoint} with "
-                            f"tickers : {futures[i][1]}"
-                            f"start-date : {start_date}"
-                            f"end-date : {end_date}"
-                        )
+                        if isinstance(exc, InvalidResponseError):
+                            error_tickers.extend(futures[i][1])
+                            logger.warning(
+                                f"Error in requestion tickers: {', '.join(futures[i][1])}."
+                                f"Error accessing {self.access.base_url + endpoint} with "
+                                f"tickers : {futures[i][1]}"
+                                f"start-date : {start_date}"
+                                f"end-date : {end_date}"
+                            )
+                            continue 
+                        else:
+                            raise exc
 
                     else:
                         if isinstance(response, list):


### PR DESCRIPTION
Exception handling code was added to allow retrying downloads (up to 5 times) before failing.
The earlier code handled all exceptions and caused retries for exceptions that require the code to break eg. AuthenticationError