### PR TITLE
Bugfix : `view_ranges`/`sns.barplot`, `ci` param deprecated

### DIFF
--- a/macrosynergy/panel/view_ranges.py
+++ b/macrosynergy/panel/view_ranges.py
@@ -98,7 +98,8 @@ def view_ranges(df: pd.DataFrame, xcats: List[str] = None,  cids: List[str] = No
 
     if kind == 'bar':
         ax = sns.barplot(
-            x='cid', y=val, hue='xcat', hue_order=xcats, palette='Paired', data=df, errrorbar='sd', order=order
+            x='cid', y=val, hue='xcat', hue_order=xcats,
+            palette='Paired', data=df, errorbar='sd', order=order
         )
     elif kind == 'box':
         ax = sns.boxplot(x='cid', y=val, hue='xcat', hue_order=xcats,

--- a/macrosynergy/panel/view_ranges.py
+++ b/macrosynergy/panel/view_ranges.py
@@ -97,8 +97,9 @@ def view_ranges(df: pd.DataFrame, xcats: List[str] = None,  cids: List[str] = No
     fig, ax = plt.subplots(figsize=size)
 
     if kind == 'bar':
-        ax = sns.barplot(x='cid', y=val, hue='xcat', hue_order=xcats,
-                         palette='Paired', data=df, ci='sd', order=order)
+        ax = sns.barplot(
+            x='cid', y=val, hue='xcat', hue_order=xcats, palette='Paired', data=df, errrorbar='sd', order=order
+        )
     elif kind == 'box':
         ax = sns.boxplot(x='cid', y=val, hue='xcat', hue_order=xcats,
                          palette='Paired', data=df,  order=order)


### PR DESCRIPTION
Seaborn deprecated the use of the `ci` parameter in favour of allowing a more generic `...errorbar=('<type>', threshold)` in [Seaborn v0.12.2](https://github.com/mwaskom/seaborn/releases/tag/v0.12.2) ([Seaborn/#2407](https://github.com/mwaskom/seaborn/pull/2407/)).
This has not yet effected the regplot, but will at some point in the future (see[ Seaborn/WhatsNew/0.12.0](https://seaborn.pydata.org/whatsnew/v0.12.0.html#more-flexible-errorbars)).

Thanks @mikiinterfiore for spotting this and the creating the PR.