### PR TITLE
Refactor: Updating `flake8` directives

### DIFF
--- a/.github/workflows/python-publish-docs.yml
+++ b/.github/workflows/python-publish-docs.yml
@@ -37,8 +37,9 @@ jobs:
 
       - name: Lint with flake8
         run: |
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          # Options: exluding docs, scripts and build folders. Also, treating certain errors as warnings.
+          flake8 --count --select=E9,F63,F7,F82 --show-source --exclude=./docs/**,./.github/scripts/*,./build/** --statistics
+          flake8 --count --exit-zero --max-complexity=10 --max-line-length=127 --exclude=./docs/**,./.github/scripts/*,./build/** --statistics
 
       - name: Run jupyterbook build of documentation
         run: |

--- a/.github/workflows/python-pypi-upload.yml
+++ b/.github/workflows/python-pypi-upload.yml
@@ -31,10 +31,9 @@ jobs:
 
       - name: Lint with flake8
         run: |
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          # Options: exluding docs, scripts and build folders. Also, treating certain errors as warnings.
+          flake8 --count --select=E9,F63,F7,F82 --show-source --exclude=./docs/**,./.github/scripts/*,./build/** --statistics
+          flake8 --count --exit-zero --max-complexity=10 --max-line-length=127 --exclude=./docs/**,./.github/scripts/*,./build/** --statistics
 
       - name: Test with pytest
         run: |

--- a/.github/workflows/python-test-docs.yml
+++ b/.github/workflows/python-test-docs.yml
@@ -23,8 +23,9 @@ jobs:
 
       - name: Run Flake8
         run: |
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          # Options: exluding docs, scripts and build folders. Also, treating certain errors as warnings.
+          flake8 --count --select=E9,F63,F7,F82 --show-source --exclude=./docs/**,./.github/scripts/*,./build/** --statistics
+          flake8 --count --exit-zero --max-complexity=10 --max-line-length=127 --exclude=./docs/**,./.github/scripts/*,./build/** --statistics
 
       - name: Build docs
         run: |

--- a/.github/workflows/python-test-pypi-upload.yml
+++ b/.github/workflows/python-test-pypi-upload.yml
@@ -34,10 +34,9 @@ jobs:
 
       - name: Lint with flake8
         run: |
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          # Options: exluding docs, scripts and build folders. Also, treating certain errors as warnings.
+          flake8 --count --select=E9,F63,F7,F82 --show-source --exclude=./docs/**,./.github/scripts/*,./build/** --statistics
+          flake8 --count --exit-zero --max-complexity=10 --max-line-length=127 --exclude=./docs/**,./.github/scripts/*,./build/** --statistics
 
       - name: Test with pytest
         run: |

--- a/.github/workflows/python-unit-tests-release.yml
+++ b/.github/workflows/python-unit-tests-release.yml
@@ -28,10 +28,10 @@ jobs:
 
       - name: Lint with flake8
         run: |
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          # Options: exluding docs, scripts and build folders. Also, treating certain errors as warnings.
+          flake8 --count --select=E9,F63,F7,F82 --show-source --exclude=./docs/**,./.github/scripts/*,./build/** --statistics
+          flake8 --count --exit-zero --max-complexity=10 --max-line-length=127 --exclude=./docs/**,./.github/scripts/*,./build/** --statistics
+
       - name: Test with pytest
         run: |
           # Options: --ignore=tests/specific.py --ignore-glob=tests/ignore-pattern

--- a/.github/workflows/python-unit-tests.yml
+++ b/.github/workflows/python-unit-tests.yml
@@ -20,13 +20,13 @@ jobs:
       - name: Check for sys.path.append
         run: |
           bash .github/scripts/check_sys_path.sh
-          
+
       - name: Lint with flake8
         run: |
-          # stop the build if there are Python syntax errors or undefined names
-          python -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          python -m flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          # Options: exluding docs, scripts and build folders. Also, treating certain errors as warnings.
+          flake8 --count --select=E9,F63,F7,F82 --show-source --exclude=./docs/**,./.github/scripts/*,./build/** --statistics
+          flake8 --count --exit-zero --max-complexity=10 --max-line-length=127 --exclude=./docs/**,./.github/scripts/*,./build/** --statistics
+
       - name: Test with pytest
         run: |
           # Options: --ignore=tests/specific.py --ignore-glob=tests/ignore-pattern


### PR DESCRIPTION
This pull request refactors the flake8 linting commands in the codebase. The changes include excluding the `docs`, `scripts`, and `build` folders from the linting process. Additionally, certain errors are now treated as warnings. These changes improve the efficiency and accuracy of the linting process.