### PR TITLE
Feature : View Metrics ~view lags~

### DIFF
--- a/macrosynergy/panel/__init__.py
+++ b/macrosynergy/panel/__init__.py
@@ -12,9 +12,9 @@ from .view_correlations import correl_matrix
 from .view_grades import heatmap_grades
 from .view_ranges import view_ranges
 from .view_timelines import view_timelines
-
+from .view_metrics import view_metrics
 
 __all__ = ['Basket', 'CategoryRelations', 'ConvergeRow', 'return_beta',
            'beta_display', 'historic_vol', 'linear_composite',
            'make_blacklist', 'make_relative_value', 'make_zn_scores', 'panel_calculator',
-           'correl_matrix', 'heatmap_grades', 'view_ranges', 'view_timelines']
+           'correl_matrix', 'heatmap_grades', 'view_ranges', 'view_timelines', 'view_metrics']

--- a/macrosynergy/panel/view_metrics.py
+++ b/macrosynergy/panel/view_metrics.py
@@ -33,11 +33,10 @@ def view_metrics(
     :param <str> end: latest date in ISO format. Default is latest available.
     :param <str> metric: name of metric to be visualized. Must be "eop_lag" (default)
         "mop_lag" or "grading".
-    :param <str> agg: aggregation method. Must be one of "mean" (default), "median",
-        "min", "max", "first" or "last".
     :param <str> freq: frequency of data. Must be one of "D", "W", "M", "Q", "A". 
         Default is "M".
-    :
+    :param <str> agg: aggregation method. Must be one of "mean" (default), "median",
+        "min", "max", "first" or "last".
     :param <str> title: string of chart title; if none given default title is printed.
     :param <Tuple[float]> figsize: Tuple (w, h) of width and height of graph.
         Default is None, meaning it is set in accordance with df.

--- a/macrosynergy/panel/view_metrics.py
+++ b/macrosynergy/panel/view_metrics.py
@@ -21,7 +21,7 @@ def view_metrics(
     figsize: Optional[Tuple[float]] = (14, None),
 ) -> None:
     """
-    A function to visualise the `eop_lag` and `mop_lag` metrics of the
+    A function to visualise the `eop_lag`, `mop_lag` or `grading` metrics for a given
     JPMaQS dataset. It generates a heatmap, where the x-axis is the observation
     date, the y-axis is the ticker, and the colour is the lag value.
 

--- a/macrosynergy/panel/view_metrics.py
+++ b/macrosynergy/panel/view_metrics.py
@@ -26,7 +26,7 @@ def view_metrics(
     date, the y-axis is the ticker, and the colour is the lag value.
 
     :param <pd.Dataframe> df: standardized DataFrame with the necessary columns:
-        'cid', 'xcat', 'real_date' and 'eop_lag' and/or 'mop_lag.
+        'cid', 'xcat', 'real_date' and 'grading', 'eop_lag' or 'mop_lag'.
     :param str xcat: extended category whose lags are to be visualized.
     :param <List[str]> cids: cross sections to visualize. Default is all in DataFrame.
     :param <str> start: earliest date in ISO format. Default is earliest available.
@@ -44,7 +44,7 @@ def view_metrics(
     :return: None
 
     :raises TypeError: if any of the inputs are of the wrong type.
-    :raises ValueError: if any of the inputs are of the wrong value.
+    :raises ValueError: if any of the inputs are semantically incorrect.
     """
     # Validating inputs
     # First check if the standard valid and expected columns are present

--- a/macrosynergy/panel/view_metrics.py
+++ b/macrosynergy/panel/view_metrics.py
@@ -1,0 +1,179 @@
+import pandas as pd
+import seaborn as sns
+import matplotlib.pyplot as plt
+
+from typing import List, Tuple, Optional
+from macrosynergy.management.simulate_quantamental_data import make_test_df
+from macrosynergy.management.utils import is_valid_iso_date
+from macrosynergy.management.shape_dfs import reduce_df
+
+
+def view_metrics(
+    df: pd.DataFrame,
+    xcat: str,
+    cids: Optional[List[str]] = None,
+    start: Optional[str] = None,
+    end: Optional[str] = None,
+    freq: str = "M",
+    agg: str = "mean",
+    metric: str = "eop_lag",
+    title: Optional[str] = None,
+    figsize: Optional[Tuple[float]] = (14, None),
+) -> None:
+    """
+    A function to visualise the `eop_lag` and `mop_lag` metrics of the
+    JPMaQS dataset. It generates a heatmap, where the x-axis is the observation
+    date, the y-axis is the ticker, and the colour is the lag value.
+
+    :param <pd.Dataframe> df: standardized DataFrame with the necessary columns:
+        'cid', 'xcat', 'real_date' and 'eop_lag' and/or 'mop_lag.
+    :param str xcat: extended category whose lags are to be visualized.
+    :param <List[str]> cids: cross sections to visualize. Default is all in DataFrame.
+    :param <str> start: earliest date in ISO format. Default is earliest available.
+    :param <str> end: latest date in ISO format. Default is latest available.
+    :param <str> metric: name of metric to be visualized. Must be "eop_lag" (default)
+        "mop_lag" or "grading".
+    :param <str> agg: aggregation method. Must be one of "mean" (default), "median",
+        "min", "max", "first" or "last".
+    :param <str> freq: frequency of data. Must be one of "D", "W", "M", "Q", "A". 
+        Default is "M".
+    :
+    :param <str> title: string of chart title; if none given default title is printed.
+    :param <Tuple[float]> figsize: Tuple (w, h) of width and height of graph.
+        Default is None, meaning it is set in accordance with df.
+
+    :return: None
+
+    :raises TypeError: if any of the inputs are of the wrong type.
+    :raises ValueError: if any of the inputs are of the wrong value.
+    """
+
+    if not isinstance(metric, str):
+        raise TypeError("`metric` must be a string")
+    elif metric not in ["eop_lag", "mop_lag", "grading"]:
+        raise ValueError("`metric` must be either 'eop_lag', 'mop_lag' or 'grading'")
+
+    expc_cols: List[str] = ["cid", "xcat", "real_date", metric]
+    if not isinstance(df, pd.DataFrame):
+        raise TypeError("`df` must be a DataFrame")
+    elif df.empty:
+        raise ValueError("`df` must not be empty")
+    elif not set(expc_cols).issubset(df.columns):
+        raise ValueError(
+            f"`df` must have columns 'cid', 'xcat', 'real_date' and '{metric}'"
+        )
+    else:
+        df = df.copy()[expc_cols]
+
+    if not isinstance(xcat, str):
+        raise TypeError("`xcat` must be a string")
+    else:
+        if not xcat in df["xcat"].unique():
+            raise ValueError(f"No data for `xcat` = {xcat} in DataFrame `df`")
+
+    if cids is not None:
+        if (
+            (not isinstance(cids, list))
+            or (not all(isinstance(cid, str) for cid in cids))
+            or (len(cids) == 0)
+        ):
+            raise TypeError("`cids` must be a list of strings")
+
+        if not set(cids).issubset(df["cid"].unique()):
+            raise ValueError("All cids in `cids` must be in the DataFrame `df`")
+
+    else:
+        cids = list(df["cid"].unique())
+
+    df["real_date"]: pd.DatetimeIndex = pd.to_datetime(df["real_date"])
+    min_date: pd.Timestamp = df["real_date"].min()
+    max_date: pd.Timestamp = df["real_date"].max()
+    if start is None:
+        start: str = min_date.strftime("%Y-%m-%d")
+    if end is None:
+        end: str = max_date.strftime("%Y-%m-%d")
+
+    for varx, namex in zip([start, end], ["start", "end"]):
+        if not is_valid_iso_date(varx):
+            raise ValueError(f"`{namex}` must be a valid ISO date string")
+
+    if title is not None:
+        if not isinstance(title, str):
+            raise TypeError("`title` must be a string")
+
+    if not isinstance(figsize, tuple):
+        if not isinstance(figsize, list) or len(figsize) != 2:
+            raise TypeError("`figsize` must be a tuple or list of length 2")
+
+    if not isinstance(figsize[0], (int, float)):
+        raise ValueError("First element of `figsize` must be a float")
+
+    if figsize[1] is None:
+        figsize = (figsize[0], len(cids))
+
+    if not isinstance(figsize[1], (int, float)):
+        raise ValueError("Second element of `figsize` must be a float")
+
+    filtered_df: pd.DataFrame = reduce_df(
+        df=df, cids=cids, xcats=[xcat], start=start, end=end
+    )
+    filtered_df["real_date"]: pd.Series = filtered_df["real_date"].dt.strftime(
+        "%Y-%m-%d"
+    )
+    pivoted_df: pd.DataFrame = filtered_df.pivot_table(
+        index="cid", columns="real_date", values=metric
+    )
+
+    fig, ax = plt.subplots(figsize=figsize, layout="constrained")
+    max_mes: float = max(1, filtered_df[metric].max())
+    min_mes: float = min(0, filtered_df[metric].min())
+    sns.heatmap(
+        pivoted_df,
+        cmap=sns.color_palette("light:red", as_cmap=True),
+        vmin=min_mes,
+        vmax=max_mes,
+        ax=ax,
+    )
+
+    if title is None:
+        title = f"Visualising {metric} for {xcat} from {start} to {end}"
+    ax.set_title(title)
+    ax.set_xlabel("Date")
+    ax.set_ylabel("Cross Section")
+    plt.show()
+
+
+if __name__ == "__main__":
+    dfE: pd.DataFrame = make_test_df(
+        cids=["USD", "EUR", "GBP"], xcats=["FX", "IR"], prefer="sharp-hill"
+    )
+
+    dfM: pd.DataFrame = make_test_df(
+        cids=["USD", "EUR", "GBP"], xcats=["FX", "IR"], prefer="four-bit-sine"
+    )
+
+    dfG: pd.DataFrame = make_test_df(
+        cids=["USD", "EUR", "GBP"], xcats=["FX", "IR"], prefer="sine"
+    )
+
+    dfE.rename(columns={"value": "eop_lag"}, inplace=True)
+    dfM.rename(columns={"value": "mop_lag"}, inplace=True)
+    dfG.rename(columns={"value": "grading"}, inplace=True)
+    mergeon = ["cid", "xcat", "real_date"]
+    dfx: pd.DataFrame = pd.merge(pd.merge(dfE, dfM, on=mergeon), dfG, on=mergeon)
+
+    view_metrics(
+        df=dfx,
+        xcat="FX",
+    )
+    view_metrics(
+        df=dfx,
+        xcat="IR",
+        metric="mop_lag",
+    )
+    view_metrics(
+        df=dfx,
+        xcat="IR",
+        metric="grading",
+    )
+    

--- a/tests/unit/panel/test_view_metrics.py
+++ b/tests/unit/panel/test_view_metrics.py
@@ -1,7 +1,6 @@
 import unittest
 import pandas as pd
-from typing import List, Tuple, Optional, Dict
-from tests.simulate import make_qdf
+from typing import List, Dict, Any
 from macrosynergy.management.simulate_quantamental_data import make_test_df
 from macrosynergy.panel import view_metrics
 import matplotlib
@@ -28,8 +27,140 @@ class TestAll(unittest.TestCase):
         self.df: pd.DataFrame = df
 
     def test_view_metrics(self):
-        pass
+        self.dataframe_construction()
 
+        matplotlib.use("Agg")
+
+        good_args: Dict[str, Any] = {
+            "df": self.df,
+            "xcat": "XR",
+            "cids": self.cids,
+            "metric": "eop_lag",
+            "start": self.start,
+            "end": self.end,
+            "freq": "M",
+            "agg": "mean",
+            "title": "Test plot",
+            "figsize": (10, None),
+        }
+        # test simple good args
+        try:
+            view_metrics(**good_args)
+        except Exception as e:
+            self.fail(f"view_metrics raised {e} unexpectedly")
+
+        # test type errors
+        for arg in good_args:
+            bad_args: Dict[str, Any] = good_args.copy()
+            bad_args[arg] = 1
+            with self.assertRaises(TypeError):
+                view_metrics(**bad_args)
+
+        bad_args: Dict[str, Any] = good_args.copy()
+
+        # test bad xcat
+        bad_args["xcat"] = "bad_xcat"
+        with self.assertRaises(ValueError):
+            try:
+                view_metrics(**bad_args)
+            except Exception as e:
+                self.assertIsInstance(e, ValueError)
+                self.assertTrue(bad_args["xcat"] in str(e))
+                raise ValueError(e)
+
+        # test bad metric
+        bad_args = good_args.copy()
+        bad_args["metric"] = "bad_metric"
+        with self.assertRaises(ValueError):
+            view_metrics(**bad_args)
+
+        # test with empty df
+        bad_args = good_args.copy()
+        bad_cases = [
+            pd.DataFrame(),
+            self.df.rename(
+            columns={"eop_lag": "bad_metric"})
+        ]
+            
+        bad_args["df"] = pd.DataFrame()
+
+        for case in bad_cases:
+            bad_args["df"] = case
+            with self.assertRaises(ValueError):
+                view_metrics(**bad_args)
+
+        # test cids with empty list and list of int
+        bad_args = good_args.copy()
+        bad_cases = [
+            [],
+            [1, 2, 3],
+        ]
+        for case in bad_cases:
+            bad_args["cids"] = case
+            with self.assertRaises(TypeError):
+                view_metrics(**bad_args)
+
+        bad_args["cids"] = self.cids[:2] + ["bad_cid"]
+        with self.assertRaises(ValueError):
+            view_metrics(**bad_args)
+
+        # test bad start and end
+        bad_args = good_args.copy()
+        for arg in ["start", "end"]:
+            bad_args[arg] = "bad_date"
+            with self.assertRaises(ValueError):
+                view_metrics(**bad_args)
+                
+        # test freq
+        bad_args = good_args.copy()
+        bad_args["freq"] = "z"
+        with self.assertRaises(ValueError):
+            view_metrics(**bad_args)
+            
+        bad_args["freq"] = "m"
+        try:
+            view_metrics(**bad_args)
+        except Exception as e:
+            self.fail(f"view_metrics raised {e} unexpectedly")
+            
+        # test agg
+        bad_args = good_args.copy()
+        bad_args["agg"] = "bad_agg"
+        with self.assertRaises(ValueError):
+            view_metrics(**bad_args)
+            
+        bad_args["agg"] = "MEAN"
+        try:
+            view_metrics(**bad_args)
+        except Exception as e:
+            self.fail(f"view_metrics raised {e} unexpectedly")
+            
+        # test if the figsize is a tuple
+        bad_args = good_args.copy()
+        bad_cases: List[Any] = [
+            ['apple', 10],
+            (10, 'apple'),
+            [None, 10],
+        ]
+        for case in bad_cases:
+            bad_args["figsize"] = case
+            with self.assertRaises(ValueError):
+                view_metrics(**bad_args)
+                
+        # pass a list of 3 ints as figsize. should raise a type error
+        bad_args["figsize"] = [10, 10, 10]
+        with self.assertRaises(TypeError):
+            view_metrics(**bad_args)
+            
+        # give it one where the first one is int, second one is none. should work
+        bad_args["figsize"] = [10, None]
+        try:
+            view_metrics(**bad_args)
+        except Exception as e:
+            self.fail(f"view_metrics raised {e} unexpectedly")
+
+        
+        
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/panel/test_view_metrics.py
+++ b/tests/unit/panel/test_view_metrics.py
@@ -159,7 +159,15 @@ class TestAll(unittest.TestCase):
         except Exception as e:
             self.fail(f"view_metrics raised {e} unexpectedly")
 
-        
+        rp_args: List[Dict[str, Any]] = ['cids', 'start', 'end', 'title']
+        for rp_arg in rp_args:
+            bad_args = good_args.copy()
+            bad_args[rp_arg] = None
+            try:
+                view_metrics(**bad_args)
+            except Exception as e:
+                self.fail(f"view_metrics raised {e} unexpectedly")
+            
         
 
 if __name__ == "__main__":

--- a/tests/unit/panel/test_view_metrics.py
+++ b/tests/unit/panel/test_view_metrics.py
@@ -1,0 +1,18 @@
+import unittest
+import pandas as pd
+from typing import List, Tuple, Optional, Dict
+from tests.simulate import make_qdf
+from macrosynergy.management.shape_dfs import reduce_df
+from macrosynergy.panel import view_metrics
+import matplotlib
+
+class TestAll(unittest.TestCase):
+
+    def dataframe_construction(self):
+        self.cids: List[str] = ['AUD', 'CAD', 'GBP', 'NZD']
+        self.xcats: List[str] = ['XR', 'CRY', 'INFL']
+        self.metrics: List[str] = ['value', 'grading', 'eop_lag', 'mop_lag']
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/panel/test_view_metrics.py
+++ b/tests/unit/panel/test_view_metrics.py
@@ -2,17 +2,34 @@ import unittest
 import pandas as pd
 from typing import List, Tuple, Optional, Dict
 from tests.simulate import make_qdf
-from macrosynergy.management.shape_dfs import reduce_df
+from macrosynergy.management.simulate_quantamental_data import make_test_df
 from macrosynergy.panel import view_metrics
 import matplotlib
 
+
 class TestAll(unittest.TestCase):
-
     def dataframe_construction(self):
-        self.cids: List[str] = ['AUD', 'CAD', 'GBP', 'NZD']
-        self.xcats: List[str] = ['XR', 'CRY', 'INFL']
-        self.metrics: List[str] = ['value', 'grading', 'eop_lag', 'mop_lag']
+        self.cids: List[str] = ["AUD", "CAD", "GBP", "NZD"]
+        self.xcats: List[str] = ["XR", "CRY", "INFL"]
+        self.metrics: List[str] = ["value", "grading", "eop_lag", "mop_lag"]
+        idx_cols: List[str] = ["cid", "xcat", "real_date"]
+        self.start: str = "2010-01-01"
+        self.end: str = "2020-12-31"
+
+        df: pd.DataFrame = make_test_df(self.cids, self.xcats, self.start, self.end)
+        for mtr in self.metrics:
+            df: pd.DataFrame = df.merge(
+                make_test_df(self.cids, self.xcats, self.start, self.end).rename(
+                    columns={"value": mtr}
+                ),
+                on=idx_cols,
+            )
+
+        self.df: pd.DataFrame = df
+
+    def test_view_metrics(self):
+        pass
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #660 .

Slightly modified implementation of function described in #660, view_lags.
Implementation here is for generic non-value metric. 

Docstring:
```python
"""
A function to visualise the `eop_lag`, `mop_lag` or `grading` metrics for a given
JPMaQS dataset. It generates a heatmap, where the x-axis is the observation
date, the y-axis is the ticker, and the colour is the lag value.

:param <pd.Dataframe> df: standardized DataFrame with the necessary columns:
    'cid', 'xcat', 'real_date' and 'grading', 'eop_lag' or 'mop_lag'.
:param str xcat: extended category whose lags are to be visualized.
:param <List[str]> cids: cross sections to visualize. Default is all in DataFrame.
:param <str> start: earliest date in ISO format. Default is earliest available.
:param <str> end: latest date in ISO format. Default is latest available.
:param <str> metric: name of metric to be visualized. Must be "eop_lag" (default)
    "mop_lag" or "grading".
:param <str> freq: frequency of data. Must be one of "D", "W", "M", "Q", "A".
    Default is "M".
:param <str> agg: aggregation method. Must be one of "mean" (default), "median",
    "min", "max", "first" or "last".
:param <str> title: string of chart title; if none given default title is printed.
:param <Tuple[float]> figsize: Tuple (w, h) of width and height of graph.
    Default is None, meaning it is set in accordance with df.

:return: None

:raises TypeError: if any of the inputs are of the wrong type.
:raises ValueError: if any of the inputs are semantically incorrect.
"""
```