### PR TITLE
Bugfix: Cumulative Sum, `msv.view.timelines`

### DIFF
--- a/macrosynergy/visuals/view.py
+++ b/macrosynergy/visuals/view.py
@@ -17,7 +17,7 @@ from typing import List, Optional, Tuple
 
 import pandas as pd
 
-from macrosynergy.management.utils import standardise_dataframe
+from macrosynergy.management.utils import standardise_dataframe, is_valid_iso_date
 from macrosynergy.visuals import FacetPlot, LinePlot
 from macrosynergy.visuals.common import Numeric
 
@@ -114,6 +114,21 @@ def timelines(
                 f"Column '{val}' (passed as `metric`) does not exist, and there are "
                 "none/many other numeric columns in the DataFrame."
             )
+
+    for dx, nx in [(start, "start"), (end, "end")]:
+        if dx is not None:
+            if not is_valid_iso_date(dx):
+                raise ValueError(f"`{nx}` must be a valid ISO date string.")
+
+    if start is None:
+        start: str = pd.Timestamp(df["real_date"].min()).strftime("%Y-%m-%d")
+
+    if end is None:
+        end: str = pd.Timestamp(df["real_date"].max()).strftime("%Y-%m-%d")
+
+    df: pd.DataFrame = df.loc[
+        (df["real_date"] >= start) & (df["real_date"] <= end), :
+    ].copy()
 
     if isinstance(xcats, str):
         xcats: List[str] = [xcats]


### PR DESCRIPTION
There was an error where the `cumsum` operation would take the earliest start date in the dataframe instead of the specified start date. this PR fixes that