### PR TITLE
Bugfix: Update logo URL in JPB docs site

### DIFF
--- a/docs.old/assets/jpb-config.yml
+++ b/docs.old/assets/jpb-config.yml
@@ -22,7 +22,7 @@ config:
     baseurl: "https://docs.macrosynergy.com/"
     announcement: |
       <p class='heading-banner'>
-        <img src='https://github.com/macrosynergy/macrosynergy/blob/main/docs/assets/MACROSYNERGY_Logo_White.png?raw=true'
+        <img src='https://github.com/macrosynergy/macrosynergy/blob/main/docs.old/assets/MACROSYNERGY_Logo_White.png?raw=true'
             width='35%' height='auto' style='display: block; margin-left: auto ; margin-right: auto ; ' class='bd-header-announcement-img'
             onclick="window.location.href='https://macrosynergy.com/'">
       </p>


### PR DESCRIPTION
The docs-site hosted on docs.macrosynergy.com has an outdated URL for the logo.
this PR fixes that. Given that the docs can be deployed by workflow dispatch, a new version is not required for this change - as it can be directly deployed from this branch.