### PR TITLE
Bugfix: Seaborn/Matplotlib style issue

### DIFF
--- a/macrosynergy/learning/panel_timeseries_split.py
+++ b/macrosynergy/learning/panel_timeseries_split.py
@@ -9,6 +9,7 @@ from typing import Optional, List, Tuple, Union
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
+import seaborn as sns
 
 from sklearn.model_selection import BaseCrossValidator, cross_validate, GridSearchCV
 from sklearn.linear_model import Lasso, LinearRegression
@@ -448,7 +449,7 @@ class PanelTimeSeriesSplit(BaseCrossValidator):
 
         :return None
         """
-        plt.style.use("seaborn-whitegrid")
+        sns.set_style("whitegrid")
         Xy: pd.DataFrame = pd.concat(
             [X, y], axis=1
         ).dropna()  # remove dropna when splitter method fixed as per TODO #3

--- a/macrosynergy/signal/signal_return.py
+++ b/macrosynergy/signal/signal_return.py
@@ -4,6 +4,7 @@ Module for analysing and visualizing signal and a return series.
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
+import seaborn as sns
 from sklearn import metrics as skm
 from scipy import stats
 from typing import List, Union, Tuple
@@ -439,7 +440,7 @@ class SignalReturnRelations:
         y_input = 0.45 if y_axis(min_value) else min_value
 
         return y_input
-    
+
     @staticmethod
     def apply_slip(
         df: pd.DataFrame,
@@ -492,7 +493,7 @@ class SignalReturnRelations:
         if size is None:
             size = (np.max([dfx.shape[0] / 2, 8]), 6)
 
-        plt.style.use("seaborn")
+        sns.set_style("darkgrid")
         plt.figure(figsize=size)
         x_indexes = np.arange(dfx.shape[0])
 
@@ -581,7 +582,7 @@ class SignalReturnRelations:
         if size is None:
             size = (np.max([dfx.shape[0] / 2, 8]), 6)
 
-        plt.style.use("seaborn")
+        sns.set_style("seaborn")
         plt.figure(figsize=size)
         x_indexes = np.arange(len(dfx.index))
         w = 0.4

--- a/macrosynergy/signal/signal_return.py
+++ b/macrosynergy/signal/signal_return.py
@@ -582,7 +582,7 @@ class SignalReturnRelations:
         if size is None:
             size = (np.max([dfx.shape[0] / 2, 8]), 6)
 
-        sns.set_style("seaborn")
+        sns.set_style("darkgrid")
         plt.figure(figsize=size)
         x_indexes = np.arange(len(dfx.index))
         w = 0.4

--- a/macrosynergy/visuals/plotter.py
+++ b/macrosynergy/visuals/plotter.py
@@ -198,18 +198,8 @@ class Plotter(metaclass=PlotterMetaClass):
         self.backend: ModuleType
         if backend.startswith("m"):
             self.backend = plt
-            try:
-                self.backend.style.use("seaborn-v0_8-darkgrid")
-            except:
-                try:
-                    sns.set_style("darkgrid")
-                except:
-                    warnings.warn(
-                        "Unable to set the default style to Seaborne's darkgrid. \n"
-                        "Please make sure Seaborn and Matplotlib are installed, "
-                        " and updated to their latest versions.",
-                        RuntimeWarning,
-                    )
+            sns.set_style("darkgrid")
+
         elif ...:
             ...
         else:


### PR DESCRIPTION
With the release of [Matplotlib version 3.8.0](https://matplotlib.org/stable/users/prev_whats_new/whats_new_3.8.0.html), the use of `seaborn-<foo>` styles has been deprecated. Their recommendation is use `seaborn-v0_8-<foo>` instead, or directly use the seaborn API.

See [Matplotlib/Changes for 3.8.0/Removal of Deprecated APIs](https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.8.0.html#removal-of-deprecated-apis) fortheir release notes