### PR TITLE
Feature: Parameter formatting in docstrings

### DIFF
--- a/docs/format_docstrings.py
+++ b/docs/format_docstrings.py
@@ -1,0 +1,64 @@
+import argparse
+import glob
+
+DOCTYPES = ["param", "return", "raises"]
+
+
+def format_docstring(docstr: str):
+    """
+    Formats the docstring to remove parameter types and return types from the docstring.
+    :param <str> docstr: The docstring to format.
+    :return <str>: The formatted docstring.
+    """
+    # assert that it starts with one of the DOCTYPES
+    if not docstr.strip().startswith(tuple([f":{x}" for x in DOCTYPES])):
+        return docstr
+
+    first_colon: int = docstr.find(":")
+    second_colon: str = docstr.find(":", first_colon)
+
+    # look for first "<"
+    start = docstr.find("<") - 1
+    # find the next first instance of ">"
+    end = docstr.find(">", start)
+
+    # remove the substring from the docstring
+    docstr = docstr[:start] + docstr[end + 1 :]
+    return docstr
+
+
+def format_python_file(file_path: str):
+    """
+    Formats the docstrings in the given python file.
+    :param <str> file_path: The path to the python file.
+    """
+    # open the file
+    with open(file_path, "r", encoding="utf8") as file:
+        data = file.readlines()
+
+    with open(file_path, "w", encoding="utf8") as file:
+        for line in data:
+            file.write(format_docstring(line))
+
+
+def format_python_files(root_dir: str):
+    """
+    Formats the docstrings in all python files in the given directory.
+    :param <str> root_dir: The root directory to search for python files.
+    """
+    for file in glob.glob(f"{root_dir}/**/*.py", recursive=True):
+        format_python_file(file)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Format docstrings in python files.")
+    parser.add_argument(
+        "-d",
+        "--dir",
+        type=str,
+        help="The root directory to search for python files.",
+        required=True,
+    )
+    args = parser.parse_args()
+
+    format_python_files(args.dir)

--- a/docs/format_docstrings.py
+++ b/docs/format_docstrings.py
@@ -1,8 +1,6 @@
 import argparse
 import glob
 
-DOCTYPES = ["param", "return", "raises"]
-
 
 def format_docstring(docstr: str):
     """
@@ -10,8 +8,8 @@ def format_docstring(docstr: str):
     :param <str> docstr: The docstring to format.
     :return <str>: The formatted docstring.
     """
-    # assert that it starts with one of the DOCTYPES
-    if not docstr.strip().startswith(tuple([f":{x}" for x in DOCTYPES])):
+    # only works with param; not with return, raises, etc.
+    if not docstr.strip().startswith(":param"):
         return docstr
 
     first_colon: int = docstr.find(":")

--- a/docs/gen.py
+++ b/docs/gen.py
@@ -77,6 +77,10 @@ def fetch_release_notes(release_notes_file: str):
     os.system(f'python ./docs/release_notes.py -o "{release_notes_file}"')
 
 
