### PR TITLE
Feature : Check availability to use last business day as benchmark

### DIFF
--- a/macrosynergy/management/check_availability.py
+++ b/macrosynergy/management/check_availability.py
@@ -170,10 +170,10 @@ def check_availability(df: pd.DataFrame, xcats: List[str] = None,
     dfx = reduce_df(df, xcats=xcats, cids=cids, start=start)
     if start_years:
         dfs = check_startyears(dfx)
-        visual_paneldates(dfs, size=start_size)
+        visual_paneldates(dfs, size=start_size, use_last_businessday=use_last_businessday)
     if missing_recent:
         dfe = check_enddates(dfx)
-        visual_paneldates(dfe, size=end_size)
+        visual_paneldates(dfe, size=end_size, use_last_businessday=use_last_businessday)
 
 
 if __name__ == "__main__":

--- a/macrosynergy/management/check_availability.py
+++ b/macrosynergy/management/check_availability.py
@@ -47,7 +47,7 @@ def check_startyears(df: pd.DataFrame):
     return df_starts.unstack().loc[:, 'real_date'].astype(int, errors='ignore')
 
 
-def check_enddates(df: pd.DataFrame):
+def check_enddates(df: pd.DataFrame) -> pd.DataFrame:
     """
     DataFrame with end dates across all extended categories and cross sections.
 
@@ -84,12 +84,16 @@ def business_day_dif(df: pd.DataFrame, maxdate: pd.Timestamp):
     df = (maxdate - df).apply(lambda x: x.dt.days)
     return df - week_df
 
-def visual_paneldates(df: pd.DataFrame, size: Tuple[float] = None):
+def visual_paneldates(df: pd.DataFrame, size: Tuple[float] = None,
+                      use_last_businessday: bool = True
+                      ):
     """
     Visualize panel dates with color codes.
 
     :param <pd.DataFrame> df: DataFrame cross sections rows and category columns.
     :param <Tuple[float]> size: tuple of floats with width/length of displayed heatmap.
+    :param <bool> use_last_businessday: boolean indicating whether or not to use the
+        last business day before today as the end date. Default is True.
 
     """
 
@@ -99,7 +103,12 @@ def visual_paneldates(df: pd.DataFrame, size: Tuple[float] = None):
         df = df.apply(pd.to_datetime)
         # All series, in principle, should be populated to the last active release date
         # in the DataFrame.
-        maxdate = df.max().max()
+        
+        if use_last_businessday:
+            maxdate: pd.Timestamp = pd.Timestamp.today() - pd.tseries.offsets.BusinessDay()
+        else:
+            maxdate: pd.Timestamp = df.max().max()
+        
         df = business_day_dif(df=df, maxdate=maxdate)
 
         df = df.astype(float)
@@ -127,7 +136,9 @@ def visual_paneldates(df: pd.DataFrame, size: Tuple[float] = None):
 def check_availability(df: pd.DataFrame, xcats: List[str] = None,
                        cids: List[str] = None, start: str = None,
                        start_size: Tuple[float] = None, end_size: Tuple[float] = None,
-                       start_years: bool = True, missing_recent: bool = True):
+                       start_years: bool = True, missing_recent: bool = True,
+                       use_last_businessday: bool = True
+                       ):
     """
     Wrapper for visualizing start and end dates of a filtered DataFrame.
 
@@ -148,6 +159,8 @@ def check_availability(df: pd.DataFrame, xcats: List[str] = None,
     :param <bool> missing_recent: boolean indicating whether or not to display a chart 
         of missing date numbers for each cross-section and indicator.
         Default is True (display missing days).
+    :param <bool> use_last_businessday: boolean indicating whether or not to use the
+        last business day before today as the end date. Default is True.
     """
     if not isinstance(start_years, bool):
         raise TypeError(f"<bool> object expected and not {type(start_years)}.")

--- a/macrosynergy/management/check_availability.py
+++ b/macrosynergy/management/check_availability.py
@@ -21,14 +21,14 @@ def missing_in_df(df: pd.DataFrame, xcats: List[str] = None, cids: List[str] = N
         the DataFrame.
 
     """
-    print("Missing xcats across df: ", set(xcats) - set(df['xcat'].unique()))
+    print("Missing xcats across df: ", list(set(xcats) - set(df['xcat'])))
 
     cids = df["cid"].unique() if cids is None else cids
-    xcats_used = sorted(list(set(xcats).intersection(set(df["xcat"].unique()))))
+    xcats_used = sorted(list(set(xcats).intersection(set(df["xcat"]))))
 
     for xcat in xcats_used:
         cids_xcat = df.loc[df["xcat"] == xcat, "cid"].unique()
-        print(f"Missing cids for {xcat}: ", set(cids) - set(cids_xcat))
+        print(f"Missing cids for {xcat}: ", list(set(cids) - set(cids_xcat)))
 
 
 def check_startyears(df: pd.DataFrame):

--- a/tests/unit/management/test_check_availability.py
+++ b/tests/unit/management/test_check_availability.py
@@ -8,8 +8,8 @@ class TestAll(unittest.TestCase):
 
     def dataframe_constructor(self):
 
-        self.__dict__["cids"] = ["AUD", "CAD", "GBP"]
-        self.__dict__["xcats"] = ["CRY", "XR", "GROWTH", "INFL", "GDP"]
+        self.cids: List[str] = ["AUD", "CAD", "GBP"]
+        self.xcats: List[str] = ["CRY", "XR", "GROWTH", "INFL", "GDP"]
 
         df_cids = pd.DataFrame(index=self.cids,
                                columns=["earliest", "latest", "mean_add", "sd_mult"])
@@ -30,7 +30,7 @@ class TestAll(unittest.TestCase):
 
         np.random.seed(0)
 
-        self.__dict__["dfd"] = make_qdf(df_cids, df_xcats, back_ar=0.75)
+        self.dfd: pd.DataFrame = make_qdf(df_cids, df_xcats, back_ar=0.75)
 
     def test_check_startyears(self):
 
@@ -85,10 +85,10 @@ class TestAll(unittest.TestCase):
     def test_business_day_dif(self):
 
         self.dataframe_constructor()
-        dfd = self.dfd
+        dfd: pd.DataFrame = self.dfd
 
-        dfe = check_enddates(dfd)
-        dfe = dfe.apply(pd.to_datetime)
+        dfe: pd.DataFrame = check_enddates(dfd)
+        dfe: pd.DataFrame = dfe.apply(pd.to_datetime)
 
         maxdate = dfe.max().max()
         bus_df = business_day_dif(df=dfe, maxdate=maxdate)


### PR DESCRIPTION
**Modifies default behaviour**
Currently, the last date used to check availability is the last date for which data is available in the passed dataframe.
This PR changes this functionality to use the last-business-day before today as the default "last day"

Closes #865 