### PR TITLE
Feature: extend `correl_matrix` to calculate correlation between two sets

### DIFF
--- a/macrosynergy/panel/view_correlations.py
+++ b/macrosynergy/panel/view_correlations.py
@@ -162,6 +162,7 @@ def correl_matrix(
     xlabel = ""
     ylabel = ""
 
+    # If more than one set of xcats or cids have been supplied.
     if xcats2 or cids2:
         if xcats2:
             xcats2 = xcats2 if isinstance(xcats2, list) else [xcats2]
@@ -183,6 +184,7 @@ def correl_matrix(
             "%Y-%m-%d"
         )
 
+        # If only one xcat, we will compute cross sectional correlation.
         if len(xcats) == 1 and len(xcats2) == 1:
             df_w1: pd.DataFrame = _transform_df_for_cross_sectional_corr(
                 df=df1, val=val, freq=freq
@@ -198,6 +200,9 @@ def correl_matrix(
                 )
             xlabel = f"{xcats[0]} cross-sections"
             ylabel = f"{xcats2[0]} cross-sections"
+
+        # If more than one xcat in at least one set, we will compute cross category
+        # correlation.
         else:
             if not lags2:
                 lags2 = lags
@@ -227,6 +232,8 @@ def correl_matrix(
 
             if corr.shape[1] > 1:
                 corr = _cluster_correlations(corr=corr.T, is_symmetric=False).T
+
+    # If there is only one set of xcats and cids.
     else:
         df, xcats, cids = reduce_df(df, xcats, cids, start, end, out_all=True)
 

--- a/macrosynergy/panel/view_correlations.py
+++ b/macrosynergy/panel/view_correlations.py
@@ -79,15 +79,15 @@ def correl_matrix(
     df: pd.DataFrame,
     xcats: Union[str, List[str]] = None,
     cids: List[str] = None,
-    xcats2: Optional[Union[str, List[str]]] = None,
-    cids2: Optional[List[str]] = None,
+    xcats_secondary: Optional[Union[str, List[str]]] = None,
+    cids_secondary: Optional[List[str]] = None,
     start: str = "2000-01-01",
     end: str = None,
     val: str = "value",
     freq: str = None,
     cluster: bool = False,
     lags: dict = None,
-    lags2: Optional[dict] = None,
+    lags_secondary: Optional[dict] = None,
     title: str = None,
     size: Tuple[float] = (14, 8),
     max_color: float = None,
@@ -103,13 +103,14 @@ def correl_matrix(
         across cross sections are displayed. If xcats contains more than one category,
         the correlation coefficients across categories are displayed. Additionally, the
         order of the xcats received will be mirrored in the correlation matrix.
-    :param <List[str]> xcats2: an optional second set of extended categories.
-        If xcats2 is provided, correlations will be calculated between the categories
-        in xcats and xcats2.
     :param <List[str]> cids: cross sections to be correlated. Default is all in the
         DataFrame.
-    :param <List[str]> cids2: an optional second list of cross sections. If cids2
-        is provided correlations will be calculated and visualized between these two sets.
+    :param <List[str]> xcats_secondary: an optional second set of extended categories.
+        If xcats_secondary is provided, correlations will be calculated between the
+        categories in xcats and xcats_secondary.
+    :param <List[str]> cids_secondary: an optional second list of cross sections. If
+        cids_secondary is provided correlations will be calculated and visualized between
+        these two sets.
     :param <str> start: earliest date in ISO format. Default is None and earliest date
         in df is used.
     :param <str> end: latest date in ISO format. Default is None and latest date in df
@@ -127,8 +128,8 @@ def correl_matrix(
         category has multiple lags applied, pass in a list of lag values. The lag factor
         will be appended to the category name in the correlation matrix.
         N.B.: Lags can include a 0 if the original should also be correlated.
-    :param <dict> lags2: optional dictionary of lags applied to the second set of
-        categories if xcats2 is provided.
+    :param <dict> lags_secondary: optional dictionary of lags applied to the second set of
+        categories if xcats_secondary is provided.
     :param <str> title: chart heading. If none is given, a default title is used.
     :param <Tuple[float]> size: two-element tuple setting width/height of figure. Default
         is (14, 8).
@@ -163,18 +164,18 @@ def correl_matrix(
     ylabel = ""
 
     # If more than one set of xcats or cids have been supplied.
-    if xcats2 or cids2:
-        if xcats2:
-            xcats2 = xcats2 if isinstance(xcats2, list) else [xcats2]
+    if xcats_secondary or cids_secondary:
+        if xcats_secondary:
+            xcats_secondary = xcats_secondary if isinstance(xcats_secondary, list) else [xcats_secondary]
         else:
-            xcats2 = xcats
+            xcats_secondary = xcats
 
-        if not cids2:
-            cids2 = cids
+        if not cids_secondary:
+            cids_secondary = cids
 
         df1, xcats, cids = reduce_df(df.copy(), xcats, cids, start, end, out_all=True)
-        df2, xcats2, cids2 = reduce_df(
-            df.copy(), xcats2, cids2, start, end, out_all=True
+        df2, xcats_secondary, cids_secondary = reduce_df(
+            df.copy(), xcats_secondary, cids_secondary, start, end, out_all=True
         )
 
         s_date = min(df1["real_date"].min(), df2["real_date"].min()).strftime(
@@ -185,7 +186,7 @@ def correl_matrix(
         )
 
         # If only one xcat, we will compute cross sectional correlation.
-        if len(xcats) == 1 and len(xcats2) == 1:
+        if len(xcats) == 1 and len(xcats_secondary) == 1:
             df_w1: pd.DataFrame = _transform_df_for_cross_sectional_corr(
                 df=df1, val=val, freq=freq
             )
@@ -195,23 +196,23 @@ def correl_matrix(
 
             if title is None:
                 title = (
-                    f"Cross-sectional correlation of {xcats[0]} and {xcats2[0]} from {s_date} to "
+                    f"Cross-sectional correlation of {xcats[0]} and {xcats_secondary[0]} from {s_date} to "
                     f"{e_date}"
                 )
             xlabel = f"{xcats[0]} cross-sections"
-            ylabel = f"{xcats2[0]} cross-sections"
+            ylabel = f"{xcats_secondary[0]} cross-sections"
 
         # If more than one xcat in at least one set, we will compute cross category
         # correlation.
         else:
-            if not lags2:
-                lags2 = lags
+            if not lags_secondary:
+                lags_secondary = lags
 
             df_w1: pd.DataFrame = _transform_df_for_cross_category_corr(
                 df=df1, xcats=xcats, val=val, freq=freq, lags=lags
             )
             df_w2: pd.DataFrame = _transform_df_for_cross_category_corr(
-                df=df2, xcats=xcats2, val=val, freq=freq, lags=lags2
+                df=df2, xcats=xcats_secondary, val=val, freq=freq, lags=lags_secondary
             )
 
             if title is None:
@@ -437,9 +438,9 @@ if __name__ == "__main__":
     correl_matrix(
         df=dfd,
         xcats=["XR"],
-        xcats2=None,
+        xcats_secondary=None,
         cids=cids,
-        cids2=["AUD"],
+        cids_secondary=None,
         start=start,
         end=end,
         val="value",
@@ -449,5 +450,5 @@ if __name__ == "__main__":
         size=(14, 8),
         max_color=None,
         lags=None,
-        lags2=None,
+        lags_secondary=None,
     )

--- a/tests/unit/panel/test_view_correlations.py
+++ b/tests/unit/panel/test_view_correlations.py
@@ -160,7 +160,7 @@ class TestAll(unittest.TestCase):
             correl_matrix(
                 self.dfd,
                 xcats=["XR"],
-                xcats2=["CRY"],
+                xcats_secondary=["CRY"],
                 cids=self.cids,
                 max_color=0.1,
                 show=False,
@@ -172,9 +172,9 @@ class TestAll(unittest.TestCase):
             correl_matrix(
                 self.dfd,
                 xcats=["XR"],
-                xcats2=["CRY"],
+                xcats_secondary=["CRY"],
                 cids=["AUD"],
-                cids2=["GBP"],
+                cids_secondary=["GBP"],
                 max_color=0.1,
                 show=False,
             )
@@ -186,7 +186,7 @@ class TestAll(unittest.TestCase):
                 self.dfd,
                 xcats=["XR"],
                 cids=["AUD"],
-                cids2=["GBP"],
+                cids_secondary=["GBP"],
                 max_color=0.1,
                 show=False,
             )

--- a/tests/unit/panel/test_view_correlations.py
+++ b/tests/unit/panel/test_view_correlations.py
@@ -14,8 +14,8 @@ from macrosynergy.management.check_availability import reduce_df
 
 class TestAll(unittest.TestCase):
     def dataframe_construction(self):
-        self.__dict__["cids"] = ["AUD", "CAD", "GBP"]
-        self.__dict__["xcats"] = ["XR", "CRY", "GROWTH", "INFL"]
+        self.cids = ["AUD", "CAD", "GBP"]
+        self.xcats = ["XR", "CRY", "GROWTH", "INFL"]
 
         df_cids = pd.DataFrame(
             index=self.cids, columns=["earliest", "latest", "mean_add", "sd_mult"]
@@ -42,7 +42,7 @@ class TestAll(unittest.TestCase):
 
         # Standard df for tests.
         dfd = make_qdf(df_cids, df_xcats, back_ar=0.75)
-        self.__dict__["dfd"] = dfd
+        self.dfd = dfd
 
     def test_lag_series(self):
         """

--- a/tests/unit/panel/test_view_correlations.py
+++ b/tests/unit/panel/test_view_correlations.py
@@ -3,7 +3,8 @@ import unittest
 import pandas as pd
 import numpy as np
 from tests.simulate import make_qdf
-from macrosynergy.panel.view_correlations import correl_matrix, lag_series
+from macrosynergy.panel.view_correlations import correl_matrix, lag_series, _transform_df_for_cross_sectional_corr, _transform_df_for_cross_category_corr
+from macrosynergy.management.check_availability import reduce_df
 
 
 class TestAll(unittest.TestCase):
@@ -160,6 +161,26 @@ class TestAll(unittest.TestCase):
             lag_dict = {'GROWTH': [0, 1, 2, 5]}
             correl_matrix(self.dfd, xcats=['XR', 'CRY'], cids=self.cids,
                           lags=lag_dict, max_color=1)
+            
+    def test_transform_df_for_cross_sectional_corr(self):
+
+        self.dataframe_construction()
+
+        df = reduce_df(self.dfd, xcats=['XR'], cids=self.cids)
+        df_w = _transform_df_for_cross_sectional_corr(df, val="value")
+        
+        self.assertEquals(df_w.columns.to_list(), self.cids)
+
+    def test_transform_df_for_cross_category_corr(self):
+
+        self.dataframe_construction()
+
+        xcats = ['XR', 'CRY']
+        df = reduce_df(self.dfd, xcats=xcats, cids=self.cids)
+        df_w = _transform_df_for_cross_category_corr(df, xcats=xcats, val="value")
+        
+        self.assertEquals(df_w.columns.to_list(), xcats)
+
 
 
 if __name__ == '__main__':

--- a/tests/unit/panel/test_view_correlations.py
+++ b/tests/unit/panel/test_view_correlations.py
@@ -145,6 +145,21 @@ class TestAll(unittest.TestCase):
         # Mainly test assertions given the function is used for visualisation. The
         # function can easily be tested through the graph returned.
 
+        try:
+            correl_matrix(self.dfd, xcats=['XR'], cids=self.cids, max_color=.1)
+        except Exception as e:
+            self.fail(f"correl_matrix raised {e} unexpectedly")
+
+        try:
+            correl_matrix(self.dfd, xcats=[['XR'], ['CRY']], cids=self.cids, max_color=.1)
+        except Exception as e:
+            self.fail(f"correl_matrix raised {e} unexpectedly")
+
+        try:
+            correl_matrix(self.dfd, xcats=[['XR'], ['CRY']], cids=[['AUD'], ['GBP']], max_color=.1)
+        except Exception as e:
+            self.fail(f"correl_matrix raised {e} unexpectedly")
+
         lag_dict = {'INFL': [0, 1, 2, 5]}
         with self.assertRaises(AssertionError):
             # Test the frequency options: either ['W', 'M', 'Q'].

--- a/tests/unit/panel/test_view_correlations.py
+++ b/tests/unit/panel/test_view_correlations.py
@@ -1,4 +1,3 @@
-
 import unittest
 import pandas as pd
 from pandas.testing import assert_frame_equal
@@ -8,36 +7,42 @@ from macrosynergy.panel.view_correlations import (
     lag_series,
     _transform_df_for_cross_sectional_corr,
     _transform_df_for_cross_category_corr,
-    _is_list_of_lists,
-    _cluster_correlations
+    _cluster_correlations,
 )
 from macrosynergy.management.check_availability import reduce_df
 
 
 class TestAll(unittest.TestCase):
-
     def dataframe_construction(self):
+        self.__dict__["cids"] = ["AUD", "CAD", "GBP"]
+        self.__dict__["xcats"] = ["XR", "CRY", "GROWTH", "INFL"]
 
-        self.__dict__['cids'] = ['AUD', 'CAD', 'GBP']
-        self.__dict__['xcats'] = ['XR', 'CRY', 'GROWTH', 'INFL']
+        df_cids = pd.DataFrame(
+            index=self.cids, columns=["earliest", "latest", "mean_add", "sd_mult"]
+        )
+        df_cids.loc["AUD", :] = ["2010-01-01", "2020-12-31", 0.5, 2]
+        df_cids.loc["CAD", :] = ["2010-01-01", "2020-11-30", 0, 1]
+        df_cids.loc["GBP", :] = ["2012-01-01", "2020-11-30", -0.2, 0.5]
 
-        df_cids = pd.DataFrame(index=self.cids, columns=['earliest', 'latest', 'mean_add',
-                                                         'sd_mult'])
-        df_cids.loc['AUD', :] = ['2010-01-01', '2020-12-31', 0.5, 2]
-        df_cids.loc['CAD', :] = ['2010-01-01', '2020-11-30', 0, 1]
-        df_cids.loc['GBP', :] = ['2012-01-01', '2020-11-30', -0.2, 0.5]
-
-        df_xcats = pd.DataFrame(index=self.xcats,
-                                columns=['earliest', 'latest', 'mean_add',
-                                         'sd_mult', 'ar_coef', 'back_coef'])
-        df_xcats.loc['CRY', :] = ['2010-01-01', '2020-10-30', 1, 2, 0.9, 0.5]
-        df_xcats.loc['XR', :] = ['2011-01-01', '2020-12-31', 0, 1, 0, 0.3]
-        df_xcats.loc['GROWTH', :] = ['2010-01-01', '2020-10-30', 1, 2, 0.9, 0.5]
-        df_xcats.loc['INFL', :] = ['2010-01-01', '2020-10-30', 0, 2, 0.9, 0.5]
+        df_xcats = pd.DataFrame(
+            index=self.xcats,
+            columns=[
+                "earliest",
+                "latest",
+                "mean_add",
+                "sd_mult",
+                "ar_coef",
+                "back_coef",
+            ],
+        )
+        df_xcats.loc["CRY", :] = ["2010-01-01", "2020-10-30", 1, 2, 0.9, 0.5]
+        df_xcats.loc["XR", :] = ["2011-01-01", "2020-12-31", 0, 1, 0, 0.3]
+        df_xcats.loc["GROWTH", :] = ["2010-01-01", "2020-10-30", 1, 2, 0.9, 0.5]
+        df_xcats.loc["INFL", :] = ["2010-01-01", "2020-10-30", 0, 2, 0.9, 0.5]
 
         # Standard df for tests.
         dfd = make_qdf(df_cids, df_xcats, back_ar=0.75)
-        self.__dict__['dfd'] = dfd
+        self.__dict__["dfd"] = dfd
 
     def test_lag_series(self):
         """
@@ -45,8 +50,9 @@ class TestAll(unittest.TestCase):
         """
         self.dataframe_construction()
 
-        df_w = self.dfd.pivot(index=("cid", "real_date"), columns="xcat",
-                              values="value")
+        df_w = self.dfd.pivot(
+            index=("cid", "real_date"), columns="xcat", values="value"
+        )
 
         # Confirm the application of the lag to the respective category is correct.
         # Compare against the original DataFrame.
@@ -71,8 +77,7 @@ class TestAll(unittest.TestCase):
         # the DataFrame are the respective lagged inflation series: ['INFL_L0',
         # 'INFL_L2', 'INFL_L5'].
 
-        update_test_columns = [xcat for xcat in test_columns
-                               if xcat not in xcats_copy]
+        update_test_columns = [xcat for xcat in test_columns if xcat not in xcats_copy]
 
         update_test_columns = sorted(update_test_columns)
         self.assertTrue(update_test_columns == ["INFL_L0", "INFL_L2", "INFL_L5"])
@@ -84,16 +89,16 @@ class TestAll(unittest.TestCase):
 
         # The benchmark value will be "INFL_L0" where a lag has not been applied. Test on
         # two cross-sections: ['AUD', 'GBP'].
-        df_w_lag = df_w_lag.loc[['AUD', 'GBP'], :]
+        df_w_lag = df_w_lag.loc[["AUD", "GBP"], :]
 
         # Arbitrary date to test the logic.
-        fixed_date = '2013-03-11'
-        condition = df_w_lag.index.get_level_values('real_date') == fixed_date
+        fixed_date = "2013-03-11"
+        condition = df_w_lag.index.get_level_values("real_date") == fixed_date
         period_t = df_w_lag[condition]["INFL_L0"]
         period_t_aud = float(period_t.loc["AUD"])
 
         lagged_date_2 = pd.Timestamp(fixed_date) + pd.DateOffset(2)
-        condition_2 = df_w_lag.index.get_level_values('real_date') == lagged_date_2
+        condition_2 = df_w_lag.index.get_level_values("real_date") == lagged_date_2
         period_t_2 = df_w_lag[condition_2]["INFL_L2"]
         period_t_2_aud = float(period_t_2.loc["AUD"])
 
@@ -102,14 +107,14 @@ class TestAll(unittest.TestCase):
         self.assertEqual(period_t_aud, period_t_2_aud)
 
         # Apply the same logic above but for INFL_L2.
-        dates_index = list(df_w_lag.loc['AUD', :].index)
-        dates_index = list(map(lambda d: str(d).split(' ')[0], dates_index))
+        dates_index = list(df_w_lag.loc["AUD", :].index)
+        dates_index = list(map(lambda d: str(d).split(" ")[0], dates_index))
 
         fixed_date_index = dates_index.index(fixed_date)
         lagged_date_5_index = fixed_date_index + 5
 
         lagged_date_5 = dates_index[lagged_date_5_index]
-        condition_5 = df_w_lag.index.get_level_values('real_date') == lagged_date_5
+        condition_5 = df_w_lag.index.get_level_values("real_date") == lagged_date_5
 
         period_t_5 = df_w_lag[condition_5]["INFL_L5"]
         period_t_5_aud = float(period_t_5.loc["AUD"])
@@ -128,97 +133,134 @@ class TestAll(unittest.TestCase):
 
         # Lag inflation & Growth by a range of possible options.
         lag_dict = {"INFL": [0, 5], "GROWTH": [3]}
-        df_w = self.dfd.pivot(index=("cid", "real_date"), columns="xcat",
-                              values="value")
+        df_w = self.dfd.pivot(
+            index=("cid", "real_date"), columns="xcat", values="value"
+        )
 
         df_w, xcat_tracker = lag_series(df_w, lag_dict, xcats=self.xcats)
         test_columns = list(df_w.columns)
 
         lagged_columns = [xcat for xcat in test_columns if xcat not in self.xcats]
-        self.assertTrue(sorted(lagged_columns) ==
-                        ["GROWTH_L3", "INFL_L0", "INFL_L5"])
+        self.assertTrue(sorted(lagged_columns) == ["GROWTH_L3", "INFL_L0", "INFL_L5"])
 
     def test_correl_matrix(self):
-
         self.dataframe_construction()
 
         # Mainly test assertions given the function is used for visualisation. The
         # function can easily be tested through the graph returned.
 
         try:
-            correl_matrix(self.dfd, xcats=['XR'], cids=self.cids, max_color=.1)
+            correl_matrix(
+                self.dfd, xcats=["XR"], cids=self.cids, max_color=0.1, show=False
+            )
         except Exception as e:
             self.fail(f"correl_matrix raised {e} unexpectedly")
 
         try:
-            correl_matrix(self.dfd, xcats=[['XR'], ['CRY']], cids=self.cids, max_color=.1)
+            correl_matrix(
+                self.dfd,
+                xcats=["XR"],
+                xcats2=["CRY"],
+                cids=self.cids,
+                max_color=0.1,
+                show=False,
+            )
         except Exception as e:
             self.fail(f"correl_matrix raised {e} unexpectedly")
 
         try:
-            correl_matrix(self.dfd, xcats=[['XR'], ['CRY']], cids=[['AUD'], ['GBP']], max_color=.1)
+            correl_matrix(
+                self.dfd,
+                xcats=["XR"],
+                xcats2=["CRY"],
+                cids=["AUD"],
+                cids2=["GBP"],
+                max_color=0.1,
+                show=False,
+            )
         except Exception as e:
             self.fail(f"correl_matrix raised {e} unexpectedly")
 
-        lag_dict = {'INFL': [0, 1, 2, 5]}
+        try:
+            correl_matrix(
+                self.dfd,
+                xcats=["XR"],
+                cids=["AUD"],
+                cids2=["GBP"],
+                max_color=0.1,
+                show=False,
+            )
+        except Exception as e:
+            self.fail(f"correl_matrix raised {e} unexpectedly")
+
+        lag_dict = {"INFL": [0, 1, 2, 5]}
         with self.assertRaises(AssertionError):
             # Test the frequency options: either ['W', 'M', 'Q'].
-            correl_matrix(self.dfd, xcats=['XR', 'CRY'], cids=self.cids,
-                          freq='BW', lags=lag_dict, max_color=0.1)
+            correl_matrix(
+                self.dfd,
+                xcats=["XR", "CRY"],
+                cids=self.cids,
+                freq="BW",
+                lags=lag_dict,
+                max_color=0.1,
+            )
 
         with self.assertRaises(AssertionError):
             # Test the max_color value. Expects a floating point value.
-            correl_matrix(self.dfd, xcats=['XR', 'CRY'], cids=self.cids,
-                          lags=lag_dict, max_color=1)
+            correl_matrix(
+                self.dfd,
+                xcats=["XR", "CRY"],
+                cids=self.cids,
+                lags=lag_dict,
+                max_color=1,
+            )
 
         with self.assertRaises(AssertionError):
             # Test the received lag data structure. Dictionary expected.
             lag_list = [0, 60]
-            correl_matrix(self.dfd, xcats=['XR', 'CRY'], cids=self.cids,
-                          lags=lag_list, max_color=1)
+            correl_matrix(
+                self.dfd,
+                xcats=["XR", "CRY"],
+                cids=self.cids,
+                lags=lag_list,
+                max_color=1,
+            )
 
         with self.assertRaises(AssertionError):
             # Test that the lagged categories are present in the received DataFrame.
             # The category, GROWTH, is not in the received categories.
-            lag_dict = {'GROWTH': [0, 1, 2, 5]}
-            correl_matrix(self.dfd, xcats=['XR', 'CRY'], cids=self.cids,
-                          lags=lag_dict, max_color=1)
-       
-    def test_transform_df_for_cross_sectional_corr(self):
+            lag_dict = {"GROWTH": [0, 1, 2, 5]}
+            correl_matrix(
+                self.dfd,
+                xcats=["XR", "CRY"],
+                cids=self.cids,
+                lags=lag_dict,
+                max_color=1,
+            )
 
+    def test_transform_df_for_cross_sectional_corr(self):
         self.dataframe_construction()
 
-        df = reduce_df(self.dfd, xcats=['XR'], cids=self.cids)
+        df = reduce_df(self.dfd, xcats=["XR"], cids=self.cids)
         df_w = _transform_df_for_cross_sectional_corr(df, val="value")
 
         # Test that columns are now the cids.
         self.assertEqual(df_w.columns.to_list(), self.cids)
 
     def test_transform_df_for_cross_category_corr(self):
-
         self.dataframe_construction()
 
-        xcats = ['XR', 'CRY']
+        xcats = ["XR", "CRY"]
         df = reduce_df(self.dfd, xcats=xcats, cids=self.cids)
         df_w = _transform_df_for_cross_category_corr(df, xcats=xcats, val="value")
 
         # Test that columns are now the xcats.
         self.assertEqual(df_w.columns.to_list(), xcats)
 
-    def test_is_lists_of_lists(self):
-
-        self.assertTrue(_is_list_of_lists([[]]))
-        self.assertTrue(_is_list_of_lists([[], []]))
-        self.assertTrue(_is_list_of_lists([['test'], ['test']]))
-
-        self.assertFalse(_is_list_of_lists(['test']))
-        self.assertFalse(_is_list_of_lists(['test', []]))
-
     def test_cluster_correlations(self):
-
         self.dataframe_construction()
 
-        df = reduce_df(self.dfd, xcats=['XR'], cids=self.cids)
+        df = reduce_df(self.dfd, xcats=["XR"], cids=self.cids)
         df_w = _transform_df_for_cross_sectional_corr(df, val="value")
 
         corr1 = df_w.corr(method="pearson")
@@ -233,5 +275,5 @@ class TestAll(unittest.TestCase):
         assert_frame_equal(corr1, corr2)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR allows the `xcats` or `cids` parameters of the `correl_matrix` function to take a list containing two lists. In this case, the correlation will be calculated and visualized between these two sets. 

If both sets contain a single category, such as `xcats = [['XR'], ['CRY']]`, correlation will be visualized between the cross-sections of these categories. If either set contains more than one category, correlation is visualized between categories.

![cross_section_corr](https://github.com/macrosynergy/macrosynergy/assets/146712736/cdbd5ca5-b7f4-423d-a4c3-e5261649225b)
![cross_category_corr](https://github.com/macrosynergy/macrosynergy/assets/146712736/fc26d5d2-0ab8-4c81-bf2a-16c9d44cc063)
