### PR TITLE
Feature: Adding `title_fontsize` argument to `SignalReturnRelations` plotting methods

### DIFF
--- a/macrosynergy/panel/historic_vol.py
+++ b/macrosynergy/panel/historic_vol.py
@@ -126,7 +126,7 @@ def historic_vol(
         not be included in the lookback window and prior non-zero values are added to the
         window instead.
     :param <str> postfix: string appended to category name for output; default is "ASD".
-    :param <float> nan_tolerance: maximum ratio of NaNs to non-NaNs in a lookback window,
+    :param <float> nan_tolerance: minimum ratio of NaNs to non-NaNs in a lookback window,
         if exceeded the resulting volatility is set to NaN. Default is 0.25.
 
     :return <pd.DataFrame>: standardized DataFrame with the estimated annualized standard


### PR DESCRIPTION
The chart functions did not have a title_fontsize parameter. This PR adds the title_fontsize parameter to the chart functions, allowing users to specify the font size of the chart header. Also adds the same functionality to `msv.view_table`