### PR TITLE
Bugfix: Fixing `test_relative_value`

### DIFF
--- a/tests/unit/panel/test_relative_value.py
+++ b/tests/unit/panel/test_relative_value.py
@@ -2,6 +2,10 @@ import unittest
 import numpy as np
 import pandas as pd
 from typing import List, Dict, Tuple, Union, Set
+
+import sys, os
+sys.path.append(os.path.abspath('.'))
+
 from tests.simulate import make_qdf
 from macrosynergy.panel.make_relative_value import make_relative_value, _prepare_basket
 from macrosynergy.management.shape_dfs import reduce_df
@@ -407,7 +411,7 @@ class TestAll(unittest.TestCase):
         function_output: np.ndarray = (dfd_3_pivot.iloc[index_val, :]).to_numpy()
 
         function_output: np.ndarray = function_output[0]
-        self.assertTrue(np.all(computed_values == function_output))
+        self.assertTrue(np.allclose(computed_values, function_output))
 
         # Test the division.
         # Computing make_relative_value() on a single category that has been chosen

--- a/tests/unit/panel/test_relative_value.py
+++ b/tests/unit/panel/test_relative_value.py
@@ -3,9 +3,6 @@ import numpy as np
 import pandas as pd
 from typing import List, Dict, Tuple, Union, Set
 
-import sys, os
-sys.path.append(os.path.abspath('.'))
-
 from tests.simulate import make_qdf
 from macrosynergy.panel.make_relative_value import make_relative_value, _prepare_basket
 from macrosynergy.management.shape_dfs import reduce_df


### PR DESCRIPTION
This makes a very small change -

Instead of checking :

`np.all(arrayX == arrayY)`


it checks 

`np.allclose(arrayX, arrayY)`



The key difference is that the latter introduce an absolute and relative tolerance.
For most cases this should work exactly the same, except when looking at very minute changes (default `r_tol = 1e-05`, `a_tol = 1e-08`)