### PR TITLE
Feature: Common cache on the `develop` branch

### DIFF
--- a/.github/workflows/github-update-cache.yml
+++ b/.github/workflows/github-update-cache.yml
@@ -1,0 +1,19 @@
+name: Update Cache on Develop
+
+on:
+  push:
+    branches:
+      - "develop"
+
+jobs:
+  # This workflow builds the Python package dependencies every time that the requirements
+  # files are modified and store it in cache to be accessible by all the CI in all other
+  # branches.
+  build-cache:
+    name: Update/Create cache
+    runs-on: ubuntu-latest
+    steps:
+      - name: Restore caches
+        uses: ./.github/actions/restore-pip-cache
+        with:
+          python-version: 3.11


### PR DESCRIPTION
Workflows can share caches built on the default branch. This PR adds logic that creates/checks the cache on every push to develop - accessible by all PRs made against develop.

Source: 
https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cach

and 

https://stackoverflow.com/a/71061281