### PR TITLE
Feature: Changing Integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -40,3 +40,7 @@ jobs:
         pytest tests/integration/
         # echo "Integration test temporarily disabled."
         echo 'Integration test complete'
+    - name: Test build settings
+      run: |
+        pip install .[all] 
+        python -c "import macrosynergy; print(macrosynergy.__version__)"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -33,8 +33,3 @@ jobs:
       run: |
         # Options: --ignore=tests/specific.py --ignore-glob=tests/ignore-pattern
         pytest -rEf tests/unit/ --cov macrosynergy -p no:warnings --verbose
-
-    - name: Test build settings
-      run: |
-        pip install .[all] 
-        python -c "import macrosynergy; print(macrosynergy.__version__)"


### PR DESCRIPTION
Currently, the package tests (unittests) had a test for build settings, i.e. pyproject.toml, setup.py, requirements.txt. This is now being swapped out to be part of the integration tests. The package tests for Main←Test still tests the build settings, as it tests across multiple python versions (and soon OSs)