### PR TITLE
Feature: Update publish trigger for docs-site

### DIFF
--- a/.github/workflows/python-publish-docs.yml
+++ b/.github/workflows/python-publish-docs.yml
@@ -4,8 +4,8 @@
 name: Package documentation - publish to GitHub Pages
 
 on:
-  push:
-    branches: [main]
+  # push:
+  #   branches: [main]
 
   workflow_dispatch:
 
@@ -54,4 +54,4 @@ jobs:
           path: "./docs.old/_build/html"
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/python-pypi-upload.yml
+++ b/.github/workflows/python-pypi-upload.yml
@@ -69,3 +69,25 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
 # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release
+
+## Publish docs
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r docs.old/requirements.txt
+          pip install flake8
+
+      - name: Run jupyterbook build of documentation
+        run: |
+          bash docs.old/scripts/build.sh
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          # Upload entire repository
+          path: "./docs.old/_build/html"
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This PR changes the trigger event for publishing the docs on GitHub pages.
Currently, the docs are updated on push to main. 
Given that the release notes on the docs-site require a release to be published on GitHub to generate notes for the latest version, the docs will now be pushed as part of the upload to PyPI (which itself is triggered when a release is published).
The old workflow for publishing docs still remains, but only with a workflow dispatch trigger.