+def format_docstrings(package_dir: str):
+    os.system(f'python ./docs/format_docstrings.py -d "{package_dir}"')
+
+
 def generate_rst_files(
     rst_output_dir: str = RST_OUTPUT_DIR,
     temp_rst_dir: str = TEMP_RST_DIR,
@@ -225,6 +229,7 @@ def driver(
     # generate release notes
     rnl_abs_path = OPx.abspath(OPx.normpath(OPx.join(rst_output_dir, release_notes_md)))
     fetch_release_notes(release_notes_file=rnl_abs_path)
+    format_docstrings(package_dir=f"./{package_name}")  # format the docstrings
     copy_subpackage_readmes(rst_output_dir=rst_output_dir, package=package_name)
     make_docs(docs_dir=PACKAGE_DOCS_DIR)
 

--- a/macrosynergy/learning/metrics.py
+++ b/macrosynergy/learning/metrics.py
@@ -20,7 +20,7 @@ from typing import Union
 
 
 def panel_significance_probability(
-    y_true: pd.Series, y_pred: Union[pd.Series, np.array]
+    y_true: pd.Series, y_pred: Union[pd.Series, np.ndarray]
 ) -> float:
     """
     Function to create a linear mixed effects model between the ground truth returns and
@@ -32,7 +32,7 @@ def panel_significance_probability(
 
     :param <pd.Series> y_true: Pandas series of ground truth labels. These must be
         multi-indexed by cross-section and date. The dates must be in datetime format.
-    :param <Union[pd.Series,np.array]> y_pred: Either a pandas series or numpy array
+    :param <Union[pd.Series,np.ndarray]> y_pred: Either a pandas series or numpy array
         of predicted targets. This must have the same length as y_true.
 
     :return <float> significance_prob: 1 - p-value of the regression slope parameter,
@@ -70,13 +70,13 @@ def panel_significance_probability(
     return 1 - pval
 
 
-def regression_accuracy(y_true: pd.Series, y_pred: Union[pd.Series, np.array]) -> float:
+def regression_accuracy(y_true: pd.Series, y_pred: Union[pd.Series, np.ndarray]) -> float:
     """
     Function to return the accuracy between the signs of the predictions and targets.
 
     :param <pd.Series> y_true: Pandas series of ground truth labels. These must be
         multi-indexed by cross-section and date. The dates must be in datetime format.
-    :param <Union[pd.Series,np.array]> y_pred: Either a pandas series or numpy array
+    :param <Union[pd.Series,np.ndarray]> y_pred: Either a pandas series or numpy array
         of predicted targets. This must have the same length as y_true.
 
     :return <float>: Accuracy between the signs of the predictions and targets.
@@ -99,7 +99,7 @@ def regression_accuracy(y_true: pd.Series, y_pred: Union[pd.Series, np.array]) -
 
 
 def regression_balanced_accuracy(
-    y_true: pd.Series, y_pred: Union[pd.Series, np.array]
+    y_true: pd.Series, y_pred: Union[pd.Series, np.ndarray]
 ) -> float:
     """
     Function to return the balanced accuracy between the signs
@@ -107,7 +107,7 @@ def regression_balanced_accuracy(
 
     :param <pd.Series> y_true: Pandas series of ground truth labels. These must be
         multi-indexed by cross-section and date. The dates must be in datetime format.
-    :param <Union[pd.Series,np.array]> y_pred: Either a pandas series or numpy array
+    :param <Union[pd.Series,np.ndarray]> y_pred: Either a pandas series or numpy array
         of predicted targets. This must have the same length as y_true.
 
     :return <float>: Balanced accuracy between the signs of the predictions and targets.
@@ -129,14 +129,14 @@ def regression_balanced_accuracy(
     return balanced_accuracy_score(y_true < 0, y_pred < 0)
 
 
-def sharpe_ratio(y_true: pd.Series, y_pred: Union[pd.Series, np.array]) -> float:
+def sharpe_ratio(y_true: pd.Series, y_pred: Union[pd.Series, np.ndarray]) -> float:
     """
     Function to return a Sharpe ratio for a strategy where we go long if the predictions
     are positive and short if the predictions are negative.
 
     :param <pd.Series> y_true: Pandas series of ground truth labels. These must be
         multi-indexed by cross-section and date. The dates must be in datetime format.
-    :param <Union[pd.Series,np.array]> y_pred: Either a pandas series or numpy array
+    :param <Union[pd.Series,np.ndarray]> y_pred: Either a pandas series or numpy array
         of predicted targets. This must have the same length as y_true.
 
     :return <float>: Sharpe ratio for the binary strategy.
@@ -170,14 +170,14 @@ def sharpe_ratio(y_true: pd.Series, y_pred: Union[pd.Series, np.array]) -> float
     return sharpe_ratio
 
 
-def sortino_ratio(y_true: pd.Series, y_pred: Union[pd.Series, np.array]) -> float:
+def sortino_ratio(y_true: pd.Series, y_pred: Union[pd.Series, np.ndarray]) -> float:
     """
     Function to return a Sortino ratio for a strategy where we go long if the predictions
     are positive and short if the predictions are negative.
 
     :param <pd.Series> y_true: Pandas series of ground truth labels. These must be
         multi-indexed by cross-section and date. The dates must be in datetime format.
-    :param <Union[pd.Series,np.array]> y_pred: Either a pandas series or numpy array
+    :param <Union[pd.Series,np.ndarray]> y_pred: Either a pandas series or numpy array
         of predicted targets. This must have the same length as y_true.
 
     :return <float>: Sortino ratio for the binary strategy.

--- a/macrosynergy/learning/panel_time_series_split.py
+++ b/macrosynergy/learning/panel_time_series_split.py
@@ -137,7 +137,7 @@ class BasePanelSplit(BaseCrossValidator):
         """
         sns.set_theme(style="whitegrid", palette="colorblind")
         Xy: pd.DataFrame = pd.concat([X, y], axis=1).dropna()
-        cross_sections: np.array[str] = np.array(
+        cross_sections: np.ndarray[str] = np.array(
             sorted(Xy.index.get_level_values(0).unique())
         )
         real_dates = Xy.index.get_level_values(1).unique().sort_values()
@@ -145,7 +145,7 @@ class BasePanelSplit(BaseCrossValidator):
         freq_est = pd.infer_freq(real_dates)
         freq_offset = pd.tseries.frequencies.to_offset(freq_est)
 
-        splits: List[Tuple[np.array[int], np.array[int]]] = list(self.split(X, y))
+        splits: List[Tuple[np.ndarray[int], np.ndarray[int]]] = list(self.split(X, y))
 
         split_idxs: List[int] = (
             [0, len(splits) // 4, len(splits) // 2, 3 * len(splits) // 4, -1]
@@ -252,7 +252,7 @@ class ExpandingKFoldPanelSplit(BasePanelSplit):
 
     def split(
         self, X: pd.DataFrame, y: pd.DataFrame, groups=None
-    ) -> Iterator[Tuple[np.array, np.array]]:
+    ) -> Iterator[Tuple[np.ndarray, np.ndarray]]:
         """
         Method that produces pairs of training and test indices as intended by the
         ExpandingKFoldPanelSplit class. Wide format Pandas (panel) dataframes are 
@@ -266,7 +266,7 @@ class ExpandingKFoldPanelSplit(BasePanelSplit):
             (cross-section, date). The dates must be in datetime format.
         :param <int> groups: Always ignored, exists for compatibility with scikit-learn.
 
-        :return <Iterator[Tuple[np.array[int],np.array[int]]]> splits:
+        :return <Iterator[Tuple[np.ndarray[int],np.ndarray[int]]]> splits:
             iterator of (train,test) indices.
         """
         self.train_indices: List[int] = []
@@ -320,7 +320,7 @@ class RollingKFoldPanelSplit(BasePanelSplit):
 
     def split(
         self, X: pd.DataFrame, y: pd.DataFrame, groups=None
-    ) -> Iterator[Tuple[np.array, np.array]]:
+    ) -> Iterator[Tuple[np.ndarray, np.ndarray]]:
         """
         Method that produces pairs of training and test indices as intended by the
         RollingKFoldPanelSplit class. Wide format Pandas (panel) dataframes are expected,
@@ -334,7 +334,7 @@ class RollingKFoldPanelSplit(BasePanelSplit):
             (cross-section, date). The dates must be in datetime format.
         :param <int> groups: Always ignored, exists for compatibility with scikit-learn.
 
-        :return <Iterator[Tuple[np.array[int],np.array[int]]]> splits: iterator of 
+        :return <Iterator[Tuple[np.ndarray[int],np.ndarray[int]]]> splits: iterator of 
             (train,test) indices.
         """
         self._validate_Xy(X, y)
@@ -521,7 +521,7 @@ class ExpandingIncrementPanelSplit(BasePanelSplit):
 
     def split(
         self, X: pd.DataFrame, y: pd.DataFrame, groups=None
-    ) -> Iterator[Tuple[np.array, np.array]]:
+    ) -> Iterator[Tuple[np.ndarray, np.ndarray]]:
         """
         Method that produces pairs of training and test indices as intended by the
         ExpandingIncrementPanelSplit class. Wide format Pandas (panel) dataframes are 
@@ -535,7 +535,7 @@ class ExpandingIncrementPanelSplit(BasePanelSplit):
             (cross-section, date). The dates must be in datetime format.
         :param <int> groups: Always ignored, exists for compatibility with scikit-learn.
 
-        :return <Iterator[Tuple[np.array[int],np.array[int]]]> splits: iterator of 
+        :return <Iterator[Tuple[np.ndarray[int],np.ndarray[int]]]> splits: iterator of 
             (train,test) indices.
         """
         train_indices: List[int] = []
@@ -543,7 +543,7 @@ class ExpandingIncrementPanelSplit(BasePanelSplit):
 
         splits, Xy = self._determine_unique_time_splits(X, y)
 
-        train_splits: List[np.array] = [
+        train_splits: List[np.ndarray] = [
             splits[0] if not self.max_periods else splits[0][-self.max_periods :]
         ]
         for i in range(1, self.n_splits):

--- a/macrosynergy/learning/signal_optimizer.py
+++ b/macrosynergy/learning/signal_optimizer.py
@@ -338,7 +338,7 @@ class SignalOptimizer:
                 "The keys in the hyperparameter grid must match those in the models "
                 "dictionary."
             )
-        if not isinstance(min_cids, int): 
+        if not isinstance(min_cids, int):
             raise TypeError("The min_cids argument must be an integer.")
         if min_cids < 1:
             raise ValueError("The min_cids argument must be greater than zero.")
@@ -478,7 +478,7 @@ class SignalOptimizer:
 
     def _worker(
         self,
-        train_idx: np.ndarrayay,
+        train_idx: np.ndarray,
         test_idx: np.ndarray,
         name: str,
         models: Dict[str, Union[BaseEstimator, Pipeline]],
@@ -676,7 +676,8 @@ class SignalOptimizer:
         if cap > 20:
             warnings.warn(
                 f"The maximum number of models to display is 20. The cap has been set to "
-                "20.", RuntimeWarning,
+                "20.",
+                RuntimeWarning,
             )
             cap = 20
 
@@ -701,10 +702,12 @@ class SignalOptimizer:
             by="real_date"
         )
         chosen_models["model_hparam_id"] = chosen_models.apply(
-            lambda row: row["model_type"]
-            if row["hparams"] == {}
-            else f"{row['model_type']}_"
-            + "_".join([f"{key}={value}" for key, value in row["hparams"].items()]),
+            lambda row: (
+                row["model_type"]
+                if row["hparams"] == {}
+                else f"{row['model_type']}_"
+                + "_".join([f"{key}={value}" for key, value in row["hparams"].items()])
+            ),
             axis=1,
         )
         chosen_models["real_date"] = chosen_models["real_date"].dt.date

--- a/macrosynergy/learning/signal_optimizer.py
+++ b/macrosynergy/learning/signal_optimizer.py
@@ -478,8 +478,8 @@ class SignalOptimizer:
 
     def _worker(
         self,
-        train_idx: np.array,
-        test_idx: np.array,
+        train_idx: np.ndarrayay,
+        test_idx: np.ndarray,
         name: str,
         models: Dict[str, Union[BaseEstimator, Pipeline]],
         metric: Callable,
@@ -492,8 +492,8 @@ class SignalOptimizer:
         Private helper function to run the grid search for a single (train, test) pair
         and a collection of models. It is used to parallelise the pipeline.
 
-        :param <np.array> train_idx: Array of indices corresponding to the training set.
-        :param <np.array> test_idx: Array of indices corresponding to the test set.
+        :param <np.ndarray> train_idx: Array of indices corresponding to the training set.
+        :param <np.ndarray> test_idx: Array of indices corresponding to the test set.
         :param <str> name: Name of the prediction model.
         :param <Dict[str, Union[BaseEstimator,Pipeline]]> models: dictionary of sklearn
             predictors.

--- a/macrosynergy/management/simulate/simulate_quantamental_data.py
+++ b/macrosynergy/management/simulate/simulate_quantamental_data.py
@@ -22,7 +22,7 @@ def simulate_ar(nobs: int, mean: float = 0, sd_mult: float = 1, ar_coef: float =
         This affects non-zero means.
     :param <float> ar_coef: autoregression coefficient (between 0 and 1): default is 0.75.
 
-    :return <np.array>: autocorrelated data series.
+    :return <np.ndarray>: autocorrelated data series.
     """
 
     # Define relative parameters for creating an AR process.

--- a/tests/simulate.py
+++ b/tests/simulate.py
@@ -19,7 +19,7 @@ def simulate_ar(nobs: int, mean: float = 0, sd_mult: float = 1, ar_coef: float =
     :param <float> ar_coef: auto-regression coefficient (between 0 and 1): default is
         0.75.
 
-    return <np.array>: auto-correlated data series.
+    return <np.ndarray>: auto-correlated data series.
     """
 
     ar_params = np.r_[1, -ar_coef]


### PR DESCRIPTION
The docs generation process uses `sphinx-autodoc-typehints`.
However, our docstring format isn't directly compatible with it.
This pull request adds a script that formats the docstrings in the temporary build directory for the docs before callng the build.