### PR TITLE
Refactor: Removing Python legacy configuration files

### DIFF
--- a/.github/workflows/python-package-release.yml
+++ b/.github/workflows/python-package-release.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Test with pytest
       run: |
         # Options: --ignore=tests/specific.py --ignore-glob=tests/ignore-pattern
-        pytest -rEf tests/unit/ --cov macrosynergy -p no:warnings --verbose
+        pytest tests/unit/
 
     - name: Test build settings
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -32,4 +32,4 @@ jobs:
     - name: Test with pytest
       run: |
         # Options: --ignore=tests/specific.py --ignore-glob=tests/ignore-pattern
-        pytest -rEf tests/unit/ --cov macrosynergy -p no:warnings --verbose
+        pytest ./tests/unit/

--- a/.github/workflows/python-publish-docs.yml
+++ b/.github/workflows/python-publish-docs.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Test with pytest
       run: |
         # Options: --ignore=tests/specific.py --ignore-glob=tests/ignore-pattern
-        pytest -rEf tests/unit/ --cov macrosynergy -p no:warnings --verbose --cov macrosynergy
+        pytest tests/unit/
     - name: Upload coverage reports to Codecov
       run: |
         curl -Os https://uploader.codecov.io/latest/linux/codecov

--- a/.github/workflows/python-test-pypi-package.yml
+++ b/.github/workflows/python-test-pypi-package.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Test with pytest
       run: |
         # Options: --ignore=tests/specific.py --ignore-glob=tests/ignore-pattern
-        pytest -rEf tests/unit/ --cov macrosynergy -p no:warnings --verbose
+        pytest tests/unit/
 
     - name: Run integration tests with pytest
       env:

--- a/.github/workflows/pythons-docs.yml
+++ b/.github/workflows/pythons-docs.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Test with pytest
       run: |
         # Options: --ignore=tests/specific.py --ignore-glob=tests/ignore-pattern
-        pytest -rEf tests/unit/ --cov macrosynergy -p no:warnings --verbose --cov macrosynergy
+        pytest tests/unit/
     - name: Upload coverage reports to Codecov
       run: |
         curl -Os https://uploader.codecov.io/latest/linux/codecov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
 requires = ["setuptools>=61.0.0", "wheel"]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "macrosynergy"
@@ -7,7 +8,8 @@ description = "Macrosynergy Quant Research Package"
 dynamic = ["version"]
 
 authors = [{ name = "Macrosynergy", email = "info@macrosynergy.com" }]
