### PR TITLE
Bugfix : Changed default env. var names

### DIFF
--- a/macrosynergy/download/dataquery.py
+++ b/macrosynergy/download/dataquery.py
@@ -975,8 +975,8 @@ if __name__ == "__main__":
     import os
 
     cf: Config = Config(
-        client_id=os.environ["JPMAQS_API_CLIENT_ID"],
-        client_secret=os.environ["JPMAQS_API_CLIENT_SECRET"],
+        client_id=os.getenv("DQ_CLIENT_ID"),
+        client_secret=os.getenv("DQ_CLIENT_SECRET"),
     )
 
     expressions = [

--- a/macrosynergy/management/utils.py
+++ b/macrosynergy/management/utils.py
@@ -398,17 +398,17 @@ class Config(object):
             None or "env", the class will attempt to load the config
             file from the following environment variables:
             For OAuth authentication:
-                - JPMAQS_API_CLIENT_ID : your_client_id
-                - JPMAQS_API_CLIENT_SECRET : your_client_secret
+                - DQ_CLIENT_ID : your_client_id
+                - DQ_CLIENT_SECRET : your_client_secret
 
             For certificate authentication:
-                - JPMAQS_API_CRT : path_to_crt_file
-                - JPMAQS_API_KEY : path_to_key_file
-                - JPMAQS_API_USERNAME : your_username
-                - JPMAQS_API_PASSWORD : your_password
+                - DQ_CRT : path_to_crt_file
+                - DQ_KEY : path_to_key_file
+                - DQ_USERNAME : your_username
+                - DQ_PASSWORD : your_password
 
             For proxy settings:
-                - JPMAQS_API_PROXY : proxy_json_string
+                - DQ_PROXY : proxy_json_string
 
                 (See https://requests.readthedocs.io/en/master/user/advanced/#proxies)
         """
@@ -434,7 +434,7 @@ class Config(object):
         if isinstance(config_path, str):
             if config_path == "env":
                 for var in loaded_vars.keys():
-                    loaded_vars[var] = os.environ.get(f"JPMAQS_API_{var.upper()}", None)
+                    loaded_vars[var] = os.environ.get(f"DQ_{var.upper()}", None)
 
             else:
                 config_dict: Optional[dict] = None
@@ -619,7 +619,7 @@ class Config(object):
             )
 
         if export_file is None:
-            export_file = f"./jpmaqs_api_credentials_({datetime.datetime.now().strftime('%Y-%m-%d-%H-%M-%S')}).{format}"
+            export_file = f"./jpmaqs_credentials_({datetime.datetime.now().strftime('%Y-%m-%d-%H-%M-%S')}).{format}"
 
         output_dict: Dict[str, dict] = {}
         credentials: Dict[str, dict] = self.credentials(mask=mask)


### PR DESCRIPTION
Changed the default env vars, and prefered YAML args to look for DQ_* instead of JPMAQS_API* variables