### PR TITLE
Bugfix: Seaborn version/Missing heatmap annotations

### DIFF
--- a/macrosynergy/visuals/__init__.py
+++ b/macrosynergy/visuals/__init__.py
@@ -11,17 +11,17 @@ from .correlation import view_correlation
 from .ranges import view_ranges
 from .table import view_table
 
-TYPES = ["NoneType", "Numeric"]
-CLASSES = ["FacetPlot", "LinePlot", "Plotter", "Heatmap"]
-MODULES = []
-FUNCTIONS = [
-    "timelines",
-    "view_metrics",
-    "view_grades",
-    "view_panel_dates",
-    "view_correlation",
-    "view_ranges",
-    "view_table"
-]
 
-__all__ = CLASSES + MODULES
+__all__ = [
+    "view_correlation",
+    "FacetPlot",
+    "view_grades",
+    "Heatmap",
+    "LinePlot",
+    "view_metrics",
+    "Plotter",
+    "view_ranges",
+    "view_table",
+    "timelines",
+    "view_panel_dates",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ readme = { file = "README.md", content-type = "text/markdown" } # file can be a 
 license = { file = "LICENSE" }
 requires-python = ">=3.8"
 dependencies = [
-  "seaborn>=0.11.2",
+  "seaborn>=0.13.0",
   "matplotlib>=3.6.0",
   "pandas>=1.3.5",
   "statsmodels>=0.13.2",


### PR DESCRIPTION
Older versions of Seaborn not fully compatible with older versions of matplotlib. Simply pushing seaborn to the latest dependency fixes the issue.

Closes #1267