-
+readme = { file = "README.md", content-type = "text/markdown" } # file can be a list
+license = { file = "LICENSE" }
 requires-python = ">=3.8"
 dependencies = [
   "seaborn>=0.11.2",
@@ -40,13 +42,6 @@ classifiers = [
   "Operating System :: OS Independent",
 ]
 
-[project.readme]
-file = "README.md"
-content-type = "text/markdown"
-
-[project.license]
-file = "LICENSE"
-# text = "copy paste the license text"
 
 [project.urls]
 homepage = "https://www.macrosynergy.com"
@@ -102,14 +97,14 @@ all = [
 ]
 
 [tool.setuptools]
-include-package-data = true
+platforms = ["Windows", "Linux", "Mac OS-X"]
 
 [tool.setuptools.packages.find]
+where = ["macrosynergy"]
 include = ["macrosynergy", "macrosynergy.*"]
+exclude = ["tests", "tests.*"]
 namespaces = true
 
-[tool.setuptools.exclude-package-data]
-"*" = ["*.c", "*.h"]
 
 [tool.versioneer]
 VCS = "git"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,8 +135,9 @@ exclude = '''
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "-rEf -p"
-testpaths = ['tests/unit/']
+addopts = "-rEf --cov=macrosynergy --cov-report=term-missing --cov-fail-under 75"
+rootdir = "."
+testpaths = ['./tests/unit/']
 
 [tool.coverage]
 source = "macrosynergy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,12 @@
 [build-system]
-requires = [ "setuptools>=61.0.0", "wheel" ]
+requires = ["setuptools>=61.0.0", "wheel"]
 
 [project]
 name = "macrosynergy"
 description = "Macrosynergy Quant Research Package"
-dynamic = [ "version" ]
+dynamic = ["version"]
 
-authors = [
-    {name = "Macrosynergy", email = "info@macrosynergy.com"}]
+authors = [{ name = "Macrosynergy", email = "info@macrosynergy.com" }]
 
 requires-python = ">=3.8"
 dependencies = [
@@ -19,7 +18,7 @@ dependencies = [
   "numpy>=1.21.6",
   "requests>=2.27.1",
   "tqdm>=4.62",
-  "PyYAML>=5.4.0"
+  "PyYAML>=5.4.0",
 ]
 classifiers = [
   "Development Status :: 4 - Beta",
@@ -38,7 +37,7 @@ classifiers = [
   "Topic :: Software Development",
   "Topic :: Scientific/Engineering",
   "Typing :: Typed",
-  "Operating System :: OS Independent"
+  "Operating System :: OS Independent",
 ]
 
 [project.readme]
@@ -47,7 +46,7 @@ content-type = "text/markdown"
 
 [project.license]
 file = "LICENSE"
-type = "BSD-3-Clause"
+# text = "copy paste the license text"
 
 [project.urls]
 homepage = "https://www.macrosynergy.com"
@@ -56,29 +55,27 @@ documentation = "https://docs.macrosynergy.com"
 tracker = "https://github.com/macrosynergy/macrosynergy/issues"
 
 [project.optional-dependencies]
-test = [ "pytest>=7.0.0", "pytest-cov>3.0.0", "coverage>=6.0.0" ]
-excel = [ "openpyxl>=3.0.10" ]
-formatting = [ "black>=22.1.0", "flake8>=4.0.1" ]
-performance = [ "bottleneck>=1.3.4", "numba>=0.55.2", "numexpr>=2.8.0" ]
-computation = [ "scipy>=1.8.1", "xarray>=2022.03.0" ]
+test = ["pytest>=7.0.0", "pytest-cov>3.0.0", "coverage>=6.0.0"]
+excel = ["openpyxl>=3.0.10"]
+formatting = ["black>=22.1.0", "flake8>=4.0.1"]
+performance = ["bottleneck>=1.3.4", "numba>=0.55.2", "numexpr>=2.8.0"]
+computation = ["scipy>=1.8.1", "xarray>=2022.03.0"]
 notebook = [
-"notebook>=6.0.0",
-"ipywidgets>=7.6.5",
-"ipython>=7.28.0",
-"jupyter>=1.0.0",
-"ipykernel>=6.4.1",
-"jupyterlab>=3.1.12"
+  "notebook>=6.0.0",
+  "ipywidgets>=7.6.5",
+  "ipython>=7.28.0",
+  "jupyter>=1.0.0",
+  "ipykernel>=6.4.1",
+  "jupyterlab>=3.1.12",
 ]
 markup = [
-"pandoc>=1.1.0",
-"pandocfilters>=1.4.3",
-"nbconvert>=6.2.0",
-"pyyaml>=5.4.0",
-"pytoml>=0.1.2"
+  "pandoc>=1.1.0",
+  "pandocfilters>=1.4.3",
+  "nbconvert>=6.2.0",
+  "pyyaml>=5.4.0",
+  "pytoml>=0.1.2",
 ]
-documentation= [
-  "sphinx>=4.2.0",
-]
+documentation = ["sphinx>=4.2.0"]
 all = [
   "pytest>=7.0.0",
   "pytest-cov>3.0.0",
@@ -102,17 +99,17 @@ all = [
   "pyyaml>=5.4.0",
   "pytoml>=0.1.2",
   "sphinx>=4.2.0",
-  ]
+]
 
 [tool.setuptools]
 include-package-data = true
 
 [tool.setuptools.packages.find]
-include = [ "macrosynergy", "macrosynergy.*" ]
+include = ["macrosynergy", "macrosynergy.*"]
 namespaces = true
 
 [tool.setuptools.exclude-package-data]
-"*" = [ "*.c", "*.h" ]
+"*" = ["*.c", "*.h"]
 
 [tool.versioneer]
 VCS = "git"
@@ -122,7 +119,7 @@ versionfile_build = "macrosynergy/version.py"
 tag_prefix = "v"
 
 [tool.black]
-target-version = [ "py38", "py39", "py310", "py311" ]
+target-version = ["py38", "py39", "py310", "py311"]
 exclude = '''
 (
   | \.egg
@@ -135,3 +132,11 @@ exclude = '''
   | dist
 )
 '''
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = "-rEf -p"
+testpaths = ['tests/unit/']
+
+[tool.coverage]
+source = "macrosynergy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,9 +135,8 @@ exclude = '''
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "-rEf --cov=macrosynergy --cov-report=term-missing --cov-fail-under 75"
-rootdir = "."
-testpaths = ['./tests/unit/']
+addopts = "-rEf --cov=macrosynergy --verbose"
+# testpaths = ['./tests/']
 
 [tool.coverage]
 source = "macrosynergy"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,0 @@
-# pytest.ini
-[pytest]
-addopts = -rEf -p no:warnings --verbose --cov macrosynergy
-
-
-testpaths =
-    tests/unit/

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,0 @@
-# Meta data description of setup.cfg
-[metadata]
-description-file = README.md

--- a/setup.py
+++ b/setup.py
@@ -3,41 +3,16 @@ import os
 import sys
 import subprocess
 import warnings
-from pathlib import Path
 
-DOCLINES = (__doc__ or '').split("\n")
-
-path = Path(__file__).parent
-with open(os.path.join(path, "README.md"), "r") as f:
-    readme = f.read()
 
 if sys.version_info[:2] < (3, 8):
     raise RuntimeError("Python version >= 3.8 required.")
-
-CLASSIFIERS = """\
-Intended Audience :: Science/Research
-Intended Audience :: Developers
-Programming Language :: Python
-Programming Language :: Python :: 3
-Programming Language :: Python :: 3.8
-Programming Language :: Python :: 3.9
-Programming Language :: Python :: 3.10
-Programming Language :: Python :: 3.11
-Programming Language :: Python :: 3 :: Only
-Topic :: Software Development
-Topic :: Scientific/Engineering
-Typing :: Typed
-Operating System :: Microsoft :: Windows
-Operating System :: POSIX
-Operating System :: MacOS
-Development Status :: 4 - Beta
-"""
 
 MAJOR = 0
 MINOR = 0
 MICRO = 35
 ISRELEASED = False
-VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
+VERSION = "%d.%d.%d" % (MAJOR, MINOR, MICRO)
 
 if sys.version_info >= (3, 12):
     # The first version not in the `Programming Language :: Python :: ...` classifiers above
@@ -46,12 +21,12 @@ if sys.version_info >= (3, 12):
         f"{sys.version_info.major}.{sys.version_info.minor}.",
         RuntimeWarning,
     )
-    
+
 if sys.version_info < (3, 8):
     warnings.warn(
         f"Python {sys.version_info.major}.{sys.version_info.minor} "
         "has reached end-of-life. The Macrosynergy package no longer supports this version. "
-        "Please upgrade to Python 3.8 or later.", 
+        "Please upgrade to Python 3.8 or later.",
         RuntimeWarning,
     )
 
@@ -61,20 +36,20 @@ def git_version():
     def _minimal_ext_cmd(cmd):
         # construct minimal environment
         env = {}
-        for k in ['SYSTEMROOT', 'PATH', 'HOME']:
+        for k in ["SYSTEMROOT", "PATH", "HOME"]:
             v = os.environ.get(k)
             if v is not None:
                 env[k] = v
         # LANGUAGE is used on win32
-        env['LANGUAGE'] = 'C'
-        env['LANG'] = 'C'
-        env['LC_ALL'] = 'C'
+        env["LANGUAGE"] = "C"
+        env["LANG"] = "C"
+        env["LC_ALL"] = "C"
         out = subprocess.check_output(cmd, stderr=subprocess.STDOUT, env=env)
         return out
 
     try:
-        out = _minimal_ext_cmd(['git', 'rev-parse', 'HEAD'])
-        GIT_REVISION = out.strip().decode('ascii')
+        out = _minimal_ext_cmd(["git", "rev-parse", "HEAD"])
+        GIT_REVISION = out.strip().decode("ascii")
     except (subprocess.SubprocessError, OSError):
         GIT_REVISION = "Unknown"
 
@@ -89,16 +64,18 @@ def get_version_info():
     # Adding the git rev number needs to be done inside write_version_py(),
     # otherwise the import of qstools.version messes up the build under Python 3.
     FULLVERSION = VERSION
-    if os.path.exists('.git'):
+    if os.path.exists(".git"):
         GIT_REVISION = git_version()
-    elif os.path.exists('macrosynergy/version.py'):
+    elif os.path.exists("macrosynergy/version.py"):
         # must be a source distribution, use existing version file
         try:
-            from qstools.version import git_revision as GIT_REVISION
+            from macrosynergy.version import git_revision as GIT_REVISION
         except ImportError:
-            raise ImportError("Unable to import git_revision. Try removing "
-                              "qstools/version.py and the build directory "
-                              "before building.")
+            raise ImportError(
+                "Unable to import git_revision. Try removing "
+                "macrosynergy/version.py and the build directory "
+                "before building."
+            )
     else:
         GIT_REVISION = "Unknown"
 
@@ -106,12 +83,12 @@ def get_version_info():
         import time
 
         time_stamp = time.strftime("%Y%m%d%H%M%S", time.localtime())
-        FULLVERSION += f'.dev0+{time_stamp}_{GIT_REVISION[:7]}'
+        FULLVERSION += f".dev0+{time_stamp}_{GIT_REVISION[:7]}"
 
     return FULLVERSION, GIT_REVISION
 
 
-def write_version_py(filename='macrosynergy/version.py'):
+def write_version_py(filename="macrosynergy/version.py"):
     cnt = """\
 # THIS FILE IS GENERATED FROM macrosynergy SETUP.PY
 short_version: str = '%(version)s'
@@ -124,65 +101,32 @@ if not release:
 """
     FULLVERSION, GIT_REVISION = get_version_info()
 
-    a = open(filename, 'w')
+    a = open(filename, "w")
     try:
-        a.write(cnt % {'version': VERSION,
-                       'full_version': FULLVERSION,
-                       'git_revision': GIT_REVISION,
-                       'isrelease': str(ISRELEASED)})
+        a.write(
+            cnt
+            % {
+                "version": VERSION,
+                "full_version": FULLVERSION,
+                "git_revision": GIT_REVISION,
+                "isrelease": str(ISRELEASED),
+            }
+        )
     finally:
         a.close()
 
 
-with open(os.path.join(os.path.dirname(__file__), "requirements.txt")) as f:
-    REQUIREMENTS = f.read()
-
-
 def setup_package():
-    from setuptools import setup, find_packages
-
-    src_path = os.path.dirname(os.path.abspath(__file__))
-    old_path = os.getcwd()
-    os.chdir(src_path)
-    sys.path.insert(0, src_path)
+    from setuptools import setup
 
     # Rewrite the version file every time
     write_version_py()
 
     metadata = dict(
-        name='macrosynergy',
-        maintainer="Macrosynergy",
-        maintainer_email="info@macrosynergy.com",
-        description=DOCLINES[0],
-        license="MIT License",
-        long_description_content_type="text/markdown",
-        long_description=readme,
-        url="https://www.macrosynergy.com",
-        author_email='info@macrosynergy.com',
-        author='Macrosynergy Ltd',
-        download_url="https://github.com/macrosynergy/macrosynergy",
-        project_urls={
-            "Bug Tracker": "https://github.com/macrosynergy/macrosynergy/issues",
-            "Source Code": "https://github.com/macrosynergy/macrosynergy",
-            "Documentation": "https://docs.macrosynergy.com"
-        },
-        classifiers=[_f for _f in CLASSIFIERS.split('\n') if _f],
-        platforms=["Windows", "Linux", "Mac OS-X"],
-        test_suite='pytest',
-        python_requires='>=3.6',
-        install_requires=REQUIREMENTS.split("\n"),
-        include_package_data=True,
-        packages=find_packages(exclude=["tests", "tests.*"]),
         version=get_version_info()[0],
     )
-    # __copyright__ = 'Copyright 2020 Macrosynergy Ltd'
 
-    try:
-        setup(**metadata)
-    finally:
-        del sys.path[0]
-        os.chdir(old_path)
-    return
+    setup(**metadata)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The functionality for `setup.py`, `setup.cfg`, and `pytest.ini` is fully supported via a `pyproject.toml`.
This is valid for Python 3.8+, which is already the cut-off for current supported Python versions