### PR TITLE
Feature : Added alternate `group-id` for DQ Catalogue

### DIFF
--- a/macrosynergy/download/dataquery.py
+++ b/macrosynergy/download/dataquery.py
@@ -731,11 +731,22 @@ class DataQueryInterface(object):
 
         :raises <ValueError>: if the response from the server is not valid.
         """
-        response_list: Dict = self._fetch(
-            url=self.base_url + CATALOGUE_ENDPOINT,
-            params={"group-id": group_id},
-            tracking_id=CATALOGUE_TRACKING_ID,
-        )
+        new_group_id: str = 'JPMAQS'
+        try:
+            response_list: Dict = self._fetch(
+                url=self.base_url + CATALOGUE_ENDPOINT,
+                params={"group-id": group_id},
+                tracking_id=CATALOGUE_TRACKING_ID,
+            )
+        except InvalidResponseError as e:
+            response_list: Dict = self._fetch(
+                url=self.base_url + CATALOGUE_ENDPOINT,
+                params={"group-id": new_group_id},
+                tracking_id=CATALOGUE_TRACKING_ID,
+            )
+        except Exception as e:
+            raise e
+            
 
         tickers: List[str] = [d["instrument-name"] for d in response_list]
         utkr_count: int = len(tickers)

--- a/macrosynergy/download/exceptions.py
+++ b/macrosynergy/download/exceptions.py
@@ -34,6 +34,9 @@ class InvalidDataframeError(ExceptionAdapter):
 
 class MissingDataError(ExceptionAdapter):
     """Raised when data is missing from a requested dataframe."""
+    
+class NoContentError(ExceptionAdapter):
+    """Raised when no data is returned from a request."""
 
 
 KNOWN_EXCEPTIONS = [

--- a/tests/unit/download/test_dataquery.py
+++ b/tests/unit/download/test_dataquery.py
@@ -11,7 +11,6 @@ import requests
 
 from macrosynergy.download import dataquery, JPMaQSDownload
 from macrosynergy.download.dataquery import (
-    JPMAQS_GROUP_ID,
     DataQueryInterface,
     OAuth,
     CertAuth,
@@ -26,6 +25,8 @@ from macrosynergy.download.dataquery import (
     TIMESERIES_ENDPOINT,
     API_DELAY_PARAM,
     CERT_BASE_URL,
+    CATALOGUE_ENDPOINT,
+    JPMAQS_GROUP_ID,
 )
 from macrosynergy.download.exceptions import (
     AuthenticationError,
@@ -33,6 +34,7 @@ from macrosynergy.download.exceptions import (
     InvalidResponseError,
     DownloadError,
     InvalidDataframeError,
+    NoContentError
 )
 from macrosynergy.management.utils import Config
 
@@ -589,6 +591,17 @@ class TestDataQueryInterface(unittest.TestCase):
                         url=OAUTH_BASE_URL + TIMESERIES_ENDPOINT,
                         params={"expr": "expression1"},
                     )
+                    
+        invl_response: Dict[str, Any] = {'info':{'code': '204', 'message': 'No Content'}}
+        with mock.patch(
+            "macrosynergy.download.dataquery.request_wrapper",
+            return_value=invl_response,
+        ):
+            with self.assertRaises(NoContentError):
+                dq._fetch(
+                    url=OAUTH_BASE_URL + CATALOGUE_ENDPOINT,
+                    params={"group": "group-name"},
+                )
 
     def test_download(self):
         good_args: Dict[str, Any] = {


### PR DESCRIPTION
DQ will be changing the group-id associated with the JPMaQS dataset. This is a change to retry with the new group-id if the old one fails. Later, when the change is confirmed, the "new" group-id will be tried before the old one. Of course, ultimately, the old one will be removed