### PR TITLE
Test←Develop for v0.0.32

### DIFF
--- a/.github/workflows/python-package-release.yml
+++ b/.github/workflows/python-package-release.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11']
     runs-on: ${{ matrix.os }}
     

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ Development Status :: 4 - Beta
 MAJOR = 0
 MINOR = 0
 MICRO = 32
-ISRELEASED = False
+ISRELEASED = True
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
 if sys.version_info >= (3, 12):


### PR DESCRIPTION
Earlier PR had GH workflow tests running on Windows & MacOS. These tests are not identical to Ubuntu, and need to be run differently