### PR TITLE
Bugfix: Fix occurence in panel calculator of when single cid is specified

### DIFF
--- a/macrosynergy/panel/panel_calculator.py
+++ b/macrosynergy/panel/panel_calculator.py
@@ -172,11 +172,12 @@ def panel_calculator(
     old_xcats_used = list(set(old_xcats_used))
     missing = sorted(set(old_xcats_used) - set(df["xcat"].unique()))
 
-    if len(missing) > 0:
+    new_xcats = list(ops.keys())
+    if len(missing) > 0 and not set(missing).issubset(set(new_xcats)):
         raise ValueError(f"Missing categories: {missing}.")
 
     # If any of the elements of single_cids are not in cids, add them to cids.
-    cids_used = cids + list(set(single_cids) - set(cids))
+    cids_used = list(set(single_cids) + set(cids))
 
     # D. Reduce dataframe with intersection requirement.
 
@@ -189,11 +190,6 @@ def panel_calculator(
         blacklist=blacklist,
         intersect=False,
     )
-    # cidx = np.sort(dfx["cid"].unique())
-
-    # if len(cidx) == len(single_cids):
-    #     if np.all(cidx == single_cids):
-    #         cidx = cids
 
     # E. Create all required wide dataframes with category names.
 
@@ -292,33 +288,18 @@ if __name__ == "__main__":
     filt1 = (dfd["xcat"] == "XR") | (dfd["xcat"] == "CRY")
     dfdx = dfd[filt1]
 
-    # First testcase.
-    dfd = reduce_df(dfd, xcats=["INFL", "XR"], cids=['USD', 'CAD'])
-    cidx = ["AUD", "EUR", "NZD", "GBP"]
-    iscores = ["INFL", "XR"]
-    calcs = []
-    for xc in iscores:
-        calcs += [f"{xc}1 = iUSD_{xc} + INFL"]
-    
+    f1 = "NEW_VAR1 = GROWTH - iEUR_INFL"
+    formulas = [f1]
+    cidx = ["AUD", "CAD"]
     df_calc = panel_calculator(
-        df=dfd, calcs=calcs, cids=cidx
+        df=dfd, calcs=formulas, cids=cidx, start=start, end=end, blacklist=black
     )
-    
-    print(df_calc.cid.unique())
-    print(df_calc.xcat.unique())
-
-    # f1 = "NEW_VAR1 = GROWTH - iEUR_INFL"
-    # formulas = [f1]
-    # cidx = ["AUD", "CAD"]
-    # df_calc = panel_calculator(
-    #     df=dfd, calcs=formulas, cids=cidx, start=start, end=end, blacklist=black
-    # )
-    # # Second testcase: EUR is not passed in as one of the cross-sections in "cids"
-    # # parameter but is defined in the dataframe. Therefore, code will not break.
-    # cids = ["AUD", "CAD", "GBP", "USD", "NZD"]
-    # formula = "NEW1 = XR - iUSD_XR"
-    # formula_2 = "NEW2 = GROWTH - iEUR_INFL"
-    # formulas = [formula, formula_2]
-    # df_calc = panel_calculator(
-    #     df=dfd, calcs=formulas, cids=cids, start=start, end=end, blacklist=black
-    # )
+    # Second testcase: EUR is not passed in as one of the cross-sections in "cids"
+    # parameter but is defined in the dataframe. Therefore, code will not break.
+    cids = ["AUD", "CAD", "GBP", "USD", "NZD"]
+    formula = "NEW1 = XR - iUSD_XR"
+    formula_2 = "NEW2 = GROWTH - iEUR_INFL"
+    formulas = [formula, formula_2]
+    df_calc = panel_calculator(
+        df=dfd, calcs=formulas, cids=cids, start=start, end=end, blacklist=black
+    )

--- a/macrosynergy/panel/panel_calculator.py
+++ b/macrosynergy/panel/panel_calculator.py
@@ -183,6 +183,9 @@ def panel_calculator(
     # If any of the elements of single_cids are not in cids, add them to cids.
     cids_used = cids + list(set(single_cids) - set(cids))
 
+    if np.all(cidx == single_cids):
+        cidx = cids
+
     # D. Reduce dataframe with intersection requirement.
 
     dfx = reduce_df(

--- a/macrosynergy/panel/panel_calculator.py
+++ b/macrosynergy/panel/panel_calculator.py
@@ -196,8 +196,9 @@ def panel_calculator(
     )
     cidx = np.sort(dfx["cid"].unique())
 
-    if np.all(cidx == single_cids):
-        cidx = cids
+    if len(cidx) == len(single_cids):
+        if np.all(cidx == single_cids):
+            cidx = cids
 
     # E. Create all required wide dataframes with category names.
 

--- a/macrosynergy/panel/panel_calculator.py
+++ b/macrosynergy/panel/panel_calculator.py
@@ -88,7 +88,7 @@ def _get_xcats_used(ops: dict) -> Tuple[List[str], List[str]]:
             singles_used += [s for s in op_list if re.match("^i", s)]
 
     single_xcats = [x[5:] for x in singles_used]
-    single_cids = [x[1:4] for x in singles_used]
+    single_cids = [x[1:4] for x in single_xcats]
     all_xcats_used = xcats_used + single_xcats
     return all_xcats_used, singles_used, single_cids
 
@@ -191,10 +191,6 @@ def panel_calculator(
         intersect=False,
     )
 
-    if len(cidx) == len(single_cids):
-        if np.all(cidx == single_cids):
-            cidx = cids
-
     # E. Create all required wide dataframes with category names.
 
     for xcat in old_xcats_used:
@@ -291,6 +287,8 @@ if __name__ == "__main__":
     # Example filter for dataframe.
     filt1 = (dfd["xcat"] == "XR") | (dfd["xcat"] == "CRY")
     dfdx = dfd[filt1]
+
+    # First testcase.
 
     f1 = "NEW_VAR1 = GROWTH - iEUR_INFL"
     formulas = [f1]

--- a/macrosynergy/panel/panel_calculator.py
+++ b/macrosynergy/panel/panel_calculator.py
@@ -88,8 +88,9 @@ def _get_xcats_used(ops: dict) -> Tuple[List[str], List[str]]:
             singles_used += [s for s in op_list if re.match("^i", s)]
 
     single_xcats = [x[5:] for x in singles_used]
+    single_cids = [x[1:4] for x in single_xcats]
     all_xcats_used = xcats_used + single_xcats
-    return all_xcats_used, singles_used
+    return all_xcats_used, singles_used, single_cids
 
 
 def panel_calculator(
@@ -166,7 +167,7 @@ def panel_calculator(
 
     # C. Check if all required categories are in the dataframe.
 
-    all_xcats_used, singles_used = _get_xcats_used(ops)
+    all_xcats_used, singles_used, single_cids = _get_xcats_used(ops)
 
     new_xcats = list(ops.keys())
     old_xcats_used = list(set(all_xcats_used) - set(new_xcats))
@@ -179,12 +180,15 @@ def panel_calculator(
         if new_xcats == all_xcats_used:
             old_xcats_used = new_xcats
 
+    # If any of the elements of single_cids are not in cids, add them to cids.
+    cids_used = cids + list(set(single_cids) - set(cids))
+
     # D. Reduce dataframe with intersection requirement.
 
     dfx = reduce_df(
         df,
         xcats=old_xcats_used,
-        cids=cids,
+        cids=cids_used,
         start=start,
         end=end,
         blacklist=blacklist,

--- a/macrosynergy/panel/panel_calculator.py
+++ b/macrosynergy/panel/panel_calculator.py
@@ -183,9 +183,6 @@ def panel_calculator(
     # If any of the elements of single_cids are not in cids, add them to cids.
     cids_used = cids + list(set(single_cids) - set(cids))
 
-    if np.all(cidx == single_cids):
-        cidx = cids
-
     # D. Reduce dataframe with intersection requirement.
 
     dfx = reduce_df(
@@ -198,6 +195,9 @@ def panel_calculator(
         intersect=False,
     )
     cidx = np.sort(dfx["cid"].unique())
+
+    if np.all(cidx == single_cids):
+        cidx = cids
 
     # E. Create all required wide dataframes with category names.
 

--- a/macrosynergy/panel/panel_calculator.py
+++ b/macrosynergy/panel/panel_calculator.py
@@ -179,6 +179,9 @@ def panel_calculator(
     # If any of the elements of single_cids are not in cids, add them to cids.
     cids_used = list(set(single_cids + cids))
 
+    if np.all(cidx == single_cids):
+        cidx = cids
+
     # D. Reduce dataframe with intersection requirement.
 
     dfx = reduce_df(

--- a/macrosynergy/panel/panel_calculator.py
+++ b/macrosynergy/panel/panel_calculator.py
@@ -88,7 +88,7 @@ def _get_xcats_used(ops: dict) -> Tuple[List[str], List[str]]:
             singles_used += [s for s in op_list if re.match("^i", s)]
 
     single_xcats = [x[5:] for x in singles_used]
-    single_cids = [x[1:4] for x in single_xcats]
+    single_cids = [x[1:4] for x in singles_used]
     all_xcats_used = xcats_used + single_xcats
     return all_xcats_used, singles_used, single_cids
 

--- a/macrosynergy/panel/panel_calculator.py
+++ b/macrosynergy/panel/panel_calculator.py
@@ -177,7 +177,7 @@ def panel_calculator(
         raise ValueError(f"Missing categories: {missing}.")
 
     # If any of the elements of single_cids are not in cids, add them to cids.
-    cids_used = list(set(single_cids) + set(cids))
+    cids_used = list(set(single_cids + cids))
 
     # D. Reduce dataframe with intersection requirement.
 

--- a/macrosynergy/panel/panel_calculator.py
+++ b/macrosynergy/panel/panel_calculator.py
@@ -191,8 +191,9 @@ def panel_calculator(
         intersect=False,
     )
 
-    if np.all(cidx == single_cids):
-        cidx = cids
+    if len(cidx) == len(single_cids):
+        if np.all(cidx == single_cids):
+            cidx = cids
 
     # E. Create all required wide dataframes with category names.
 

--- a/macrosynergy/panel/panel_calculator.py
+++ b/macrosynergy/panel/panel_calculator.py
@@ -179,9 +179,6 @@ def panel_calculator(
     # If any of the elements of single_cids are not in cids, add them to cids.
     cids_used = list(set(single_cids + cids))
 
-    if np.all(cidx == single_cids):
-        cidx = cids
-
     # D. Reduce dataframe with intersection requirement.
 
     dfx = reduce_df(
@@ -193,6 +190,9 @@ def panel_calculator(
         blacklist=blacklist,
         intersect=False,
     )
+
+    if np.all(cidx == single_cids):
+        cidx = cids
 
     # E. Create all required wide dataframes with category names.
 


### PR DESCRIPTION
Please look over and check logic, not entirely sure if this is fully correct.

Idea of the bugfix is that when someone specifies: 

```
cidx = ['DEM', 'ESP', 'FRF', 'ITL']
calcs = [f"RIR_NSA = iEUR_RIR_NSA"]
dfa = msp.panel_calculator(dfx, calcs=calcs, cids=cidx)
```

and only EUR_RIR_NSA is in the dataframe then as of right now the intention should be to create 4 new expressions called DEM_RIR_NSA, ESP_RIR_NSA, etc... with the same values as EUR_RIR_NSA. However upon reduce_df it would get an empty df and hence throw an error. I've changed the logic of how cids are calculated so when reduce_df is called it includes the specific cids specified in the calculation as well as the cids specified in the arguments of panel calculator.

However after reducing the dataframe it then specifies the cids "cidx" to be used in calculating the new panel. The original code was just this:

`cidx = np.sort(dfx["cid"].unique())`

I added this:

`if len(cidx) == len(single_cids):
        if np.all(cidx == single_cids):
            cidx = cids`

This logic definitely holds for the above example, however I'm not sure whether it holds for an example where multiple specific cids are specified in the calculation.



