### PR TITLE
Bugfix : Proxy not being handled correctly for API/Oauth Flow

### DIFF
--- a/macrosynergy/download/dataquery.py
+++ b/macrosynergy/download/dataquery.py
@@ -422,6 +422,7 @@ class CertAuth(object):
         password: str,
         crt: str,
         key: str,
+        proxy: Optional[dict] = None,
     ):
         for varx, namex in zip([username, password], ["username", "password"]):
             if not isinstance(varx, str):
@@ -441,6 +442,7 @@ class CertAuth(object):
         self.crt: str = crt
         self.username: str = username
         self.password: str = password
+        self.proxy: Optional[dict] = proxy
 
     def get_auth(self) -> Dict[str, Union[str, Optional[Tuple[str, str]]]]:
         headers = {"Authorization": f"Basic {self.auth:s}"}
@@ -609,7 +611,11 @@ class DataQueryInterface(object):
         self.config: Config = config
         self.auth: Optional[Union[CertAuth, OAuth]] = None
         if oauth:
-            self.auth: OAuth = OAuth(**config.oauth(mask=False), token_url=token_url)
+            self.auth: OAuth = OAuth(
+                **config.oauth(mask=False),
+                token_url=token_url,
+                proxy=config.proxy(mask=False),
+            )
         else:
             if base_url == OAUTH_BASE_URL:
                 base_url: str = CERT_BASE_URL

--- a/macrosynergy/download/dataquery.py
+++ b/macrosynergy/download/dataquery.py
@@ -375,7 +375,7 @@ class OAuth(object):
                 method="post",
                 proxy=self.proxy,
                 tracking_id=OAUTH_TRACKING_ID,
-                user_id=self.token_data["client_id"],
+                user_id=self._get_user_id(),
             )
             # on failure, exception will be raised by request_wrapper
 
@@ -387,14 +387,16 @@ class OAuth(object):
             }
 
         return self._stored_token["access_token"]
+    
+    def _get_user_id(self) -> str:
+        return "OAuth_ClientID - " + self.token_data["client_id"]
 
     def get_auth(self) -> Dict[str, Union[str, Optional[Tuple[str, str]]]]:
-        headers = {"Authorization": "Bearer " + self._get_token()}
-        user_id = "OAuth_ClientID : " + self.token_data["client_id"]
+        headers: Dict = {"Authorization": "Bearer " + self._get_token()}
         return {
             "headers": headers,
             "cert": None,
-            "user_id": user_id,
+            "user_id": self._get_user_id(),
         }
 
 
@@ -442,7 +444,7 @@ class CertAuth(object):
 
     def get_auth(self) -> Dict[str, Union[str, Optional[Tuple[str, str]]]]:
         headers = {"Authorization": f"Basic {self.auth:s}"}
-        user_id = "CertAuth_Username : " + self.username
+        user_id = "CertAuth_Username - " + self.username
         return {
             "headers": headers,
             "cert": (self.crt, self.key),

--- a/macrosynergy/download/exceptions.py
+++ b/macrosynergy/download/exceptions.py
@@ -34,7 +34,8 @@ class InvalidDataframeError(ExceptionAdapter):
 
 class MissingDataError(ExceptionAdapter):
     """Raised when data is missing from a requested dataframe."""
-    
+
+
 class NoContentError(ExceptionAdapter):
     """Raised when no data is returned from a request."""
 


### PR DESCRIPTION
`dataquery.OAuth` was trying to fetch the OAuth token with `self.proxy`. This was being confused with `dataquery.DataQueryInterface.proxy`. 
Another small change has been made to the printing and generating method of the User ID