### PR TITLE
Feature: Add unit tests for VintageData class

### DIFF
--- a/macrosynergy/management/simulate/simulate_vintage_data.py
+++ b/macrosynergy/management/simulate/simulate_vintage_data.py
@@ -90,7 +90,7 @@ class VintageData:
             try:
                 pd.Timestamp(date_string).strftime("%Y-%m-%d")
             except ValueError:
-                raise AssertionError(date_error)
+                raise ValueError(date_error)
             else:
                 date = pd.Timestamp(date_string).strftime("%Y-%m-%d")
                 return pd.Timestamp(date)

--- a/macrosynergy/management/simulate/simulate_vintage_data.py
+++ b/macrosynergy/management/simulate/simulate_vintage_data.py
@@ -2,6 +2,7 @@
 Module with functionality for generating mock 
 quantamental data vintages for testing purposes.
 """
+
 import numpy as np
 import pandas as pd
 from typing import List, Union, Tuple
@@ -79,14 +80,17 @@ class VintageData:
     def date_check(date_string):
         """
         Validates that the dates passed are valid timestamp expressions and will convert
-        to the required form '%Y-%m-%d'. Will raise an assertion if not in the expected
-        form.
+        to the required form '%Y-%m-%d'.
 
         :param <str> date_string: valid date expression. For instance, "1st January,
             2000."
