### PR TITLE
Feature: Remove old group-id from `DataQueryInterface.get_catalogue()`

### DIFF
--- a/macrosynergy/download/dataquery.py
+++ b/macrosynergy/download/dataquery.py
@@ -767,17 +767,10 @@ class DataQueryInterface(object):
 
         :raises <ValueError>: if the response from the server is not valid.
         """
-        old_group_id: str = "CA_QI_MACRO_SYNERGY"
         try:
             response_list: Dict = self._fetch(
                 url=self.base_url + CATALOGUE_ENDPOINT,
                 params={"group-id": group_id},
-                tracking_id=CATALOGUE_TRACKING_ID,
-            )
-        except NoContentError as e:
-            response_list: Dict = self._fetch(
-                url=self.base_url + CATALOGUE_ENDPOINT,
-                params={"group-id": old_group_id},
                 tracking_id=CATALOGUE_TRACKING_ID,
             )
         except Exception as e:


### PR DESCRIPTION
This pull request removes the usage of the old group-id "CA_QI_MACRO_SYNERGY" from the DQ.get_catalogue method. The method now only uses the provided group-id parameter to fetch the response from the server. This change ensures that the code is up to date and removes unnecessary code.

Closes #1036 