### PR TITLE
Feature: Removing `pd.DataFrame` from `msm.decorators.argcopy`

### DIFF
--- a/macrosynergy/management/decorators.py
+++ b/macrosynergy/management/decorators.py
@@ -203,11 +203,8 @@ def argcopy(func: Callable) -> Callable:
         copy_types = (
             list,
             dict,
-            pd.DataFrame,
             np.ndarray,
             pd.Series,
-            pd.Index,
-            pd.MultiIndex,
             set,
         )
         new_args: List[Tuple[Any, ...]] = []


### PR DESCRIPTION
Removed `pd.DataFrame`, `pd.MultiIndex`, and `pd.Index` from `argcopy`. This was initially done to prevent side-effects within the visuals subpackage 