+        :raises <TypeError>: if the date_string is not a string.
+        :raises <ValueError>: if the date_string is not in the correct format.
         """
         date_error = "Expected form of string: '%Y-%m-%d'."
         if date_string is not None:
+            if not isinstance(date_string, str):
+                raise TypeError("`date_string` must be a string.")
             try:
                 pd.Timestamp(date_string).strftime("%Y-%m-%d")
             except ValueError:

--- a/tests/unit/management/test_vintage_data.py
+++ b/tests/unit/management/test_vintage_data.py
@@ -119,6 +119,20 @@ class Test_All(unittest.TestCase):
         self.assertEqual(len(unique_transformation), 1)
         self.assertEqual(unique_transformation[0], None)
 
+    def test_misc(self):
+        # make grade1 with freq = W
+        vins_m = VintageData(
+            "USD_INDX_SA",
+            cutoff="2019-06-30",
+            release_lags=[3, 20, 25],
+            number_firsts=12,
+            shortest=12,
+            sd_ar=5,
+            trend_ar=20,
+            seasonal=10,
+            added_dates=6,
+            freq="W",
+        ).make_grade1()
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/management/test_vintage_data.py
+++ b/tests/unit/management/test_vintage_data.py
@@ -1,0 +1,124 @@
+import unittest
+import random
+import numpy as np
+import pandas as pd
+import os
+from typing import List
+from macrosynergy.management.simulate import VintageData
+
+
+class Test_All(unittest.TestCase):
+    def setUp(self):
+        self.vins_m = VintageData(
+            "USD_INDX_SA",
+            cutoff="2019-06-30",
+            release_lags=[3, 20, 25],
+            number_firsts=12,
+            shortest=12,
+            sd_ar=5,
+            trend_ar=20,
+            seasonal=10,
+            added_dates=6,
+        )
+
+    def test_grade1(self):
+        grade1: pd.DataFrame = self.vins_m.make_grade1()
+        expected_columns: List[str] = [
+            "cross_section",
+            "category_code",
+            "adjustment",
+            "transformation",
+            "release_date",
+            "observation_date",
+            "value",
+            "grading",
+        ]
+        self.assertEqual(list(grade1.columns), expected_columns)
+
+        # check that grade1[cross_section] is a single value - USD
+        unique_cross_section = grade1["cross_section"].unique().tolist()
+        self.assertEqual(len(unique_cross_section), 1)
+        self.assertEqual(unique_cross_section[0], "USD")
+
+        unique_category_code = grade1["category_code"].unique().tolist()
+        self.assertEqual(len(unique_category_code), 1)
+        self.assertEqual(unique_category_code[0], "INDX")
+
+        unique_adjustment = grade1["adjustment"].unique().tolist()
+        self.assertEqual(len(unique_adjustment), 1)
+        self.assertEqual(unique_adjustment[0], "SA")
+
+        unique_transformation = grade1["transformation"].unique().tolist()
+        self.assertEqual(len(unique_transformation), 1)
+        self.assertEqual(unique_transformation[0], None)
+
+        min_release_date = grade1["release_date"].min().strftime("%Y-%m-%d")
+        max_release_date = grade1["release_date"].max().strftime("%Y-%m-%d")
+        self.assertEqual(min_release_date, "2018-07-04")
+        self.assertEqual(max_release_date, "2019-06-26")
+
+        # grading should be 1
+        unique_grading = grade1["grading"].unique().tolist()
+        self.assertEqual(len(unique_grading), 1)
+        self.assertAlmostEqual(unique_grading[0], 1.0)
+
+    def test_grade2(self):
+        dfm2: pd.DataFrame = self.vins_m.make_grade2()
+
+        # earlist release date - 2018-01-03, latest release date - 2019-06-25
+        min_release_date = dfm2["release_date"].min().strftime("%Y-%m-%d")
+        max_release_date = dfm2["release_date"].max().strftime("%Y-%m-%d")
+        self.assertEqual(min_release_date, "2018-01-03")
+        self.assertEqual(max_release_date, "2019-06-25")
+
+        # check that grade2[cross_section] is a single value - USD
+        unique_cross_section = dfm2["cross_section"].unique().tolist()
+        self.assertEqual(len(unique_cross_section), 1)
+        self.assertEqual(unique_cross_section[0], "USD")
+
+        unique_category_code = dfm2["category_code"].unique().tolist()
+        self.assertEqual(len(unique_category_code), 1)
+        self.assertEqual(unique_category_code[0], "INDX")
+
+        unique_adjustment = dfm2["adjustment"].unique().tolist()
+        self.assertEqual(len(unique_adjustment), 1)
+        self.assertEqual(unique_adjustment[0], "SA")
+
+        unique_transformation = dfm2["transformation"].unique().tolist()
+        self.assertEqual(len(unique_transformation), 1)
+        self.assertEqual(unique_transformation[0], None)
+
+        # ticker should be a single value - USD_INDX_SA
+        unique_ticker = dfm2["ticker"].unique().tolist()
+        self.assertEqual(len(unique_ticker), 1)
+        self.assertEqual(unique_ticker[0], "USD_INDX_SA")
+
+    def test_make_graded(self):
+        graded: pd.DataFrame = self.vins_m.make_graded(grading=[3, 2.1, 1], upgrades=[12, 24])
+        
+        min_release_date = graded["release_date"].min().strftime("%Y-%m-%d")
+        max_release_date = graded["release_date"].max().strftime("%Y-%m-%d")
+
+        self.assertEqual(min_release_date, "2018-07-04")
+        self.assertEqual(max_release_date, "2019-06-26")
+
+        # check that grade2[cross_section] is a single value - USD
+        unique_cross_section = graded["cross_section"].unique().tolist()
+        self.assertEqual(len(unique_cross_section), 1)
+        self.assertEqual(unique_cross_section[0], "USD")
+
+        unique_category_code = graded["category_code"].unique().tolist()
+        self.assertEqual(len(unique_category_code), 1)
+        self.assertEqual(unique_category_code[0], "INDX")
+
+        unique_adjustment = graded["adjustment"].unique().tolist()
+        self.assertEqual(len(unique_adjustment), 1)
+        self.assertEqual(unique_adjustment[0], "SA")
+
+        unique_transformation = graded["transformation"].unique().tolist()
+        self.assertEqual(len(unique_transformation), 1)
+        self.assertEqual(unique_transformation[0], None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/management/test_vintage_data.py
+++ b/tests/unit/management/test_vintage_data.py
@@ -134,5 +134,19 @@ class Test_All(unittest.TestCase):
             freq="W",
         ).make_grade1()
 
+        with self.assertRaises(ValueError):
+            vins_m = VintageData(
+                "USD_INDX_SA",
+                cutoff="sdfm",
+                release_lags=[3, 20, 25],
+                number_firsts=12,
+                shortest=12,
+                sd_ar=5,
+                trend_ar=20,
+                seasonal=10,
+                added_dates=6,
+                freq="M",
+            ).make_grade1()
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This pull request adds unit tests for the VintageData class in the simulate module. The tests cover the make_grade1, make_grade2, and make_graded methods, ensuring that the generated dataframes have the expected structure and values.