### PR TITLE
Bugfix : DQ/Unexpected Dates

### DIFF
--- a/macrosynergy/download/jpmaqs.py
+++ b/macrosynergy/download/jpmaqs.py
@@ -789,7 +789,6 @@ if __name__ == "__main__":
     metrics = "all"
     start_date: str = "2023-01-01"
     end_date: str = "2023-03-20"
-    start_date, end_date = end_date, start_date
 
     with JPMaQSDownload(
         credentials_config="env",


### PR DESCRIPTION
Currently, the interface breaks and raises an unintelligable error when a date such as 1600-01-01 is passed.

New behaviour:
A hard limit of 1677-09-22 == `pd.Timestamp.min` has to be imposed, as it would simply be impossible to create a pd.Timestamp for a date before this.
A warning message is raised if the start_date or the end_date is before 1950-01-01.
When the start_date is after the end_date, the two dates are swapped and a warning message is raised.
 