### PR TITLE
Feature: Updating delay param code

### DIFF
--- a/macrosynergy/download/dataquery.py
+++ b/macrosynergy/download/dataquery.py
@@ -475,15 +475,15 @@ def validate_download_args(
 
     if not isinstance(delay_param, float):
         raise TypeError("`delay_param` must be a float >=0.2 (seconds).")
-    else:
-        if delay_param < 0.2:
-            warnings.warn(
-                RuntimeWarning(
-                    f"`delay_param` is too low; DataQuery API may reject requests. "
-                    f"Minimum recommended value is 0.2 seconds. "
-                ))
-        if delay_param < 0.0:
-            raise ValueError("`delay_param` must be a float >=0.2 (seconds).")
+
+    if delay_param < 0.2:
+        warnings.warn(
+            RuntimeWarning(
+                f"`delay_param` is too low; DataQuery API may reject requests. "
+                f"Minimum recommended value is 0.2 seconds. "
+            ))
+    if delay_param < 0.0:
+        raise ValueError("`delay_param` must be a float >=0.2 (seconds).")
 
     vars_types_zip: zip = zip(
         [

--- a/macrosynergy/download/dataquery.py
+++ b/macrosynergy/download/dataquery.py
@@ -475,8 +475,15 @@ def validate_download_args(
 
     if not isinstance(delay_param, float):
         raise TypeError("`delay_param` must be a float >=0.2 (seconds).")
-    elif delay_param < 0.2:
-        raise ValueError("`delay_param` must be a float >=0.2 (seconds).")
+    else:
+        if delay_param < 0.2:
+            warnings.warn(
+                RuntimeWarning(
+                    f"`delay_param` is too low; DataQuery API may reject requests. "
+                    f"Minimum recommended value is 0.2 seconds. "
+                ))
+        if delay_param < 0.0:
+            raise ValueError("`delay_param` must be a float >=0.2 (seconds).")
 
     vars_types_zip: zip = zip(
         [

--- a/tests/unit/download/test_dataquery.py
+++ b/tests/unit/download/test_dataquery.py
@@ -682,7 +682,7 @@ class TestDataQueryInterface(unittest.TestCase):
             with self.assertRaises(ValueError):
                 validate_download_args(**bad_args)
 
-        for delay_param in [0.0, 0.1, 1.0]:
+        for delay_param in [0.0, 0.1, 0.15]:
             bad_args: Dict[str, Any] = good_args.copy()
             bad_args["delay_param"] = delay_param
             with self.assertWarns(RuntimeWarning):

--- a/tests/unit/download/test_dataquery.py
+++ b/tests/unit/download/test_dataquery.py
@@ -676,10 +676,16 @@ class TestDataQueryInterface(unittest.TestCase):
             with self.assertRaises(TypeError):
                 validate_download_args(**bad_args)
 
-        for delay_param in [0.1, -1.0]:
+        for delay_param in [-0.1, -1.0]:
             bad_args: Dict[str, Any] = good_args.copy()
             bad_args["delay_param"] = delay_param
             with self.assertRaises(ValueError):
+                validate_download_args(**bad_args)
+
+        for delay_param in [0.0, 0.1, 1.0]:
+            bad_args: Dict[str, Any] = good_args.copy()
+            bad_args["delay_param"] = delay_param
+            with self.assertWarns(RuntimeWarning):
                 validate_download_args(**bad_args)
 
         for date_arg in ["start_date", "end_date"]:


### PR DESCRIPTION
Lowering the delay parameter below 200ms only throws an Runtime Warnings now, whereas it would throw a ValueError earlier.
In cases where a request fails and the `request_wrapper()` does a retry, the default `API_DELAY_PARAM (300ms)` will be used (the user cannot edit this.

Use as:
```python
with JPMaQSDownload(..., dq_download_kwargs={"delay_param" : 0.1}) ...
```