### PR TITLE
Feature : Changing Unit Testing strategy for CI/CD branches

### DIFF
--- a/.github/workflows/python-package-release.yml
+++ b/.github/workflows/python-package-release.yml
@@ -1,0 +1,44 @@
+# This is a workflow in for running the package tests for the macrosynergy package when doing a release to PyPI.
+# It runs on Ubuntu, Windows and MacOS, for Python 3.8, 3.9, 3.10 and 3.11.
+
+name: Test Python package on Ubuntu
+
+on:
+  pull_request:
+    branches: [ main ] 
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ['3.8', '3.9', '3.10', '3.11']
+    runs-on: ${{ matrix.os }}
+    
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 pytest sphinx pytest-cov
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        # Options: --ignore=tests/specific.py --ignore-glob=tests/ignore-pattern
+        pytest -rEf tests/unit/ --cov macrosynergy -p no:warnings --verbose
+
+    - name: Test build settings
+      run: |
+        pip install .[all] 
+        python -c "import macrosynergy; print(macrosynergy.__version__)"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,29 +1,23 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+# This test is for develop←branch , and test←develop or test←branch pull requests.
+# It runs on Ubuntu, and tests Python 3.11. For testing for production, see /.github/workflows/python-package-release.yml
 
 name: Test Python package on Ubuntu
 
 on:
-  push:
-    branches: [ main, dev, test, prod, develop, release ]
   pull_request:
-    branches: [ main, dev, test, prod, develop, release ]
+    branches: [ test, develop ]
   workflow_dispatch:
 
 jobs:
   build:
 
-    runs-on: ubuntu-latest  # Alternative: windows-latest
-    strategy:
-      matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
-
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: 3.11
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
Unittests for PRs to Develop and Test will now run on os=ubuntu-latest and python=3.11 only.

PRs to Main will run on os=[Windows, MacOS, Ubuntu] and python=[3.8, 3.9, 3.10, 3.11]