### PR TITLE
Refactor: Moved `.coveragerc` into `pyproject.toml`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,0 @@
-[report]
-exclude_lines=
-    if __name__ == .__main__.:
-    if 0:
-    if False:
-omit = tests/*,setup.py,*/__init__.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,3 +135,5 @@ addopts = "-rEf --cov=macrosynergy --verbose"
 
 [tool.coverage]
 source = "macrosynergy"
+exclude_lines = ["if __name__ == .__main__.:", "if 0:", "if False:"]
+omit = ["test/*", "setup.py", "macrosynergy/version.py", "**/__init__.py"]


### PR DESCRIPTION
`[tools.coverage]` allows coverage RC directives to be put into `pyproject.toml`