### PR TITLE
Feature: Adding slippage functionality to SignalReturnRelations

### DIFF
--- a/macrosynergy/signal/signal_return.py
+++ b/macrosynergy/signal/signal_return.py
@@ -51,19 +51,29 @@ class SignalReturnRelations:
     :param <int> fwin: forward window of return category in base periods. Default is 1.
         This conceptually corresponds to the holding period of a position in
         accordance with the signal.
+    :param <int> slip: implied slippage of feature availability for relationship with
+        the target category. This mimics the relationship between trading signals and
+        returns, which is often characterized by a delay due to the setup of of positions.
+        Technically, this is a negative lag (early arrival) of the target category
+        in working days prior to any frequency conversion. Default is 0.
+  
     """
     def __init__(self, df: pd.DataFrame, ret: str, sig: str,
                  rival_sigs: Union[str, List[str]] = None, cids: List[str] = None,
                  sig_neg: bool = False, cosp: bool = False, start: str = None,
-                 end: str = None, fwin: int = 1, blacklist: dict = None,
-                 agg_sig: str = 'last', freq: str = 'M'):
+                 end: str = None, blacklist: dict = None, freq: str = 'M',
+                  agg_sig: str = 'last', fwin: int = 1, slip: int = 0):
 
+        if not isinstance(df, pd.DataFrame):
+            raise TypeError(f"DataFrame expected and not {type(df)}.")
+        
         df["real_date"] = pd.to_datetime(df["real_date"], format="%Y-%m-%d")
 
         self.dic_freq = {'D': 'daily', 'W': 'weekly', 'M': 'monthly',
                          'Q': 'quarterly', 'A': 'annual'}
         freq_error = f"Frequency parameter must be one of {list(self.dic_freq.keys())}."
-        assert freq in self.dic_freq.keys(), freq_error
+        if not freq in self.dic_freq.keys():
+            raise ValueError(freq_error)
 
         self.metrics = ['accuracy', 'bal_accuracy', 'pos_sigr', "pos_retr",
                         'pos_prec', 'neg_prec', 'pearson', 'pearson_pval',
@@ -105,6 +115,12 @@ class SignalReturnRelations:
 
         dfd = reduce_df(
             df, xcats=xcats, cids=cids, start=start, end=end, blacklist=blacklist
+        )
+        
+        dfd = self.apply_slip(
+            df=dfd, slip=slip,
+            cids=cids, xcats=xcats,
+            metrics=self.metrics
         )
 
         # Naturally, only applicable if rival signals have been passed.
@@ -154,6 +170,44 @@ class SignalReturnRelations:
             df_cs = df
 
         return df_cs
+    
+    @classmethod
+    def apply_slip(self, target_df: pd.DataFrame, slip: int,
+                    cids: List[str], xcats: List[str],
+                    metrics: List[str]) -> pd.DataFrame:
+        """
+        Applied a slip, i.e. a negative lag, to the target DataFrame 
+        for the given cross-sections and categories, on the given metrics.
+        
+        Parameters
+        ----------
+        :param <pd.DataFrame> target_df: DataFrame to which the slip is applied.
+        :param <int> slip: Slip to be applied.
+        :param <List[str]> cids: List of cross-sections.
+        :param <List[str]> xcats: List of categories.
+        :param <List[str]> metrics: List of metrics to which the slip is applied.
+        :return <pd.DataFrame> target_df: DataFrame with the slip applied.
+        :raises <TypeError>: If the provided parameters are not of the expected type.
+        :raises <ValueError>: If the provided parameters are semantically incorrect.
+        """
+
+        target_df = target_df.copy(deep=True)
+        if not (isinstance(slip, int) and slip >= 0):
+            raise ValueError("Slip must be a non-negative integer.")
+
+        sel_tickers : List[str] = [f"{cid}_{xcat}" for cid in cids for xcat in xcats]
+        target_df['tickers'] = target_df['cid'] + '_' + target_df['xcat']
+
+        if not set(sel_tickers).issubset(set(target_df['tickers'].unique())):
+            raise ValueError("Tickers targetted for applying slip are not present in the DataFrame.\n"
+             f"Missing tickers: {set(sel_tickers) - set(target_df['tickers'].unique())}")
+
+        slip : int = slip.__neg__()
+        
+        target_df[metrics] = target_df.groupby('tickers')[metrics].shift(slip)
+        target_df = target_df.drop(columns=['tickers'])
+        
+        return target_df
 
     def __table_stats__(self, df_segment: pd.DataFrame, df_out: pd.DataFrame,
                         segment: str, signal: str):

--- a/macrosynergy/signal/signal_return.py
+++ b/macrosynergy/signal/signal_return.py
@@ -117,10 +117,13 @@ class SignalReturnRelations:
             df, xcats=xcats, cids=cids, start=start, end=end, blacklist=blacklist
         )
         
+        # Since there may be any metrics in the DF at this point, simply apply slip to all.
+        metric_cols: List[str] = list(set(dfd.columns.tolist()) 
+                                  - set(['real_date', 'xcat', 'cid']))
         dfd = self.apply_slip(
-            df=dfd, slip=slip,
+            target_df=dfd, slip=slip,
             cids=cids, xcats=xcats,
-            metrics=self.metrics
+            metrics=metric_cols
         )
 
         # Naturally, only applicable if rival signals have been passed.
@@ -194,6 +197,11 @@ class SignalReturnRelations:
         target_df = target_df.copy(deep=True)
         if not (isinstance(slip, int) and slip >= 0):
             raise ValueError("Slip must be a non-negative integer.")
+        
+        if cids is None:
+            cids = target_df['cid'].unique().tolist()
+        if xcats is None:
+            xcats = target_df['xcat'].unique().tolist()
 
         sel_tickers : List[str] = [f"{cid}_{xcat}" for cid in cids for xcat in xcats]
         target_df['tickers'] = target_df['cid'] + '_' + target_df['xcat']

--- a/macrosynergy/signal/signal_return.py
+++ b/macrosynergy/signal/signal_return.py
@@ -120,7 +120,7 @@ class SignalReturnRelations:
         # Since there may be any metrics in the DF at this point, simply apply slip to all.
         metric_cols: List[str] = list(set(dfd.columns.tolist()) 
                                   - set(['real_date', 'xcat', 'cid']))
-        dfd = self.apply_slip(
+        dfd: pd.DataFrame = self.apply_slip(
             target_df=dfd, slip=slip,
             cids=cids, xcats=xcats,
             metrics=metric_cols

--- a/tests/unit/signal/test_signal_return.py
+++ b/tests/unit/signal/test_signal_return.py
@@ -81,19 +81,19 @@ class TestAll(unittest.TestCase):
         arbitrary_date_one = '2011-01-10'
         arbitrary_date_two = '2020-10-27'
 
-        test_aud = df_signal[df_signal['real_date'] == arbitrary_date_one]
+        test_aud: pd.Series = df_signal[df_signal['real_date'] == arbitrary_date_one]
         test_aud = test_aud[test_aud['cid'] == 'AUD']['value']
 
-        test_usd = df_signal[df_signal['real_date'] == arbitrary_date_two]
+        test_usd: pd.Series = df_signal[df_signal['real_date'] == arbitrary_date_two]
         test_usd = test_usd[test_usd['cid'] == 'USD']['value']
 
         lagged_df = srr.df
         aud_lagged = lagged_df.loc['AUD', signal]['2011-01-11']
-        condition = round(float(test_aud), 5) - round(aud_lagged, 5)
+        condition = round(test_aud.values[0], 5) - round(aud_lagged, 5)
         self.assertTrue(abs(condition) < 0.0001)
 
         usd_lagged = lagged_df.loc['USD', signal]['2020-10-28']
-        condition = round(float(test_usd), 5) - round(usd_lagged, 5)
+        condition = round(test_usd.values[0], 5) - round(usd_lagged, 5)
         self.assertTrue(condition < 0.0001)
 
         # In addition to the DataFrame returned by categories_df(), an instance of the

--- a/tests/unit/signal/test_signal_return.py
+++ b/tests/unit/signal/test_signal_return.py
@@ -9,6 +9,7 @@ from scipy import stats
 import random
 import pandas as pd
 import numpy as np
+from typing import List, Dict
 
 
 class TestAll(unittest.TestCase):
@@ -18,8 +19,8 @@ class TestAll(unittest.TestCase):
         Create a standardised DataFrame defined over the three categories.
         """
 
