### PR TITLE
Bugfix : Fixed Dict Search for Config 

### DIFF
--- a/macrosynergy/download/dataquery.py
+++ b/macrosynergy/download/dataquery.py
@@ -7,6 +7,7 @@ JPMorgan DataQuery API.
 """
 import concurrent.futures
 import time
+import os
 import logging
 import itertools
 import base64
@@ -530,7 +531,8 @@ def get_unavailable_expressions(
     :return <List[str]>: list of expressions that were not found in the dicts.
     """
     found_exprs: List[str] = [
-        curr_dict["attributes"][0]["expression"] for curr_dict in dicts_list
+        curr_dict["attributes"][0]["expression"]
+        for curr_dict in dicts_list
         if curr_dict["attributes"][0]["time-series"] is not None
     ]
     return list(set(expected_exprs) - set(found_exprs))
@@ -547,7 +549,7 @@ class DataQueryInterface(object):
     :param <bool> concurrent: whether to use concurrent requests. Defaults to True.
     :param <int> batch_size: default 20, number of expressions to send in a single
         request. Must be a number between 1 and 20 (both included).
-    :param <bool> check_connection: whether to send a check_connection request. 
+    :param <bool> check_connection: whether to send a check_connection request.
         Defaults to True.
     :param <str> base_url: base URL for the DataQuery API. Defaults to OAUTH_BASE_URL
         if `oauth` is True, CERT_BASE_URL otherwise.

--- a/macrosynergy/download/jpmaqs.py
+++ b/macrosynergy/download/jpmaqs.py
@@ -263,7 +263,7 @@ class JPMaQSDownload(object):
                 " Check logger output for complete list. \n"
                 f"{len(expr_missing)} out of {len(expr_expected)} expressions are missing."
             )
-            
+
             logger.warning(log_str)
             logger.warning(f"Missing expressions: {expr_missing}")
             if verbose:
@@ -332,7 +332,7 @@ class JPMaQSDownload(object):
         cid: str
         xcat: str
         found_expressions: List[str] = []
-        _missing_exprs : List[str] = []
+        _missing_exprs: List[str] = []
         self.unavailable_expr_messages = []
         # _missing_exprs is just a sanity check to verify self.unavailable_expressions
         for d in dicts_list:
@@ -343,7 +343,8 @@ class JPMaQSDownload(object):
                 found_expressions.append(d["attributes"][0]["expression"])
                 df: pd.DataFrame = (
                     pd.DataFrame(
-                        d["attributes"][0]["time-series"], columns=["real_date", metricx]
+                        d["attributes"][0]["time-series"],
+                        columns=["real_date", metricx],
                     )
                     .assign(cid=cid, xcat=xcat, metric=metricx)
                     .rename(columns={metricx: "obs"})
@@ -353,9 +354,10 @@ class JPMaQSDownload(object):
             else:
                 _missing_exprs.append(d["attributes"][0]["expression"])
                 self.unavailable_expr_messages.append(d["attributes"][0]["message"])
-                
-        assert set(_missing_exprs) == set(self.unavailable_expressions), \
-            "Downloaded `dicts_list` has been modified before calling `time_series_to_df`"
+
+        assert set(_missing_exprs) == set(
+            self.unavailable_expressions
+        ), "Downloaded `dicts_list` has been modified before calling `time_series_to_df`"
 
         final_df: pd.DataFrame = pd.concat(dfs, ignore_index=True)
 
@@ -399,11 +401,11 @@ class JPMaQSDownload(object):
         )
         # sort found_metrics in the order of self.valid_metrics, then re-order the columns
         final_df = final_df[["real_date", "cid", "xcat"] + found_metrics]
-        
+
         # IMPORTANT NOTE:
         # Drop NA containing rows to be revisited when blacklisting is implemented
-        
-        final_df = final_df.dropna(axis=0, how='any').reset_index(drop=True)
+
+        final_df = final_df.dropna(axis=0, how="any").reset_index(drop=True)
 
         if validate_df:
             vdf = self.validate_downloaded_df(
@@ -748,7 +750,7 @@ if __name__ == "__main__":
         "EUR",
         "FRF",
         "GBP",
-        "USD"
+        "USD",
     ]
     xcats = [
         "RIR_NSA",

--- a/macrosynergy/management/utils.py
+++ b/macrosynergy/management/utils.py
@@ -69,52 +69,46 @@ def get_dict_max_depth(d: dict) -> int:
         else 0
     )
 
