### PR TITLE
Feature : Error info to include `client_id`/cert `username` as a generic `user_id`

### DIFF
--- a/macrosynergy/download/dataquery.py
+++ b/macrosynergy/download/dataquery.py
@@ -25,7 +25,7 @@ from macrosynergy.download.exceptions import (
     DownloadError,
     InvalidResponseError,
     HeartbeatError,
-    KNOWN_EXCEPTIONS
+    KNOWN_EXCEPTIONS,
 )
 from macrosynergy.management.utils import (
     is_valid_iso_date,
@@ -65,7 +65,10 @@ logger.addHandler(debug_stream_handler)
 egress_logger: dict = {}
 
 
-def validate_response(response: requests.Response) -> dict:
+def validate_response(
+    response: requests.Response,
+    user_id: str,
+) -> dict:
     """
     Validates a response from the API. Raises an exception if the response
     is invalid (e.g. if the response is not a 200 status code).
@@ -82,6 +85,7 @@ def validate_response(response: requests.Response) -> dict:
 
     error_str: str = (
         f"Response: {response}\n"
+        f"User ID: {user_id}\n"
         f"Requested URL: {response.request.url}\n"
         f"Response status code: {response.status_code}\n"
         f"Response headers: {response.headers}\n"
@@ -151,6 +155,8 @@ def request_wrapper(
     if method not in ["get", "post"]:
         raise ValueError(f"Invalid method: {method}")
 
+    user_id: str = kwargs.pop("user_id", "unknown")
+
     # insert tracking info in headers
     if headers is None:
         headers: Dict = {}
@@ -203,7 +209,7 @@ def request_wrapper(
             }
 
             if isinstance(response, requests.Response):
-                return validate_response(response)
+                return validate_response(response=response, user_id=user_id)
 
         except Exception as exc:
             # if keyboard interrupt, raise as usual
@@ -217,6 +223,7 @@ def request_wrapper(
 
             error_statement = (
                 f"Request to {log_url} failed with error {exc}. "
+                f"User ID: {user_id}. "
                 f"Retry count: {retry_count}. "
                 f"Tracking ID: {tracking_id}"
             )
@@ -225,7 +232,7 @@ def request_wrapper(
 
             known_exceptions = KNOWN_EXCEPTIONS + [HeartbeatError]
             # NOTE : HeartBeat is a special case
-                
+
             # NOTE: exceptions that need the code to break should be caught before this
             # all other exceptions are caught here and retried after a delay
 
@@ -367,6 +374,7 @@ class OAuth(object):
                 method="post",
                 proxy=self.proxy,
                 tracking_id=OAUTH_TRACKING_ID,
+                user_id=self.token_data["client_id"],
             )
             # on failure, exception will be raised by request_wrapper
 
@@ -381,7 +389,11 @@ class OAuth(object):
 
     def get_auth(self) -> Dict[str, Union[str, Optional[Tuple[str, str]]]]:
         headers = {"Authorization": "Bearer " + self._get_token()}
-        return {"headers": headers, "cert": None}
+        return {
+            "headers": headers,
+            "cert": None,
+            "user_id": self.token_data["client_id"],
+        }
 
 
 class CertAuth(object):
@@ -423,10 +435,16 @@ class CertAuth(object):
                 raise FileNotFoundError(f"The file '{varx}' does not exist.")
         self.key: str = key
         self.crt: str = crt
+        self.username: str = username
+        self.password: str = password
 
     def get_auth(self) -> Dict[str, Union[str, Optional[Tuple[str, str]]]]:
         headers = {"Authorization": f"Basic {self.auth:s}"}
-        return {"headers": headers, "cert": (self.crt, self.key)}
+        return {
+            "headers": headers,
+            "cert": (self.crt, self.key),
+            "user_id": self.username,
+        }
 
 
 def validate_download_args(
@@ -583,7 +601,7 @@ class DataQueryInterface(object):
                 " Check macrosynergy.management.utils.Config "
                 "for more details."
             )
-
+        self.config: Config = config
         self.auth: Optional[Union[CertAuth, OAuth]] = None
         if oauth:
             self.auth: OAuth = OAuth(**config.oauth(mask=False), token_url=token_url)
@@ -677,6 +695,7 @@ class DataQueryInterface(object):
         if (response is None) or ("instruments" not in response.keys()):
             raise InvalidResponseError(
                 f"Invalid response from DataQuery: {response}\n"
+                f"User ID: {self.auth.get_auth()['user_id']}\n"
                 f"URL: {form_full_url(url, params)}"
                 f"Timestamp (UTC): {datetime.utcnow().isoformat()}"
             )
@@ -918,7 +937,8 @@ class DataQueryInterface(object):
                 raise ConnectionError(
                     HeartbeatError(
                         f"Heartbeat failed. Timestamp (UTC):"
-                        f" {datetime.utcnow().isoformat()}"
+                        f" {datetime.utcnow().isoformat()}\n"
+                        f"User ID: {self.auth.get_auth()['user_id']}\n"
                     )
                 )
             time.sleep(delay_param)

--- a/macrosynergy/download/exceptions.py
+++ b/macrosynergy/download/exceptions.py
@@ -1,5 +1,6 @@
 import requests
 
+
 class ExceptionAdapter(Exception):
     """Base class for all exceptions raised by the macrosynergy package."""
 
@@ -36,15 +37,15 @@ class MissingDataError(ExceptionAdapter):
 
 
 KNOWN_EXCEPTIONS = [
-                requests.exceptions.ConnectionError,
-                requests.exceptions.ConnectTimeout,
-                requests.exceptions.ReadTimeout,
-                ConnectionResetError,
-                requests.exceptions.Timeout,
-                requests.exceptions.TooManyRedirects,
-                requests.exceptions.RequestException,
-                requests.exceptions.HTTPError,
-                requests.exceptions.InvalidURL,
-                requests.exceptions.InvalidSchema,
-                requests.exceptions.ChunkedEncodingError,
-                ]
+    requests.exceptions.ConnectionError,
+    requests.exceptions.ConnectTimeout,
+    requests.exceptions.ReadTimeout,
+    ConnectionResetError,
+    requests.exceptions.Timeout,
+    requests.exceptions.TooManyRedirects,
+    requests.exceptions.RequestException,
+    requests.exceptions.HTTPError,
+    requests.exceptions.InvalidURL,
+    requests.exceptions.InvalidSchema,
+    requests.exceptions.ChunkedEncodingError,
+]

--- a/tests/unit/download/test_dataquery.py
+++ b/tests/unit/download/test_dataquery.py
@@ -61,20 +61,25 @@ class TestRequestWrapper(unittest.TestCase):
         # mock a response with 401. assert raises authentication error
         user_id: str = f"User_{random_string()}"
         with self.assertRaises(AuthenticationError):
-            validate_response(self.mock_response(url=OAUTH_TOKEN_URL, status_code=401),
-                                user_id=user_id)
+            validate_response(
+                self.mock_response(url=OAUTH_TOKEN_URL, status_code=401),
+                user_id=user_id,
+            )
 
         # mock with a 403, and use url=oauth+heartbeat. assert raises heartbeat error
         with self.assertRaises(HeartbeatError):
             validate_response(
                 self.mock_response(
                     url=OAUTH_BASE_URL + HEARTBEAT_ENDPOINT, status_code=403
-                ), user_id=user_id
+                ),
+                user_id=user_id,
             )
 
         # mock with a 403, and use url=oauth_base_url. assert raises invalid response error
         with self.assertRaises(InvalidResponseError):
-            validate_response(self.mock_response(url=OAUTH_BASE_URL, status_code=403))
+            validate_response(
+                self.mock_response(url=OAUTH_BASE_URL, status_code=403), user_id=user_id
+            )
 
         # oauth_bas_url+timeseires and empty content, assert raises invalid response error
         with self.assertRaises(InvalidResponseError):
@@ -83,7 +88,8 @@ class TestRequestWrapper(unittest.TestCase):
                     url=OAUTH_BASE_URL + TIMESERIES_ENDPOINT,
                     status_code=200,
                     content=b"",
-                ), user_id=user_id
+                ),
+                user_id=user_id,
             )
 
         # with 200 , and empty content, assert raises invalid response error
@@ -98,12 +104,13 @@ class TestRequestWrapper(unittest.TestCase):
             validate_response(
                 self.mock_response(
                     url=OAUTH_TOKEN_URL, status_code=200, content=b"not json"
-                ), user_id=user_id
+                ),
+                user_id=user_id,
             )
 
     def test_request_wrapper(self):
         user_id: str = f"User_{random_string()}"
-        
+
         with self.assertRaises(ValueError):
             request_wrapper(method="pop", url=OAUTH_TOKEN_URL, user_id=user_id)
 

--- a/tests/unit/download/test_dataquery.py
+++ b/tests/unit/download/test_dataquery.py
@@ -59,15 +59,17 @@ class TestRequestWrapper(unittest.TestCase):
 
     def test_validate_response(self):
         # mock a response with 401. assert raises authentication error
+        user_id: str = f"User_{random_string()}"
         with self.assertRaises(AuthenticationError):
-            validate_response(self.mock_response(url=OAUTH_TOKEN_URL, status_code=401))
+            validate_response(self.mock_response(url=OAUTH_TOKEN_URL, status_code=401),
+                                user_id=user_id)
 
         # mock with a 403, and use url=oauth+heartbeat. assert raises heartbeat error
         with self.assertRaises(HeartbeatError):
             validate_response(
                 self.mock_response(
                     url=OAUTH_BASE_URL + HEARTBEAT_ENDPOINT, status_code=403
-                )
+                ), user_id=user_id
             )
 
         # mock with a 403, and use url=oauth_base_url. assert raises invalid response error
@@ -81,13 +83,14 @@ class TestRequestWrapper(unittest.TestCase):
                     url=OAUTH_BASE_URL + TIMESERIES_ENDPOINT,
                     status_code=200,
                     content=b"",
-                )
+                ), user_id=user_id
             )
 
         # with 200 , and empty content, assert raises invalid response error
         with self.assertRaises(InvalidResponseError):
             validate_response(
-                self.mock_response(url=OAUTH_TOKEN_URL, status_code=200, content=b"")
+                self.mock_response(url=OAUTH_TOKEN_URL, status_code=200, content=b""),
+                user_id=user_id,
             )
 
         # with non-json content, assert raises invalid response error
@@ -95,12 +98,14 @@ class TestRequestWrapper(unittest.TestCase):
             validate_response(
                 self.mock_response(
                     url=OAUTH_TOKEN_URL, status_code=200, content=b"not json"
-                )
+                ), user_id=user_id
             )
 
     def test_request_wrapper(self):
+        user_id: str = f"User_{random_string()}"
+        
         with self.assertRaises(ValueError):
-            request_wrapper(method="pop", url=OAUTH_TOKEN_URL)
+            request_wrapper(method="pop", url=OAUTH_TOKEN_URL, user_id=user_id)
 
         def mock_auth_error(*args, **kwargs) -> requests.Response:
             return self.mock_response(url=OAUTH_TOKEN_URL, status_code=401)
@@ -110,6 +115,7 @@ class TestRequestWrapper(unittest.TestCase):
                 request_wrapper(
                     method="get",
                     url=OAUTH_TOKEN_URL,
+                    user_id=user_id,
                 )
 
         def mock_heartbeat_error(*args, **kwargs) -> requests.Response:


### PR DESCRIPTION
DataQuery confirmed that client_id or the username for a certificate need not be treated as secret, and can be printed to the console for debug/error info. These changes allow that.