-        self.__dict__['cids'] = ['AUD', 'CAD', 'GBP', 'NZD', 'USD']
-        self.__dict__['xcats'] = ['XR', 'CRY', 'GROWTH', 'INFL']
+        self.cids: List[str] = ['AUD', 'CAD', 'GBP', 'NZD', 'USD']
+        self.xcats: List[str] = ['XR', 'CRY', 'GROWTH', 'INFL']
 
         df_cids = pd.DataFrame(index=self.cids, columns=['earliest', 'latest',
                                                          'mean_add', 'sd_mult'])
@@ -44,12 +45,12 @@ class TestAll(unittest.TestCase):
         random.seed(2)
         dfd = make_qdf(df_cids, df_xcats, back_ar=0.75)
 
-        self.__dict__['dfd'] = dfd
+        self.dfd: pd.DataFrame = dfd
 
         black = {'AUD': ['2000-01-01', '2003-12-31'],
                  'GBP': ['2018-01-01', '2100-01-01']}
 
-        self.__dict__['blacklist'] = black
+        self.blacklist: Dict[str, List[str]] = black 
 
         assert 'dfd' in vars(self).keys(), "Instantiation of DataFrame missing from " \
                                            "field dictionary."
@@ -68,7 +69,7 @@ class TestAll(unittest.TestCase):
                                         freq='D', blacklist=self.blacklist)
 
         signal = 'CRY'
