### PR TITLE
Bugfix : Make ZN Scores failing with pure NA series

### DIFF
--- a/tests/unit/panel/test_zn_scores.py
+++ b/tests/unit/panel/test_zn_scores.py
@@ -4,17 +4,14 @@ import warnings
 from tests.simulate import make_qdf
 from macrosynergy.panel.make_zn_scores import *
 from itertools import groupby
-
-
-with warnings.catch_warnings():
-    warnings.filterwarnings("ignore", category=DeprecationWarning)
+from typing import List, Dict, Callable
 
 class TestAll(unittest.TestCase):
 
     def dataframe_construction(self):
 
-        self.__dict__['cids'] = ['AUD', 'CAD', 'GBP']
-        self.__dict__['xcats'] = ['CRY', 'XR']
+        self.cids : List[str] = ['AUD', 'CAD', 'GBP']
+        self.xcats : List[str] = ['CRY', 'XR']
 
         df_cids = pd.DataFrame(index=self.cids, columns=['earliest', 'latest', 'mean_add',
                                                     'sd_mult'])
@@ -30,13 +27,13 @@ class TestAll(unittest.TestCase):
 
         # Standard df for tests.
         dfd = make_qdf(df_cids, df_xcats, back_ar=0.75)
-        self.__dict__['dfd'] = dfd[dfd['xcat'] == 'CRY']
-        self.__dict__['dfw'] = self.dfd.pivot(index='real_date', columns='cid',
-                                              values='value')
 
-        daily_dates = pd.date_range(start='2010-01-01', end='2020-10-30', freq='B')
-        self.__dict__['dates_iter'] = daily_dates
-        self.__dict__['func_dict'] = {'mean': np.mean, 'median': np.median}
+        self.dfd : pd.DataFrame = dfd[dfd['xcat'] == 'CRY']
+        self.dfw : pd.DataFrame = self.dfd.pivot(index='real_date', columns='cid',
+                                                    values='value')
+
+        self.dates_iter : pd.DatetimeIndex = pd.date_range(start='2010-01-01', end='2020-10-30', freq='B')
+        self.func_dict : Dict[str, Callable] = {'mean': np.mean, 'median': np.median}
 
     def in_sampling(self, dfw, neutral, min_obs):
         """
@@ -466,6 +463,20 @@ class TestAll(unittest.TestCase):
         check = sum(values[~np.isnan(values)] > threshold)
 
         self.assertTrue(check == 0)
+        
+    def test_zn_scores_warning(self):
+        self.dataframe_construction()
+        
+        with self.assertWarns(UserWarning):
+            warnings.simplefilter("always")
+            r_cid : str = self.cids[0]
+            r_xcat : str = 'CRY'
+            self.dfd.loc[(self.dfd['cid'] == r_cid) & (self.dfd['xcat'] == r_xcat), 'value'] : float = pd.NA
+            dfr : pd.DataFrame = make_zn_scores(df=self.dfd, xcat=r_xcat, cids=self.cids, start="2010-01-01",)
+            dfr['xcat'] : pd.Series = dfr['xcat'].str.replace('ZN', '')
+            self.assertEqual(dfr['xcat'].unique()[0], r_xcat)
+            self.assertFalse(r_cid in dfr['cid'].unique())
+        
 
         
 if __name__ == '__main__':


### PR DESCRIPTION
If a CID_XCAT pair in the dataframe is filled with NAs only, it will now be dropped and a warning will be raised.
Closes #731.
Unit tests for warning included.