### PR TITLE
Bugfix: Add legend location and bbox args to `view_ranges()`

### DIFF
--- a/macrosynergy/panel/view_ranges.py
+++ b/macrosynergy/panel/view_ranges.py
@@ -25,6 +25,8 @@ def view_ranges(
     ylab: Optional[str] = None,
     size: Tuple[float] = (16, 8),
     xcat_labels: Optional[List[str]] = None,
+    legend_loc: str = "center right",
+    legend_bbox_to_anchor: Tuple[float] = (1.2, 0.5),
 ):
     """Plots averages and various ranges across sections for one or more categories.
 
@@ -46,6 +48,10 @@ def view_ranges(
     :param <str> ylab: y label. Default is no label.
     :param <Tuple[float]> size: Tuple of width and height of graph. Default is (16, 8).
     :param <List[str]> xcat_labels: custom labels to be used for the ranges.
+    :param <str> legend_loc: location of legend; passed to matplotlib.pyplot.legend().
+        Default is 'center right'.
+    :param <Tuple[float]> legend_bbox_to_anchor: passed to matplotlib.pyplot.legend().
+        Default is (1.2, 0.5).
 
     """
     msv.view_ranges(
@@ -61,6 +67,8 @@ def view_ranges(
         ylab=ylab,
         size=size,
         xcat_labels=xcat_labels,
+        legend_loc=legend_loc,
+        legend_bbox_to_anchor=legend_bbox_to_anchor,
     )
 
 

--- a/macrosynergy/visuals/ranges.py
+++ b/macrosynergy/visuals/ranges.py
@@ -26,8 +26,8 @@ def view_ranges(
     ylab: Optional[str] = None,
     size: Tuple[float] = (16, 8),
     xcat_labels: Optional[List[str]] = None,
-    legend_loc: str = "center right",
-    legend_bbox_to_anchor: Tuple[float] = (1.2, 0.5),
+    legend_loc: str = "best",
+    legend_bbox_to_anchor: Optional[Tuple[float]] = None,
 ):
     """Plots averages and various ranges across sections for one or more categories.
 
@@ -49,10 +49,10 @@ def view_ranges(
     :param <str> ylab: y label. Default is no label.
     :param <Tuple[float]> size: Tuple of width and height of graph. Default is (16, 8).
     :param <List[str]> xcat_labels: custom labels to be used for the ranges.
-    :param <str> legend_loc: location of legend; passed to matplotlib.pyplot.legend().
-        Default is 'center right'.
-    :param <Tuple[float]> legend_bbox_to_anchor: passed to matplotlib.pyplot.legend().
-        Default is (1.2, 0.5).
+    :param <str> legend_loc: location of legend; passed to matplotlib.pyplot.legend() as
+        `loc`. Default is 'center right'.
+    :param <Tuple[float]> legend_bbox_to_anchor: passed to matplotlib.pyplot.legend() as
+        `bbox_to_anchor`. Default is None.
 
     """
 

--- a/macrosynergy/visuals/ranges.py
+++ b/macrosynergy/visuals/ranges.py
@@ -54,6 +54,8 @@ def view_ranges(
     :param <Tuple[float]> legend_bbox_to_anchor: passed to matplotlib.pyplot.legend() as
         `bbox_to_anchor`. Default is None.
 
+    Please see [Matplotlib's Legend Documentation](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.legend.html)
+    for more information on the legend parameters `loc` and `bbox_to_anchor`.
     """
 
     df["real_date"] = pd.to_datetime(df["real_date"], format="%Y-%m-%d")

--- a/macrosynergy/visuals/ranges.py
+++ b/macrosynergy/visuals/ranges.py
@@ -26,6 +26,8 @@ def view_ranges(
     ylab: Optional[str] = None,
     size: Tuple[float] = (16, 8),
     xcat_labels: Optional[List[str]] = None,
+    legend_loc: str = "center right",
+    legend_bbox_to_anchor: Tuple[float] = (1.2, 0.5),
 ):
     """Plots averages and various ranges across sections for one or more categories.
 
@@ -47,6 +49,10 @@ def view_ranges(
     :param <str> ylab: y label. Default is no label.
     :param <Tuple[float]> size: Tuple of width and height of graph. Default is (16, 8).
     :param <List[str]> xcat_labels: custom labels to be used for the ranges.
+    :param <str> legend_loc: location of legend; passed to matplotlib.pyplot.legend().
+        Default is 'center right'.
+    :param <Tuple[float]> legend_bbox_to_anchor: passed to matplotlib.pyplot.legend().
+        Default is (1.2, 0.5).
 
     """
 

--- a/macrosynergy/visuals/ranges.py
+++ b/macrosynergy/visuals/ranges.py
@@ -180,7 +180,15 @@ def view_ranges(
     if (len(xcats) == 1) and (xcat_labels is None):
         ax.get_legend().remove()
     else:
-        ax.legend(handles=handles[0:], labels=labels[0:])
+        ax.legend(
+            handles=handles[0:],
+            labels=labels[0:],
+            loc=legend_loc,
+            bbox_to_anchor=legend_bbox_to_anchor,
+        )
+
+    plt.tight_layout()
+
     plt.show()
 
 


### PR DESCRIPTION
This pull request adds the ability to specify the location and bbox of the legend in the `view_ranges` function. This is achieved by passing the `legend_loc` and `legend_bbox_to_anchor` arguments to `ax.legend`.

Commits included:

- adding legend loc args and docstrings

- added loc and bbox_to_anchor pass-through to ax.legend

- Add legend location and bbox to `view_ranges`, for pass-through to `msv.view_ranges`

No issues fixed.