### PR TITLE
Bugfix: Standard keywords in `make_test_df()`

### DIFF
--- a/macrosynergy/management/simulate_quantamental_data.py
+++ b/macrosynergy/management/simulate_quantamental_data.py
@@ -321,8 +321,8 @@ def generate_lines(sig_len: int, style: str = "linear") -> Union[np.ndarray, Lis
 def make_test_df(
     cids: List[str] = ["AUD", "CAD", "GBP"],
     xcats: List[str] = ["XR", "CRY"],
-    start_date: str = "2010-01-01",
-    end_date: str = "2020-12-31",
+    start: str = "2010-01-01",
+    end: str = "2020-12-31",
     style: str = "any",
 ):
     """
@@ -350,7 +350,7 @@ def make_test_df(
     if isinstance(xcats, str):
         xcats = [xcats]
 
-    dates: pd.DatetimeIndex = pd.bdate_range(start_date, end_date)
+    dates: pd.DatetimeIndex = pd.bdate_range(start, end)
 
     df_list: List[pd.DataFrame] = []
     for cid in cids:

--- a/macrosynergy/panel/linear_composite.py
+++ b/macrosynergy/panel/linear_composite.py
@@ -475,15 +475,15 @@ if __name__ == "__main__":
             make_test_df(
                 cids=cids,
                 xcats=xcats[:-1],
-                start_date="2000-01-01",
-                end_date="2000-02-01",
+                start="2000-01-01",
+                end="2000-02-01",
                 style="linear",
             ),
             make_test_df(
                 cids=cids,
                 xcats=["INFL"],
-                start_date="2000-01-01",
-                end_date="2000-02-01",
+                start="2000-01-01",
+                end="2000-02-01",
                 style="decreasing-linear",
             ),
         ]

--- a/macrosynergy/visuals/view.py
+++ b/macrosynergy/visuals/view.py
@@ -335,14 +335,14 @@ if __name__ == "__main__":
     df: pd.DataFrame = make_test_df(
         cids=list(set(cids) - set(sel_cids)),
         xcats=xcats,
-        start_date="2000-01-01",
+        start="2000-01-01",
     )
 
     for rstyle, xcatx in zip(r_styles, sel_xcats):
         dfB: pd.DataFrame = make_test_df(
             cids=sel_cids,
             xcats=[xcatx],
-            start_date="2000-01-01",
+            start="2000-01-01",
             style=rstyle,
         )
         df: pd.DataFrame = pd.concat([df, dfB], axis=0)

--- a/tests/unit/management/test_simulate_quantamental_data.py
+++ b/tests/unit/management/test_simulate_quantamental_data.py
@@ -233,7 +233,7 @@ class Test_All(unittest.TestCase):
         line_styles : List[str] = generate_lines(sig_len=len(date_range), style='all')
         
         for ls in list(line_styles):
-            df : pd.DataFrame = make_test_df(cids=cids, xcats=xcats, start_date=start_date, end_date=end_date, style=ls)
+            df : pd.DataFrame = make_test_df(cids=cids, xcats=xcats, start=start_date, end=end_date, style=ls)
             
             self.assertTrue(isinstance(df, pd.DataFrame))
             self.assertFalse(df.empty)

--- a/tests/unit/panel/test_linear_composite.py
+++ b/tests/unit/panel/test_linear_composite.py
@@ -15,8 +15,8 @@ class TestAll(unittest.TestCase):
         dfd: pd.DataFrame = make_test_df(
             cids=self.cids,
             xcats=self.xcats,
-            start_date="2000-01-01",
-            end_date="2020-12-31",
+            start="2000-01-01",
+            end="2020-12-31",
         )
         self.dfd: pd.DataFrame = dfd
 
@@ -93,8 +93,8 @@ class TestAll(unittest.TestCase):
         _test_df: pd.DataFrame = make_test_df(
             cids=self.cids,
             xcats=self.xcats,
-            start_date="2000-01-01",
-            end_date="2000-02-01",
+            start="2000-01-01",
+            end="2000-02-01",
         )
 
         _test_df = _test_df[
@@ -121,8 +121,8 @@ class TestAll(unittest.TestCase):
         _test_df: pd.DataFrame = make_test_df(
             cids=self.cids,
             xcats=self.xcats,
-            start_date="2000-01-01",
-            end_date="2000-02-01",
+            start="2000-01-01",
+            end="2000-02-01",
         )
 
         _test_df = _test_df[
@@ -149,7 +149,7 @@ class TestAll(unittest.TestCase):
 
         ## Test Case 1a - Testing non-normalized weights
         dfd = make_test_df(
-            cids=all_cids, xcats=all_xcats, start_date=start, end_date=end
+            cids=all_cids, xcats=all_xcats, start=start, end=end
         )
         # set all values to 1
         dfd["value"] = 1
@@ -194,7 +194,7 @@ class TestAll(unittest.TestCase):
         ## Test Case 2a & b - Testing nan logic
         _end: str = "2000-02-01"
         dfd = make_test_df(
-            cids=all_cids, xcats=all_xcats, start_date=start, end_date=_end
+            cids=all_cids, xcats=all_xcats, start=start, end=_end
         )
         dfd["value"] = 1
 
@@ -222,7 +222,7 @@ class TestAll(unittest.TestCase):
         weights: List[str] = [1, 2, 4]
         _end: str = "2000-02-01"
         dfd = make_test_df(
-            cids=all_cids, xcats=all_xcats, start_date=start, end_date=_end
+            cids=all_cids, xcats=all_xcats, start=start, end=_end
         )
         dfd["value"] = 1
 
@@ -310,7 +310,7 @@ class TestAll(unittest.TestCase):
             signs: List[str] = [1, -1]
 
             dfd: pd.DataFrame = make_test_df(
-                cids=all_cids, xcats=_xcats, start_date=start, end_date=end
+                cids=all_cids, xcats=_xcats, start=start, end=end
             )
             dfd["value"] = 1
 
@@ -336,8 +336,8 @@ class TestAll(unittest.TestCase):
             dfd: pd.DataFrame = make_test_df(
                 cids=all_cids,
                 xcats=_xcats,
-                start_date=start,
-                end_date=end,
+                start=start,
+                end=end,
                 style="linear",
             )
             adf: pd.DataFrame = linear_composite(
@@ -362,7 +362,7 @@ class TestAll(unittest.TestCase):
 
         # Test Case 1a - Testing basic functionality
         dfd: pd.DataFrame = make_test_df(
-            cids=all_cids, xcats=all_xcats, start_date=start, end_date=end
+            cids=all_cids, xcats=all_xcats, start=start, end=end
         )
 
         dfd["value"] = 1
@@ -429,7 +429,7 @@ class TestAll(unittest.TestCase):
         _weights: List[str] = [1, 2, 4]
 
         dfd: pd.DataFrame = make_test_df(
-            cids=all_cids, xcats=all_xcats, start_date=start, end_date=end
+            cids=all_cids, xcats=all_xcats, start=start, end=end
         )
         dfd["value"] = 1
         for n_w, r_v in zip([True, False], [1, 7]):
@@ -450,7 +450,7 @@ class TestAll(unittest.TestCase):
         _weights: List[str] = [1, 2, 4]
         _end: str = "2000-02-01"
         dfd: pd.DataFrame = make_test_df(
-            cids=all_cids, xcats=all_xcats, start_date=start, end_date=_end
+            cids=all_cids, xcats=all_xcats, start=start, end=_end
         )
         dfd["value"] = 1
         dfd.loc[
@@ -525,7 +525,7 @@ class TestAll(unittest.TestCase):
         _weights: str = "INFL"
         _end: str = "2000-02-01"
         dfd: pd.DataFrame = make_test_df(
-            cids=all_cids, xcats=all_xcats, start_date=start, end_date=_end
+            cids=all_cids, xcats=all_xcats, start=start, end=_end
         )
         dfd["value"] = 1
 
@@ -572,7 +572,7 @@ class TestAll(unittest.TestCase):
         _weights: str = "INFL"
         _end: str = "2000-02-01"
         dfd: pd.DataFrame = make_test_df(
-            cids=all_cids, xcats=all_xcats, start_date=start, end_date=_end
+            cids=all_cids, xcats=all_xcats, start=start, end=_end
         )
         dfd["value"] = 1
 
@@ -619,7 +619,7 @@ class TestAll(unittest.TestCase):
         _weights: str = "INFL"
         _end: str = "2000-02-01"
         dfd: pd.DataFrame = make_test_df(
-            cids=all_cids, xcats=all_xcats, start_date=start, end_date=_end
+            cids=all_cids, xcats=all_xcats, start=start, end=_end
         )
         # for each, mutiply the weight by the sign
         dfd["value"] = 1

--- a/tests/unit/panel/test_panel_calculator.py
+++ b/tests/unit/panel/test_panel_calculator.py
@@ -251,8 +251,8 @@ class TestAll(unittest.TestCase):
             test_df : pd.DataFrame = make_test_df(
                 cids=test_cids,
                 xcats=test_xcats,
-                start_date=self.start,
-                end_date=self.end
+                start=self.start,
+                end=self.end
             )
             
             test_df.loc[(test_df['cid'] == 'USD') , 'value'] = pd.NA


### PR DESCRIPTION
The function used `start_date` and `end_date` to specify dates, whereas the rest of the package uses `start` and `end` (with the notable exception of `ms.download`)