-        srr = SignalReturnRelations(self.dfd, ret='XR', sig=signal,
+        srr: SignalReturnRelations = SignalReturnRelations(self.dfd, ret='XR', sig=signal,
                                     freq='D', blacklist=self.blacklist)
 
         # The signal will invariably be used as the explanatory variable and the return
@@ -87,19 +88,19 @@ class TestAll(unittest.TestCase):
         test_usd: pd.Series = df_signal[df_signal['real_date'] == arbitrary_date_two]
         test_usd = test_usd[test_usd['cid'] == 'USD']['value']
 
-        lagged_df = srr.df
-        aud_lagged = lagged_df.loc['AUD', signal]['2011-01-11']
-        condition = round(test_aud.values[0], 5) - round(aud_lagged, 5)
+        lagged_df: pd.DataFrame = srr.df
+        aud_lagged: float = lagged_df.loc['AUD', signal]['2011-01-11']
+        condition: float = round(test_aud.values[0], 5) - round(aud_lagged, 5)
         self.assertTrue(abs(condition) < 0.0001)
 
-        usd_lagged = lagged_df.loc['USD', signal]['2020-10-28']
-        condition = round(test_usd.values[0], 5) - round(usd_lagged, 5)
+        usd_lagged: float = lagged_df.loc['USD', signal]['2020-10-28']
+        condition: float = round(test_usd.values[0], 5) - round(usd_lagged, 5)
         self.assertTrue(condition < 0.0001)
 
         # In addition to the DataFrame returned by categories_df(), an instance of the
         # Class will hold two "tables" for each segmentation type.
         # Confirm the indices are the expected: cross-sections or years.
-        test_index = list(srr.df_cs.index)[3:]
+        test_index: List[str] = list(srr.df_cs.index)[3:]
         self.assertTrue(sorted(self.cids) == sorted(test_index))
 
     def test_constructor_multiple_sigs(self):


### PR DESCRIPTION
Adding a method `apply_slip()` to `SignalReturnRelations`.
The function is a replica of [`CategoryRelation.apply_slip()`](https://github.com/macrosynergy/macrosynergy/blob/d129d0ed1a0750c2a12d87c1b9a68f03f70ffc5e/macrosynergy/panel/category_relations.py#L157).

Closes https://github.com/macrosynergy/macrosynergy/issues/802

Once the functionality is verified independently for both these functions, they'll be merged to a common utility/DF tool.