### PR TITLE
Feature: use business day freq

### DIFF
--- a/macrosynergy/management/constants.py
+++ b/macrosynergy/management/constants.py
@@ -1,0 +1,9 @@
+
+
+FREQUENCY_MAP = {
+    "D": "B",
+    "W": "W-FRI",
+    "M": "BM",
+    "Q": "BQ",
+    "A": "BA",
+}

--- a/macrosynergy/management/utils/__init__.py
+++ b/macrosynergy/management/utils/__init__.py
@@ -29,6 +29,7 @@ from .df_utils import (
     categories_df,
     categories_df_aggregation_helper,
     categories_df_expln_df,
+    _map_to_business_day_frequency,
 )
 
 from .math import (
@@ -67,4 +68,5 @@ __all__ = [
     "categories_df_aggregation_helper",
     "categories_df_expln_df",
     "expanding_mean_with_nan",
+    "_map_to_business_day_frequency",
 ]

--- a/macrosynergy/management/utils/df_utils.py
+++ b/macrosynergy/management/utils/df_utils.py
@@ -5,6 +5,7 @@ Utility functions for working with DataFrames.
 import itertools
 
 from macrosynergy.management.types import QuantamentalDataFrame
+from macrosynergy.management.constants import FREQUENCY_MAP
 import warnings
 from typing import Any, Dict, Iterable, List, Optional, Set, Union, overload
 
@@ -276,9 +277,7 @@ def downsample_df_on_real_date(
     if not isinstance(freq, str):
         raise TypeError("`freq` must be a string")
     else:
-        freq: str = freq.upper()
-        if freq not in ["D", "W", "M", "Q", "A"]:
-            raise ValueError("`freq` must be one of 'D', 'W', 'M', 'Q' or 'A'")
+        freq: str = _map_to_business_day_frequency(freq)
 
     if not isinstance(agg, str):
         raise TypeError("`agg` must be a string")
@@ -664,10 +663,7 @@ def categories_df(
     columns will reflect the order of the categories list.
     """
 
-    frq_options = ["D", "W", "M", "Q", "A"]
-    frq_error = f"Frequency parameter must be one of the stated options, {frq_options}."
-    assert freq in frq_options, frq_error
-    frq_dict = dict(zip(frq_options, ["B", "W-Fri", "BM", "BQ", "BA"]))
+    freq = _map_to_business_day_frequency(freq)
 
     assert isinstance(xcats, list), f"<list> expected and not {type(xcats)}."
     assert all([isinstance(c, str) for c in xcats]), "List of categories expected."
@@ -728,7 +724,7 @@ def categories_df(
         df_w = df_w.groupby(
             [
                 pd.Grouper(level="cid"),
-                pd.Grouper(level="real_date", freq=frq_dict[freq]),
+                pd.Grouper(level="real_date", freq=freq),
             ]
         )
 
@@ -796,3 +792,23 @@ def categories_df(
     # how is set to "any", a potential unnecessary loss of data on certain categories
     # could arise.
     return dfc.dropna(axis=0, how="all")
+
+
+def _map_to_business_day_frequency(freq: str, valid_freqs: List[str] = None) -> str:
+    """
+    Maps a frequency string to a business frequency string.
+
+    :param <str> freq: The frequency string to be mapped.
+    :param <List[str]> valid_freqs: The valid frequency strings. If None, defaults to
+        ["D", "W". "M", "Q", "A"].
+    """
+    freq = freq.upper()
+
+    if valid_freqs is None:
+        valid_freqs = list(FREQUENCY_MAP.keys())
+
+    if freq not in valid_freqs:
+        raise ValueError(
+            f"Frequency must be one of {valid_freqs}, but received {freq}."
+        )
+    return FREQUENCY_MAP[freq]

--- a/macrosynergy/panel/category_relations.py
+++ b/macrosynergy/panel/category_relations.py
@@ -172,7 +172,7 @@ class CategoryRelations(object):
             val=val,
             start=start,
             end=end,
-            freq=freq,
+            freq=self.freq,
             blacklist=blacklist,
             years=years,
             lag=lag,

--- a/macrosynergy/panel/historic_vol.py
+++ b/macrosynergy/panel/historic_vol.py
@@ -79,15 +79,15 @@ def flat_std(x: np.ndarray, remove_zeros: bool = True):
 
 def get_cycles(
     dates_df: pd.DataFrame,
-    freq: str = "m",
+    freq: str = "M",
 ) -> pd.Series:
     """Returns a DataFrame with values aggregated by the frequency specified.
 
     :param <pd.DataFrame>  dates_df: standardized DataFrame with the following necessary columns:
         'cid', 'xcats', 'real_date' and 'value'. Will contain all of the data across all
         macroeconomic fields.
-    :param <str> freq: Frequency of the data. Options are 'w' (weekly), 'm' (monthly),
-        'q' (quarterly) and 'd' (daily). Default is 'm'.
+    :param <str> freq: Frequency of the data. Options are 'W' (weekly), 'M' (monthly),
+        'Q' (quarterly) and 'D' (daily). Default is 'M'.
 
     :return <pd.Series>: A boolean mask which is True where the calculation is triggered.
     """
@@ -122,7 +122,7 @@ def get_cycles(
     elif freq == "d":
         func = lambda x, y: len(pd.bdate_range(x, y)) - 1
     else:
-        raise ValueError("Frequency parameter must be one of m, w, d or q")
+        raise ValueError("Frequency parameter must be one of D, M, W, or Q")
 
     dfc["cycleCount"] = dfc["real_date"].apply(func, args=(start_date,))
 
@@ -142,7 +142,7 @@ def historic_vol(
     half_life=11,
     start: str = None,
     end: str = None,
-    est_freq: str = "d",
+    est_freq: str = "D",
     blacklist: dict = None,
     remove_zeros: bool = True,
     postfix="ASD",
@@ -170,9 +170,9 @@ def historic_vol(
         df is used.
     :param <str> end: latest date in ISO format. Default is None and latest date in df is
         used.
-    :param <str> est_freq: Frequency of (re-)estimation of volatility. Options are 'd'
-        for end of each day (default), 'w' for end of each work week, 'm' for end of each month,
-         and 'q' for end of each week.
+    :param <str> est_freq: Frequency of (re-)estimation of volatility. Options are 'D'
+        for end of each day (default), 'W' for end of each work week, 'M' for end of each month,
+         and 'Q' for end of each week.
     :param <dict> blacklist: cross sections with date ranges that should be excluded from
         the data frame. If one cross section has several blacklist periods append numbers
         to the cross section code.
@@ -210,7 +210,7 @@ def historic_vol(
         "w",
         "m",
         "q",
-    ], "Estimation frequency must be one of 'd', 'w', 'm', 'q'."
+    ], "Estimation frequency must be one of 'D', 'W', 'M', or 'Q'."
 
     # assert nan tolerance is an int or float. must be >0. if >1 must be int
     assert isinstance(

--- a/macrosynergy/panel/make_zn_scores.py
+++ b/macrosynergy/panel/make_zn_scores.py
@@ -9,7 +9,11 @@ import pandas as pd
 from typing import List, Dict, Set
 import warnings
 from macrosynergy.management.simulate import make_qdf
-from macrosynergy.management.utils import drop_nan_series, reduce_df
+from macrosynergy.management.utils import (
+    drop_nan_series,
+    reduce_df,
+    _map_to_business_day_frequency,
+)
 from macrosynergy.management.types import QuantamentalDataFrame, Numeric
 
 
@@ -92,7 +96,7 @@ def make_zn_scores(
     min_obs: int = 261,
     iis: bool = True,
     neutral: str = "zero",
-    est_freq: str = "d",
+    est_freq: str = "D",
     thresh: float = None,
     pan_weight: float = 1,
     postfix: str = "ZN",
@@ -130,8 +134,8 @@ def make_zn_scores(
     :param <str> neutral: method to determine neutral level. Default is 'zero'.
         Alternatives are 'mean' and "median".
     :param <str> est_freq: the frequency at which standard deviations or means are
-        are re-estimated. The options are weekly, monthly & quarterly "w", "m", "q".
-        Default is daily, "d". Re-estimation is performed at period end.
+        are re-estimated. The options are daily, weekly, monthly & quarterly: "D", "W", "M", "Q".
+        Default is daily. Re-estimation is performed at period end.
     :param <float> thresh: threshold value beyond which scores are winsorized,
         i.e. contained at that threshold. The threshold is the maximum absolute
         score value that the function is allowed to produce. The minimum threshold is 1
@@ -185,18 +189,7 @@ def make_zn_scores(
     if not isinstance(min_obs, int) or min_obs < 0:
         raise ValueError(error_min)
 
-    frequencies = ["d", "w", "m", "q"]
-    error_freq = (
-        f"String Object required and must be one of the available frequencies: "
-        f"{frequencies}."
-    )
-
-    if not isinstance(est_freq, str):
-        raise TypeError(error_freq)
-    elif est_freq not in frequencies:
-        raise ValueError(error_freq)
-
-    pd_freq = dict(zip(frequencies, ["B", "W-Fri", "BM", "BQ"]))
+    est_freq = _map_to_business_day_frequency(freq=est_freq, valid_freqs=["D", "W", "M", "Q"])
 
     # --- Prepare re-estimation dates and time-series DataFrame.
 
@@ -221,7 +214,7 @@ def make_zn_scores(
 
     s_date = min(df["real_date"])
     e_date = max(df["real_date"])
-    dates_iter = pd.date_range(start=s_date, end=e_date, freq=pd_freq[est_freq])
+    dates_iter = pd.date_range(start=s_date, end=e_date, freq=est_freq)
 
     dfw = df.pivot(index="real_date", columns="cid", values="value")
     cross_sections = dfw.columns

--- a/macrosynergy/visuals/correlation.py
+++ b/macrosynergy/visuals/correlation.py
@@ -15,6 +15,7 @@ from collections import defaultdict
 
 from macrosynergy.management.utils import reduce_df
 from macrosynergy.management.simulate import make_qdf
+from macrosynergy.management.utils import _map_to_business_day_frequency
 
 
 def view_correlation(
@@ -90,12 +91,7 @@ def view_correlation(
     df = df[col_names]
 
     if freq is not None:
-        freq_options = ["W", "M", "Q"]
-        error_message = (
-            f"Frequency parameter must be one of the following options:"
-            f"{freq_options}."
-        )
-        assert freq in freq_options, error_message
+        freq = _map_to_business_day_frequency(freq=freq, valid_freqs=["W", "M", "Q"])
 
     xcats = xcats if isinstance(xcats, list) else [xcats]
 

--- a/tests/unit/panel/test_return_beta.py
+++ b/tests/unit/panel/test_return_beta.py
@@ -379,7 +379,7 @@ class TestAll(unittest.TestCase):
             )
 
         # Test the re-estimation frequency parameter.
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValueError):
             # The re-estimation frequency can either be weekly, monthly or quarterly:
             # ['w', 'm', 'q']. Set the 'refreq' parameter to an incorrect value.
             df_hedge = return_beta(

--- a/tests/unit/panel/test_view_correlations.py
+++ b/tests/unit/panel/test_view_correlations.py
@@ -195,7 +195,7 @@ class TestAll(unittest.TestCase):
             self.fail(f"correl_matrix raised {e} unexpectedly")
 
         lag_dict = {"INFL": [0, 1, 2, 5]}
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValueError):
             # Test the frequency options: either ['W', 'M', 'Q'].
             correl_matrix(
                 self.dfd,


### PR DESCRIPTION
- We should always be using business date frequencies `B`, `W-FRI`, `BM`, `BQ`, `BA`, instead of `D`, `W`, `M`, `Q`, `A`.
- Methods will continue to expect `D`, `W`, `M`, `Q`, or `A` as arguments but they'll be mapped to their business date counterpart. 