### PR TITLE
Feature: Added ability to pass directives in docstrings

### DIFF
--- a/docs/scripts/build_md.py
+++ b/docs/scripts/build_md.py
@@ -85,10 +85,7 @@ class DocstringMethods:
         module_docstrings: Dict[str, Union[str, Dict[str, Any]]],
         directives: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
-        if False:
-            if 5 * 2 == 10:
-                return module_docstrings
-
+        
         # sort the module_docstrings['classes'] and module_docstrings['functions'] by key
         if module_docstrings["classes"]:
             module_docstrings["classes"] = dict(

--- a/docs/scripts/build_md.py
+++ b/docs/scripts/build_md.py
@@ -26,6 +26,15 @@ class DocstringMethods:
         if not docstring:
             return ""
 
+        # remove any docstring directives
+        # look for lines where line.strip() starts with "::docs::" and ends with "::"
+        lines: List[str] = docstring.split("\n")
+        for il, line in enumerate(lines):
+            if line.strip().startswith("::docs::") and line.strip().endswith("::"):
+                lines[il] = "\n"
+
+        docstring = "\n".join(lines)
+
         options: Dict[str, Any] = {
             "number": True,
             "code_blocks": True,
@@ -71,12 +80,122 @@ class DocstringMethods:
 
         return DocstringMethods.markdown_format("\n".join(formatted_lines))
 
+    @staticmethod
+    def sort_docstrings(
+        module_docstrings: Dict[str, Union[str, Dict[str, Any]]],
+        directives: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        if False:
+            if 5 * 2 == 10:
+                return module_docstrings
+
+        # sort the module_docstrings['classes'] and module_docstrings['functions'] by key
+        if module_docstrings["classes"]:
+            module_docstrings["classes"] = dict(
+                sorted(module_docstrings["classes"].items(), key=lambda x: x[0])
+            )
+
+        if module_docstrings["functions"]:
+            module_docstrings["functions"] = dict(
+                sorted(module_docstrings["functions"].items(), key=lambda x: x[0])
+            )
+
+        if module_docstrings["functions"]:
+            underscore_functions: Dict[str, Any] = {
+                k: v
+                for k, v in module_docstrings["functions"].items()
+                if k.startswith("_")
+            }
+            # sort the underscore_functions by key
+            underscore_functions = dict(
+                sorted(underscore_functions.items(), key=lambda x: x[0])
+            )
+            # remove the underscore_functions from module_docstrings["functions"], and add them back at the end
+            module_docstrings["functions"] = {
+                k: v
+                for k, v in module_docstrings["functions"].items()
+                if not k in underscore_functions
+            }
+            for k, v in underscore_functions.items():
+                module_docstrings["functions"][k] = v
+
+        output: Dict[str, Union[dict, str]] = {
+            "classes": {},
+            "functions": {},
+            "<module>": "",
+        }
+
+        sorted_first: Dict[str, Union[dict, str]] = output.copy()
+        sorted_last: Dict[str, Union[dict, str]] = output.copy()
+        if directives:
+            for doctype in ["classes", "functions"]:
+                if doctype in module_docstrings and module_docstrings[doctype]:
+                    for name, doc in module_docstrings[doctype].items():
+                        if name in directives and directives[name]:
+                            # if there is a sort_first directive then move the docstring to the top
+                            if "sort_first" in directives[name]:
+                                sorted_first[doctype][name] = doc
+                            elif "sort_last" in directives[name]:
+                                sorted_last[doctype][name] = doc
+
+                # reverse the order of the sorted_last dict
+                sorted_last[doctype]: Dict[str, Any] = {
+                    k: sorted_last[doctype][k]
+                    for k in list(sorted_last[doctype].keys())[::-1]
+                }
+
+                output[doctype] = {
+                    **sorted_first[doctype], # if sorted_first[doctype] else {},
+                    **module_docstrings[doctype], # if module_docstrings[doctype] else {},
+                    **sorted_last[doctype], # if sorted_last[doctype] else {},
+                }
+
+            output["<module>"] = module_docstrings["<module>"]
+
+        else:
+            output = module_docstrings
+
+        return output
+
+    @staticmethod
+    def get_directives(docstring: str) -> Dict[str, Dict[str, Any]]:
+        """
+        Returns the docs-directives and the docs-flags from the docstring.
+        Looks for lines where line.strip() starts with "::docs::" and ends with "::".
+        """
+        # look for lines where line.strip() starts with "::docs::" and ends with "::"
+        lines: List[str] = docstring.split("\n")
+        directives: Dict[str, Dict[str, str]] = {}
+        for line in lines:
+            if line.strip().startswith("::docs::") and line.strip().endswith("::"):
+                directive: List[str] = line.strip().replace("::docs::", "").split("::")
+                # remove any empty strings
+                directive = [d.strip() for d in directive if d.strip()]
+                if len(directive) != 2:
+                    raise ValueError(f"Invalid directive: {line}")
+
+                if directive[0] not in directives:
+                    directives[directive[0]] = {}
+
+                directives[directive[0]][directive[1]] = True
+
+        return directives
+
 
 def extract_docstrings(source: str) -> Dict[str, Union[str, Dict[str, Any]]]:
     """
     Extracts docstrings from the given Python source code and returns a structured dictionary.
     """
     tree = ast.parse(source)
+
+    # if "historic volatility" in source:
+    #     breakpoint()
+
+    directives: Optional[dict] = None
+    if tree is not None:
+        directives: Dict[str, Dict[str, Any]] = DocstringMethods.get_directives(
+            docstring=source
+        )
     structure = {"<module>": ast.get_docstring(tree), "classes": {}, "functions": {}}
 
     for node in tree.body:
@@ -99,6 +218,12 @@ def extract_docstrings(source: str) -> Dict[str, Union[str, Dict[str, Any]]]:
                 "doc": ast.get_docstring(node),
                 "parameters": node.args.args,
             }
+
+    # pass the dict to the sort_docstrings method
+    if "historic volatility" in source:
+        structure = DocstringMethods.sort_docstrings(
+            module_docstrings=structure, directives=directives
+        )
 
     return structure
 

--- a/docs/scripts/build_md.py
+++ b/docs/scripts/build_md.py
@@ -85,7 +85,6 @@ class DocstringMethods:
         module_docstrings: Dict[str, Union[str, Dict[str, Any]]],
         directives: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
-        
         # sort the module_docstrings['classes'] and module_docstrings['functions'] by key
         if module_docstrings["classes"]:
             module_docstrings["classes"] = dict(
@@ -124,33 +123,30 @@ class DocstringMethods:
 
         sorted_first: Dict[str, Union[dict, str]] = output.copy()
         sorted_last: Dict[str, Union[dict, str]] = output.copy()
-        if directives:
-            for doctype in ["classes", "functions"]:
-                if doctype in module_docstrings and module_docstrings[doctype]:
-                    for name, doc in module_docstrings[doctype].items():
-                        if name in directives and directives[name]:
-                            # if there is a sort_first directive then move the docstring to the top
-                            if "sort_first" in directives[name]:
-                                sorted_first[doctype][name] = doc
-                            elif "sort_last" in directives[name]:
-                                sorted_last[doctype][name] = doc
 
-                # reverse the order of the sorted_last dict
-                sorted_last[doctype]: Dict[str, Any] = {
-                    k: sorted_last[doctype][k]
-                    for k in list(sorted_last[doctype].keys())[::-1]
-                }
+        for doctype in ["classes", "functions"]:
+            if doctype in module_docstrings and module_docstrings[doctype]:
+                for name, doc in module_docstrings[doctype].items():
+                    if name in directives and directives[name]:
+                        # if there is a sort_first directive then move the docstring to the top
+                        if "sort_first" in directives[name]:
+                            sorted_first[doctype][name] = doc
+                        elif "sort_last" in directives[name]:
+                            sorted_last[doctype][name] = doc
 
-                output[doctype] = {
-                    **sorted_first[doctype], # if sorted_first[doctype] else {},
-                    **module_docstrings[doctype], # if module_docstrings[doctype] else {},
-                    **sorted_last[doctype], # if sorted_last[doctype] else {},
-                }
+            # reverse the order of the sorted_last dict
+            sorted_last[doctype]: Dict[str, Any] = {
+                k: sorted_last[doctype][k]
+                for k in list(sorted_last[doctype].keys())[::-1]
+            }
 
-            output["<module>"] = module_docstrings["<module>"]
+            output[doctype] = {
+                **sorted_first[doctype],  # if sorted_first[doctype] else {},
+                **module_docstrings[doctype],  # if module_docstrings[doctype] else {},
+                **sorted_last[doctype],  # if sorted_last[doctype] else {},
+            }
 
-        else:
-            output = module_docstrings
+        output["<module>"] = module_docstrings["<module>"]
 
         return output
 
@@ -185,9 +181,6 @@ def extract_docstrings(source: str) -> Dict[str, Union[str, Dict[str, Any]]]:
     """
     tree = ast.parse(source)
 
-    # if "historic volatility" in source:
-    #     breakpoint()
-
     directives: Optional[dict] = None
     if tree is not None:
         directives: Dict[str, Dict[str, Any]] = DocstringMethods.get_directives(
@@ -217,10 +210,9 @@ def extract_docstrings(source: str) -> Dict[str, Union[str, Dict[str, Any]]]:
             }
 
     # pass the dict to the sort_docstrings method
-    if "historic volatility" in source:
-        structure = DocstringMethods.sort_docstrings(
-            module_docstrings=structure, directives=directives
-        )
+    structure = DocstringMethods.sort_docstrings(
+        module_docstrings=structure, directives=directives
+    )
 
     return structure
 

--- a/macrosynergy/download/dataquery.py
+++ b/macrosynergy/download/dataquery.py
@@ -4,6 +4,8 @@ This module is not intended to be used directly, but rather through
 macrosynergy.download.jpmaqs.py. However, for a use cases independent
 of JPMaQS, this module can be used directly to download data from the
 JPMorgan DataQuery API.
+
+::docs::DataQueryInterface::sort_first::
 """
 import concurrent.futures
 import time
@@ -541,7 +543,7 @@ def validate_download_args(
     return True
 
 
-def get_unavailable_expressions(
+def _get_unavailable_expressions(
     expected_exprs: List[str],
     dicts_list: List[Dict],
 ) -> List[str]:
@@ -1029,7 +1031,7 @@ class DataQueryInterface(object):
             show_progress=show_progress,
         )
 
-        self.unavailable_expressions = get_unavailable_expressions(
+        self.unavailable_expressions = _get_unavailable_expressions(
             expected_exprs=expressions, dicts_list=final_output
         )
         logger.info(

--- a/macrosynergy/download/jpmaqs.py
+++ b/macrosynergy/download/jpmaqs.py
@@ -1,4 +1,7 @@
-""" JPMaQS Download Interface """
+""" JPMaQS Download Interface 
+
+::docs::JPMaQSDownload::sort_first::
+"""
 
 from typing import List, Optional, Dict, Union
 import pandas as pd

--- a/macrosynergy/management/check_availability.py
+++ b/macrosynergy/management/check_availability.py
@@ -2,6 +2,8 @@
 Module for checking the availability of data availabity from a 
 Quantamental DataFrame. Includes functions for checking start years
 and end dates of a DataFrame, as well as visualizing the results.
+
+::docs::check_availability::sort_first::
 """
 
 import numpy as np

--- a/macrosynergy/management/simulate_quantamental_data.py
+++ b/macrosynergy/management/simulate_quantamental_data.py
@@ -1,6 +1,11 @@
 """
 Module with functionality for generating mock 
 quantamental data for testing purposes.
+
+::docs::make_qdf::sort_first::
+::docs::make_qdf_black::sort_first::
+::docs::make_test_df::sort_first::
+
 """
 import numpy as np
 import pandas as pd

--- a/macrosynergy/management/update_df.py
+++ b/macrosynergy/management/update_df.py
@@ -1,5 +1,8 @@
 """
 Tools used to update and modify a quantamental DataFrame.
+
+::docs::update_df::sort_first::
+
 """
 import pandas as pd
 from itertools import product

--- a/macrosynergy/panel/basket.py
+++ b/macrosynergy/panel/basket.py
@@ -17,34 +17,33 @@ import matplotlib.dates as mdates
 
 
 class Basket(object):
+    """
+    Calculates the returns and carries of baskets of financial contracts using
+    various weighting methods.
 
+    :param <pd.Dataframe> df: standardized DataFrame containing the columns: 'cid',
+        'xcat', 'real_date' and 'value'.
+    :param <List[str]> contracts: base tickers (combinations of cross-sections and
+        base categories) that define the contracts that go into the basket.
+    :param <str> ret: return category postfix to be appended to the contract base;
+        default is "XR_NSA".
+    :param <List[str] or str> cry: carry category postfix; default is None. The field
+        can either be a single carry or multiple carries defined in a List.
+    :param <str> start: earliest date in ISO 8601 format. Default is None.
+    :param <str> end: latest date in ISO 8601 format. Default is None.
+    :param <dict> blacklist: cross-sections with date ranges that should be excluded
+        from the DataFrame. If one cross-section has several blacklist periods append
+        numbers to the cross-section code.
+    :param List[str] ewgts: one or more postfixes that may identify exogenous weight
+        categories. Similar to return postfixes they are appended to base tickers.
+
+    N.B.: Each instance of the class will update associated standardised DataFrames,
+    containing return and carry categories, and external weights.
+    """
     def __init__(self, df: pd.DataFrame, contracts: List[str], ret: str = "XR_NSA",
                  cry: Union[str, List[str]] = None, start: str = None, end: str = None,
                  blacklist: dict = None, ewgts: List[str] = None):
 
-        """
-        Calculates the returns and carries of baskets of financial contracts using
-        various weighting methods.
-
-        :param <pd.Dataframe> df: standardized DataFrame containing the columns: 'cid',
-            'xcat', 'real_date' and 'value'.
-        :param <List[str]> contracts: base tickers (combinations of cross-sections and
-            base categories) that define the contracts that go into the basket.
-        :param <str> ret: return category postfix to be appended to the contract base;
-            default is "XR_NSA".
-        :param <List[str] or str> cry: carry category postfix; default is None. The field
-            can either be a single carry or multiple carries defined in a List.
-        :param <str> start: earliest date in ISO 8601 format. Default is None.
-        :param <str> end: latest date in ISO 8601 format. Default is None.
-        :param <dict> blacklist: cross-sections with date ranges that should be excluded
-            from the DataFrame. If one cross-section has several blacklist periods append
-            numbers to the cross-section code.
-        :param List[str] ewgts: one or more postfixes that may identify exogenous weight
-            categories. Similar to return postfixes they are appended to base tickers.
-
-        N.B.: Each instance of the class will update associated standardised DataFrames,
-        containing return and carry categories, and external weights.
-        """
         df["real_date"] = pd.to_datetime(df["real_date"], format="%Y-%m-%d")
         df = df[["cid", "xcat", "real_date", "value"]]
 

--- a/macrosynergy/panel/converge_row.py
+++ b/macrosynergy/panel/converge_row.py
@@ -7,23 +7,19 @@ class ConvergeRow(object):
     Class designed to receive a row of weights, where at least one weight in the
     aforementioned row exceeds the permitted upper-bound, and subsequently redistributes
     the excess evenly across all cross-sections.
+    :param <np.ndarray> row: Array of weights.
+    :param <Float> max_weight: Maximum weight.
+    :param <Float> margin: Margin of error allowed in the convergence to within the
+                            upper-bound, "max_weight".
+    :param <Integer> max_loops: Controls the accuracy: in theory, the greater the
+                                number of loops allowed, the more accurate the
+                                convergence. However, will only become significant if
+                                a tight margin is imposed: the "looser" the margin,
+                                the less likely the maximum number of loops permitted
+                                will be exceeded.
     """
 
     def __init__(self, row, max_weight, margin=0.001, max_loops=25):
-        """
-        Class's Constructor.
-
-        :param <np.ndarray> row: Array of weights.
-        :param <Float> max_weight: Maximum weight.
-        :param <Float> margin: Margin of error allowed in the convergence to within the
-                                upper-bound, "max_weight".
-        :param <Integer> max_loops: Controls the accuracy: in theory, the greater the
-                                    number of loops allowed, the more accurate the
-                                    convergence. However, will only become significant if
-                                    a tight margin is imposed: the "looser" the margin,
-                                    the less likely the maximum number of loops permitted
-                                    will be exceeded.
-        """
         self.row = row
         self.max_weight = max_weight
         self.flag = (1 / np.sum(self.row > 0)) <= self.max_weight

--- a/macrosynergy/panel/historic_vol.py
+++ b/macrosynergy/panel/historic_vol.py
@@ -1,5 +1,7 @@
 """
 Function for calculating historic volatility of quantamental data.
+
+::docs::historic_vol::sort_first::
 """
 import numpy as np
 import pandas as pd

--- a/macrosynergy/panel/linear_composite.py
+++ b/macrosynergy/panel/linear_composite.py
@@ -1,14 +1,17 @@
 """
 Implementation of linear_composite() function as a module.
+
+::docs::linear_composite::sort_first::
+
 """
 
 import numpy as np
 import pandas as pd
-from typing import List, Dict, Union, Optional, Tuple, Any, Callable, Type
+from typing import List, Dict, Union, Optional, Tuple, Type
 import warnings
 
 from macrosynergy.management.shape_dfs import reduce_df
-from macrosynergy.management.simulate_quantamental_data import make_qdf, make_test_df
+from macrosynergy.management.simulate_quantamental_data import make_test_df
 from macrosynergy.management.utils import is_valid_iso_date
 
 listtypes: Tuple[Type, ...] = (list, np.ndarray, pd.Series, tuple)

--- a/macrosynergy/panel/make_blacklist.py
+++ b/macrosynergy/panel/make_blacklist.py
@@ -1,6 +1,9 @@
 """
 Module with functions for processing "blacklist" data for cross-sections in a quantamental
 DataFrame.
+
+::docs::make_blacklist::sort_first::
+
 """
 
 import numpy as np

--- a/macrosynergy/panel/make_relative_value.py
+++ b/macrosynergy/panel/make_relative_value.py
@@ -1,6 +1,9 @@
 """
 Implementation of `make_relative_value()` function as a module. The function is used
 to calculate values for indicators relative to a basket of cross-sections.
+
+::docs::make_relative_value::sort_first::
+
 """
 import numpy as np
 import pandas as pd

--- a/macrosynergy/panel/make_zn_scores.py
+++ b/macrosynergy/panel/make_zn_scores.py
@@ -1,5 +1,8 @@
 """
 Module for calculating z-scores for a panel around a neutral level ("zn scores").
+
+::docs::make_zn_scores::sort_first::
+
 """
 import numpy as np
 import pandas as pd

--- a/macrosynergy/panel/panel_calculator.py
+++ b/macrosynergy/panel/panel_calculator.py
@@ -1,6 +1,9 @@
 """
 Implementation of panel calculation functions for quantamental data.
 The functionality allows applying mathematical operations on time-series data.
+
+::docs::panel_calculator::sort_first::
+
 """
 import numpy as np
 import pandas as pd

--- a/macrosynergy/panel/return_beta.py
+++ b/macrosynergy/panel/return_beta.py
@@ -1,6 +1,8 @@
 """
 Functions for calculating the hedge ratios of a panel of returns with respect to a
 single return. 
+
+::docs::return_beta::sort_first::
 """
 import warnings
 import numpy as np


### PR DESCRIPTION
Currently functional directives-

```
::docs::function_name::sort_first::
::docs::function_name::sort_last::
```


As of now, all directives within a module are parsed together. i.e. it wouldn't matter if you were addressing some other function in a functions docstring.
For this reason, it is recommended to list these directives in the module docstring.
Future directives can include highlighting, more sorting, and even appending examples