### PR TITLE
Bugfix: Fix QDF column names in docstrings

### DIFF
--- a/macrosynergy/management/utils/check_availability.py
+++ b/macrosynergy/management/utils/check_availability.py
@@ -28,7 +28,7 @@ def check_availability(
     Wrapper for visualizing start and end dates of a filtered DataFrame.
 
     :param <pd.DataFrame> df: standardized DataFrame with the following necessary
-        columns: 'cid', 'xcats', 'real_date'.
+        columns: 'cid', 'xcat', 'real_date'.
     :param <List[str]> xcats: extended categories to be checked on.
         Default is all in the DataFrame.
     :param <List[str]> cids: cross sections to be checked on.
@@ -68,7 +68,7 @@ def missing_in_df(df: pd.DataFrame, xcats: List[str] = None, cids: List[str] = N
     Print missing cross-sections and categories
 
     :param <pd.DataFrame> df: standardized DataFrame with the following necessary
-        columns: 'cid', 'xcats', 'real_date'.
+        columns: 'cid', 'xcat', 'real_date'.
     :param <List[str]> xcats: extended categories to be checked on. Default is all
         in the DataFrame.
     :param <List[str]> cids: cross sections to be checked on. Default is all in
@@ -90,7 +90,7 @@ def check_startyears(df: pd.DataFrame):
     DataFrame with starting years across all extended categories and cross-sections
 
     :param <pd.DataFrame> df: standardized DataFrame with the following necessary
-        columns: 'cid', 'xcats', 'real_date'.
+        columns: 'cid', 'xcat', 'real_date'.
 
     """
     df: pd.DataFrame = df.copy()
@@ -106,7 +106,7 @@ def check_enddates(df: pd.DataFrame) -> pd.DataFrame:
     DataFrame with end dates across all extended categories and cross sections.
 
     :param <pd.DataFrame> df: standardized DataFrame with the following necessary
-        columns: 'cid', 'xcats', 'real_date'.
+        columns: 'cid', 'xcat', 'real_date'.
     """
     df: pd.DataFrame = df.copy()
     df = df.dropna(how="any")

--- a/macrosynergy/management/utils/df_utils.py
+++ b/macrosynergy/management/utils/df_utils.py
@@ -259,7 +259,7 @@ def downsample_df_on_real_date(
     Downsample JPMaQS DataFrame.
 
     :param <pd.Dataframe> df: standardized JPMaQS DataFrame with the necessary columns:
-        'cid', 'xcats', 'real_date' and at least one column with values of interest.
+        'cid', 'xcat', 'real_date' and at least one column with values of interest.
     :param <List> groupby_columns: a list of columns used to group the DataFrame.
     :param <str> freq: frequency option. Per default the correlations are calculated
         based on the native frequency of the datetimes in 'real_date', which is business
@@ -416,7 +416,7 @@ def reduce_df(
     Filter DataFrame by xcats and cids and notify about missing xcats and cids.
 
     :param <pd.Dataframe> df: standardized JPMaQS DataFrame with the necessary columns:
-        'cid', 'xcats', 'real_date' and 'value'.
+        'cid', 'xcat', 'real_date' and 'value'.
     :param <Union[str, List[str]]> xcats: extended categories to be filtered on. Default is
         all in the DataFrame.
     :param <List[str]> cids: cross sections to be checked on. Default is all in the
@@ -502,7 +502,7 @@ def reduce_df_by_ticker(
     Filter dataframe by xcats and cids and notify about missing xcats and cids
 
     :param <pd.Dataframe> df: standardized dataframe with the following columns:
-        'cid', 'xcats', 'real_date'.
+        'cid', 'xcat', 'real_date'.
     :param <List[str]> ticks: tickers (cross sections + base categories)
     :param <str> start: string in ISO 8601 representing earliest date. Default is None.
     :param <str> end: string ISO 8601 representing the latest date. Default is None.
@@ -619,7 +619,7 @@ def categories_df(
     if applicable, lags.
 
     :param <pd.Dataframe> df: standardized JPMaQS DataFrame with the following necessary
-        columns: 'cid', 'xcats', 'real_date' and at least one column with values of
+        columns: 'cid', 'xcat', 'real_date' and at least one column with values of
         interest.
     :param <List[str]> xcats: extended categories involved in the custom DataFrame. The
         last category in the list represents the dependent variable, and the (n - 1)

--- a/macrosynergy/panel/basket.py
+++ b/macrosynergy/panel/basket.py
@@ -730,7 +730,7 @@ class Basket(object):
             the instance are selected.
 
         :return <pd.Dataframe>: standardized DataFrame with the basket return and
-            (possibly) carry data in standard form, i.e. columns 'cid', 'xcats',
+            (possibly) carry data in standard form, i.e. columns 'cid', 'xcat',
             'real_date' and 'value'.
         """
 

--- a/macrosynergy/panel/historic_vol.py
+++ b/macrosynergy/panel/historic_vol.py
@@ -95,7 +95,7 @@ def historic_vol(
     Controls the functionality.
 
     :param <pd.DataFrame> df: standardized DataFrame with the following necessary columns:
-        'cid', 'xcats', 'real_date' and 'value'. Will contain all of the data across all
+        'cid', 'xcat', 'real_date' and 'value'. Will contain all of the data across all
         macroeconomic fields.
     :param <str> xcat:  extended category denoting the return series for which volatility
         should be calculated.

--- a/macrosynergy/panel/return_beta.py
+++ b/macrosynergy/panel/return_beta.py
@@ -211,7 +211,7 @@ def return_beta(
     Estimate sensitivities (betas) of return category with respect to single return.
 
     :param <pd.Dataframe> df: standardized DataFrame with the necessary columns:
-        'cid', 'xcats', 'real_date' and 'value.
+        'cid', 'xcat', 'real_date' and 'value.
     :param <str> xcat:  return category based on the type of positions that are
         to be hedged.
         N.B.: Each cross-section of this category uses the same hedge asset/basket.

--- a/macrosynergy/panel/view_correlations.py
+++ b/macrosynergy/panel/view_correlations.py
@@ -32,7 +32,7 @@ def correl_matrix(
     Visualize correlation across categories or cross-sections of panels.
 
     :param <pd.Dataframe> df: standardized JPMaQS DataFrame with the necessary columns:
-        'cid', 'xcats', 'real_date' and at least one column with values of interest.
+        'cid', 'xcat', 'real_date' and at least one column with values of interest.
     :param <List[str]> xcats: extended categories to be correlated. Default is all in the
         DataFrame. If xcats contains only one category the correlation coefficients
         across cross sections are displayed. If xcats contains more than one category,

--- a/macrosynergy/panel/view_ranges.py
+++ b/macrosynergy/panel/view_ranges.py
@@ -31,7 +31,7 @@ def view_ranges(
     """Plots averages and various ranges across sections for one or more categories.
 
     :param <pd.Dataframe> df: standardized DataFrame with the necessary columns:
-        'cid', 'xcats', 'real_date' and at least one column with values of interest.
+        'cid', 'xcat', 'real_date' and at least one column with values of interest.
     :param <List[str]> xcats: extended categories to be checked on. Default is all
         in the DataFrame.
     :param <List[str]> cids: cross sections to plot. Default is all in DataFrame.

--- a/macrosynergy/panel/view_timelines.py
+++ b/macrosynergy/panel/view_timelines.py
@@ -40,7 +40,7 @@ def view_timelines(
     """Displays a facet grid of time line charts of one or more categories.
 
     :param <pd.Dataframe> df: standardized DataFrame with the necessary columns:
-        'cid', 'xcats', 'real_date' and at least one column with values of interest.
+        'cid', 'xcat', 'real_date' and at least one column with values of interest.
     :param <List[str]> xcats: extended categories to plot. Default is all in DataFrame.
     :param <List[str]> cids: cross sections to plot. Default is all in DataFrame.
         If this contains only one cross section a single line chart is created.

--- a/macrosynergy/signal/target_positions.py
+++ b/macrosynergy/signal/target_positions.py
@@ -70,7 +70,7 @@ def modify_signals(
     or conversion to signs (digital method).
 
     :param <pd.Dataframe> df: standardized DataFrame containing the following columns:
-        'cid', 'xcats', 'real_date' and 'value'.
+        'cid', 'xcat', 'real_date' and 'value'.
     :param <List[str]> cids: cross sections of markets or currency areas in which
         positions should be taken.
     :param <str> xcat_sig: category that serves as signal across markets.
@@ -134,7 +134,7 @@ def cs_unit_returns(
     Calculate returns of composite unit positions (that jointly depend on one signal).
 
     :param <pd.Dataframe> df: standardized DataFrame containing the following columns:
-        'cid', 'xcats', 'real_date' and 'value'.
+        'cid', 'xcat', 'real_date' and 'value'.
     :param <List[str]> contract_returns: list of the contract return types.
     :param <List[float]> sigrels: respective signal for each contract type.
     :param <str> ret: postfix denoting the returns in % applied to the contract types.
@@ -346,7 +346,7 @@ def target_positions(
     Converts signals into contract-specific target positions.
 
     :param <pd.Dataframe> df: standardized DataFrame containing at least the following
-        columns: 'cid', 'xcats', 'real_date' and 'value'.
+        columns: 'cid', 'xcat', 'real_date' and 'value'.
     :param <List[str]> cids: cross-sections of markets or currency areas in which
         positions should be taken.
     :param <str> xcat_sig: category that serves as signal across markets.

--- a/macrosynergy/visuals/correlation.py
+++ b/macrosynergy/visuals/correlation.py
@@ -38,7 +38,7 @@ def view_correlation(
     Visualize correlation across categories or cross-sections of panels.
 
     :param <pd.Dataframe> df: standardized JPMaQS DataFrame with the necessary columns:
-        'cid', 'xcats', 'real_date' and at least one column with values of interest.
+        'cid', 'xcat', 'real_date' and at least one column with values of interest.
     :param <List[str]> xcats: extended categories to be correlated. Default is all in the
         DataFrame. If xcats contains only one category the correlation coefficients
         across cross sections are displayed. If xcats contains more than one category,

--- a/macrosynergy/visuals/ranges.py
+++ b/macrosynergy/visuals/ranges.py
@@ -32,7 +32,7 @@ def view_ranges(
     """Plots averages and various ranges across sections for one or more categories.
 
     :param <pd.Dataframe> df: standardized DataFrame with the necessary columns:
-        'cid', 'xcats', 'real_date' and at least one column with values of interest.
+        'cid', 'xcat', 'real_date' and at least one column with values of interest.
     :param <List[str]> xcats: extended categories to be checked on. Default is all
         in the DataFrame.
     :param <List[str]> cids: cross sections to plot. Default is all in DataFrame.

--- a/macrosynergy/visuals/timelines.py
+++ b/macrosynergy/visuals/timelines.py
@@ -57,7 +57,7 @@ def timelines(
 
     Parameters
     :param <pd.Dataframe> df: standardized DataFrame with the necessary columns:
-        'cid', 'xcats', 'real_date' and at least one column with values of interest.
+        'cid', 'xcat', 'real_date' and at least one column with values of interest.
     :param <List[str]> xcats: extended categories to plot. Default is all in DataFrame.
     :param <List[str]> cids: cross sections to plot. Default is all in DataFrame.
         If this contains only one cross section a single line chart is created.


### PR DESCRIPTION
This pull request fixes the column names in the DataFrame specification. The QDF spec. has columns 'xcat' as a column, whereas 'xcats' had been used in the docstrings