-
-def rec_search_dict(d: dict, key: str, match_substring: bool = False, match_type : Any = None) -> str:
+def rec_search_dict(d : dict,
+                    key : str,
+                    match_substring : bool = False,
+                    match_type=None):
     """
     Recursively searches a dictionary for a key and returns the value
     associated with it.
 
-    Parameters
     :param <dict> d: The dictionary to be searched.
     :param <str> key: The key to be searched for.
     :param <bool> match_substring: If True, the function will return
         the value of the first key that contains the substring
         specified by the key parameter. If False, the function will
         return the value of the first key that matches the key
-        parameter exactly.
+        parameter exactly. Default is False.
     :param <Any> match_type: If not None, the function will look for
-        a key that matches that matches the search parameters and has
-        the specified type.
-
-    Returns
-    :return <str>: The value associated with the key.
+        a key that matches the search parameters and has
+        the specified type. Default is None.
+    :return Any: The value associated with the key, or None if the key
+        is not found.
     """
     if not isinstance(d, dict):
-        raise TypeError("Argument `d` must be a dictionary.")
-    result: Any = None
-    
-    # match the key exactly or match a substring. if match_type is not None, then match the type as well.
-    if match_substring:
-        if match_type is None:
-            result = next((v for k, v in d.items() if key in k), None)
-        else:
-            result = next((v for k, v in d.items() if key in k and isinstance(v, match_type)), None)
-    else:
-        if match_type is None:
-            result = d.get(key, None)
-        else:
-            result = next((v for k, v in d.items() if k == key and isinstance(v, match_type)), None)
-            
-    if result is None:
-        for k, v in d.items():
-            if isinstance(v, dict):
-                result = rec_search_dict(v, key, match_substring, match_type)
-                if result is not None:
-                    break
+        return None
 
-    return result
-        
+    for k, v in d.items():
+        if match_substring:
+            if key in k:
+                if match_type is None or isinstance(v, match_type):
+                    return v
+        else:
+            if k == key:
+                if match_type is None or isinstance(v, match_type):
+                    return v
+
+        if isinstance(v, dict):
+            result = rec_search_dict(v, key, match_substring, match_type)
+            if result is not None:
+                return result
+
+    return None
 
 
 def is_valid_iso_date(date: str) -> bool:
@@ -393,6 +387,9 @@ class Config(object):
                     config_dict = {k.lower(): v for k, v in config_dict.items()}
                     for var in loaded_vars.keys():
                         loaded_vars[var] = rec_search_dict(d=config_dict, key=var, match_type=str)
+
+                    for var in proxy_var_names:
+                        loaded_vars[var] = rec_search_dict(d=config_dict, key=var, match_type=dict)
 
                     if loaded_vars["crt"] is None:
                         loaded_vars["crt"] = rec_search_dict(d=config_dict, key="cert",

--- a/tests/unit/management/test_utils.py
+++ b/tests/unit/management/test_utils.py
@@ -41,14 +41,20 @@ class TestFunctions(unittest.TestCase):
         d: dict = {"a": 1, "b": {"c": 2, "d": {"e": 3}}}
         self.assertEqual(rec_search_dict(d, "e"), 3)
 
-        d: int = 10
-        with self.assertRaises(TypeError):
-            rec_search_dict(d, "e")
+        self.assertEqual(rec_search_dict('Some string', "KEY"), None)
 
         dx: dict = {0: "a"}
         for i in range(1, 100):
             dx = {i: dx}
         self.assertEqual(rec_search_dict(dx, 0), "a")
+
+        d = {"12": 1, "123": 2, "234": 3, "1256": 4, "246": 5}
+        self.assertEqual(rec_search_dict(d=d, key="25", match_substring=True), 4)
+        self.assertEqual(rec_search_dict(d=d, key="99", match_substring=True), None)
+
+        d = {"12": 1, "123": [2], "234": '3', "1256": 4.0, "246": {"a": 1}}
+        for k in d.keys():
+            self.assertEqual(rec_search_dict(d=d, key=k, match_substring=True, match_type=type(d[k])), d[k])
 
     def test_is_valid_iso_date(self):
         d1: str = "2020-01-01"


### PR DESCRIPTION
A special bug arising when the user uses a yaml like:
```yaml
oauth:
  client_id: "userName"
  client_secret: "passwordX"

cert_auth:
  username: "username"
  password: "password"
  cert: "certif.crt"
  key: "keyx.key"
```

It caused the recursive dict search to return the dict itself when searching for 'cert'.
Possible solutions were, 
1. force the user to use 'crt' as the dict key to the path (str).
2. add a match_type =<type> feature in the search function.

Solution 2 was implemented.