### PR TITLE
Setting out principles for portfolio volatility estimates

### DIFF
--- a/macrosynergy/pnl/historic_portfolio_volatility.py
+++ b/macrosynergy/pnl/historic_portfolio_volatility.py
@@ -2,7 +2,7 @@
 Module for calculating the historic portfolio volatility for a given strategy.
 """
 
-from typing import List, Optional, Callable
+from typing import List, Optional, Callable, Tuple
 import pandas as pd
 import numpy as np
 from macrosynergy.panel.historic_vol import expo_std, flat_std, expo_weights
@@ -15,7 +15,6 @@ from macrosynergy.management.utils import (
     ticker_df_to_qdf,
     get_eops,
     get_cid,
-    get_xcat,
 )
 
 RETURN_SERIES_XCAT = "_PNL_USD1S_ASD"
@@ -67,62 +66,15 @@ def _univariate_volatility(
     return univariate_vol
 
 
-def _rolling_window_calc(
-    real_date_pdt: pd.Timestamp,
-    ticker_df: pd.DataFrame,
-    lback_periods: int,
-    nan_tolerance: float,
-    roll_func: Callable,
-    remove_zeros: bool,
-    rstring: str,
-    sname: str,
-    weights: Optional[np.ndarray] = None,
-):
-    """
-    Runs the volatility calculation for a given row of the dataframe.
-    It needs access to the full 'ticker_df' dataframe to make the lookback possible.
-
-    :param <pd.Series> row: a row of the dataframe, which contains the index, the
-        'real_date' and the 'ticker' of the current calculation.
-    :param <pd.DataFrame> ticker_df: the wide dataframe of all the tickers in the strategy.
-    :param <int> lback_periods: the number of periods to use for the lookback period
-        of the volatility-targeting method. Default is 21.
-    :param <float> nan_tolerance: maximum ratio of NaNs to non-NaNs in a lookback window,
-        if exceeded the resulting volatility is set to NaN. Default is 0.25.
-    :param <callable> roll_func: the function to use for the rolling window calculation.
-        The function must have a signature of (np.ndarray, *, remove_zeros: bool) -> float.
-        See `expo_std` and `flat_std` for examples.
-    :param <bool> remove_zeros: removes zeroes as invalid entries and shortens the
-        effective window.
-    :param <np.ndarray> weights: array of exponential weights for each period in the
-        lookback window. Default is None, which means that the weights are equal.
-    """
-    # use end=row["real_date"] when using apply
-    df_wide: pd.DataFrame = ticker_df.loc[
-        ticker_df.index.isin(pd.bdate_range(end=real_date_pdt, periods=lback_periods))
-    ]
-
-    ## Calculate univariate volatility
-    df_cs = df_wide.loc[:, df_wide.columns.str.endswith(f"_CSIG_{sname}")]
-
-    # univariate_vol: pd.Series = _univariate_volatility(...)
-
-    # multiply contract signals by the returns
-    for _cs in df_cs.columns.tolist():
-        asset = _cs.replace(f"_CSIG_{sname}", "")
-        df_cs.loc[:, _cs] = df_cs[_cs] * df_wide[f"{asset}_{rstring}"]
-        # already ends in _XR
-
-    vcv = df_cs.cov()
-    total_variance: float = vcv.to_numpy().sum()
-    period_volatility: float = np.sqrt(total_variance)
-    annualized_vol: pd.Series = period_volatility * np.sqrt(252)
-
-    return annualized_vol
+def _estimate_variance_covariance(pivot: pd.DataFrame) -> pd.DataFrame:
+    # TODO add complexity of weighting and estimation methods
+    vcv = pivot.cov()
+    return vcv
 
 
 def _hist_vol(
-    df: pd.DataFrame,
+    pivot_signals: pd.DataFrame,
+    pivot_returns: pd.DataFrame,
     sname: str,
     rstring: str,
     est_freq: str = "m",
@@ -136,8 +88,8 @@ def _hist_vol(
     Calculates historic volatility for a given strategy. It assumes that the dataframe
     is composed solely of the relevant signals and returns for the strategy.
 
-    :param <pd.DataFrame> df:  standardized JPMaQS DataFrame with the necessary
-        columns: 'cid', 'xcat', 'real_date' and 'value'.
+    :param <pd.DataFrame> pivot_signals: the pivot table of the contract signals.
+    :param <pd.DataFrame> pivot_returns: the pivot table of the contract returns.
     :param <str> est_freq: the frequency of the volatility estimation. Default is 'm'
         for monthly. Alternatives are 'w' for business weekly, 'd' for daily, and 'q'
         for quarterly. Estimations are conducted for the end of the period.
@@ -154,15 +106,19 @@ def _hist_vol(
         effective window.
     """
 
+    # TODO split into steps:
+    # [1] Find rebalance dates.
+    # [2] Calculate variance-covariance matrix for each rebalance date.
+    # [3] Calculate variance of portfolio for each rebalance date weighted by signal.
+
     lback_meth = lback_meth.lower()
-    if not lback_meth in ["ma", "xma"]:
+    if lback_meth not in ["ma", "xma"]:
         raise NotImplementedError(
             f"`lback_meth` must be 'ma' or 'xma'; got {lback_meth}"
         )
 
-    df_wide: pd.DataFrame = qdf_to_ticker_df(df=df)
-
-    df_wide = df_wide[sorted(df_wide.columns)]  # Sort columns to keep debugging easier
+    # df_wide: pd.DataFrame = qdf_to_ticker_df(df=df)
+    # df_wide = df_wide[sorted(df_wide.columns)]  # Sort columns to keep debugging easier
 
     # NOTE: `get_eops` helps identify the dates for which the volatility calculation
     # will be performed. This is done by identifying the last date of each cycle.
@@ -171,69 +127,74 @@ def _hist_vol(
     # used here as well.
 
     trigger_indices = get_eops(
-        dates=df_wide.index,
+        dates=pivot_signals.index,
         freq=est_freq,
     )
-    return_series = f"{sname}{RETURN_SERIES_XCAT}"
-    dfw_calc: pd.DataFrame = pd.DataFrame(
-        index=trigger_indices, columns=[return_series], dtype=float
-    )
 
-    expo_weights_arr: Optional[np.ndarray] = None
-    if lback_meth == "xma":
-        expo_weights_arr: np.ndarray = expo_weights(
-            lback_periods=lback_periods,
-            half_life=half_life,
-        )
+    
+    # dfw_calc: pd.DataFrame = pd.DataFrame(
+    #     index=trigger_indices, columns=[return_series], dtype=float
+    # )
 
-    _args: dict = dict(remove_zeros=remove_zeros, rstring=rstring, sname=sname)
+    # expo_weights_arr: Optional[np.ndarray] = None
+    # if lback_meth == "xma":
+    #     expo_weights_arr: np.ndarray = expo_weights(
+    #         lback_periods=lback_periods,
+    #         half_life=half_life,
+    #     )
 
-    if est_freq == "d":
-        if lback_meth == "xma":
-            _args.update(dict(func=expo_std, w=expo_weights_arr))
-        elif lback_meth == "ma":
-            _args.update(dict(func=flat_std))
+    # _args: dict = dict(remove_zeros=remove_zeros, rstring=rstring, sname=sname)
 
-    else:
-        _args.update(
-            dict(
-                lback_periods=lback_periods,
-                nan_tolerance=nan_tolerance,
-            )
-        )
-        if lback_meth == "xma":
-            _args.update(dict(roll_func=expo_std, w=expo_weights_arr))
-        elif lback_meth == "ma":
-            _args.update(dict(roll_func=flat_std))
+    # if est_freq == "d":
+    #     if lback_meth == "xma":
+    #         _args.update(dict(func=expo_std, w=expo_weights_arr))
+    #     elif lback_meth == "ma":
+    #         _args.update(dict(func=flat_std))
 
-    if est_freq == "d":
-        # dfw_calc = df_wide.rolling(lback_periods).agg(**_args)
-        raise NotImplementedError("Daily volatility not implemented yet.")
-        # TODO: Contradiction to other condition above
+    # else:
+    #     _args.update(
+    #         dict(
+    #             lback_periods=lback_periods,
+    #             nan_tolerance=nan_tolerance,
+    #         )
+    #     )
+    #     if lback_meth == "xma":
+    #         _args.update(dict(roll_func=expo_std, w=expo_weights_arr))
+    #     elif lback_meth == "ma":
+    #         _args.update(dict(roll_func=flat_std))
 
-    else:
-        for r_date in trigger_indices:
-            dfw_calc.loc[r_date, :] = _rolling_window_calc(
-                real_date_pdt=r_date,
-                ticker_df=df_wide,
-                **_args,
-            )
+    # if est_freq == "d":
+    #     # dfw_calc = df_wide.rolling(lback_periods).agg(**_args)
+    #     raise NotImplementedError("Daily volatility not implemented yet.")
+    #     # TODO: Contradiction to other condition above
 
-    fills = {"d": 1, "w": 5, "m": 24, "q": 64}
-    dfw_calc = dfw_calc.reindex(df_wide.index).ffill(limit=fills[est_freq])
+    # else:
+    #     for r_date in trigger_indices:
+    #         dfw_calc.loc[r_date, :] = _rolling_window_calc(
+    #             real_date_pdt=r_date,
+    #             ticker_df=df_wide,
+    #             **_args,
+    #         )
 
-    return ticker_df_to_qdf(df=dfw_calc)
+    # fills = {"d": 1, "w": 5, "m": 24, "q": 64}
+    # dfw_calc = dfw_calc.reindex(df_wide.index).ffill(limit=fills[est_freq])
 
 
-# dfw_calc.loc[trigger_indices, :] = (
-#     dfw_calc.loc[trigger_indices, :]
-#     .reset_index()
-#     .apply(
-#         lambda row: _rolling_window_calc(row=row, ticker_df=df_wide, **_args),
-#         axis=1,
-#     )
-#     .set_index(dfw_calc.index)
-# )
+    # TODO get the correct rebalance dates
+    # TODO allow for multiple estimation frequency
+    list_vcv: List[Tuple[pd.Timestamp, pd.DataFrame, pd.Series]] = [
+        (trigger_date, _estimate_variance_covariance(pivot=pivot_returns.loc[pivot_returns.index <= trigger_date].iloc[-lback_periods:]), pivot_signals.loc[trigger_date, :])
+        for trigger_date in trigger_indices
+    ]
+
+    list_pvol = [(tt, signal.T.dot(vcv).dot(signal)) for tt, vcv, signal in list_vcv]
+    portfolio_return_name = f"{sname}{RETURN_SERIES_XCAT}"
+    df_out = pd.DataFrame(list_pvol, columns=["real_date", portfolio_return_name]).set_index("real_date")
+
+    # Annualised standard deviation (ASD)
+    df_out[portfolio_return_name] = np.sqrt(df_out[portfolio_return_name]) * np.sqrt(252)
+
+    return ticker_df_to_qdf(df=df_out)
 
 
 def historic_portfolio_vol(
@@ -273,8 +234,8 @@ def historic_portfolio_vol(
         "xma", for exponential moving average.
     :param <str> rstring: a general string of the return category. This identifies
         the contract returns that are required for the volatility-targeting method, based
-        on the category identifier format <cid>_<ctype><rstring>_<rstring>_CSIG_<sname>
-        in accordance with JPMaQS conventions. Default is 'XR'.
+        on the category identifier format <cid>_<ctype><rstring> in accordance with
+        JPMaQS conventions. Default is 'XR'.
     :param <str> start: the start date of the data. Default is None, which means that
         the start date is taken from the dataframe.
     :param <str> end: the end date of the data. Default is None, which means that
@@ -355,7 +316,7 @@ def historic_portfolio_vol(
         ):
             raise ValueError(f"Contract identifier `{contx}` not in dataframe.")
 
-    if not all([f"{contx}_{rstring}" in u_tickers for contx in fids]):
+    if not all([f"{contx}{rstring}" in u_tickers for contx in fids]):
         missing_tickers = [
             f"{contx}_{rstring}"
             for contx in fids
@@ -365,26 +326,25 @@ def historic_portfolio_vol(
             f"The dataframe is missing the following return series: {missing_tickers}"
         )
 
-    ## Filter DF and select CSIGs and XR_XRs
-    _cfids = list(set(get_cid(ticker=fids)))
-
+    ## Filter DF and select CSIGs and XR
     filt_csigs: List[str] = [tx for tx in u_tickers if tx.endswith(f"_CSIG_{sname}")]
 
     filt_xrs: List[str] = [
-        tx for tx in u_tickers if tx.endswith(f"{rstring}_{rstring}")
+        tx for tx in u_tickers if tx.endswith(f"{rstring}")
     ]
 
-    df: pd.DataFrame = df.loc[df["ticker"].isin(filt_csigs + filt_xrs)]
+    # df: pd.DataFrame = df.loc[df["ticker"].isin(filt_csigs + filt_xrs)]
+    df["fid"] = df["cid"] + "_" + df["xcat"].str.split("_").map(lambda x: x[0][:-2] if x[0].endswith("XR") else x[0])
+    pivot_signals: pd.DataFrame = df.loc[df.ticker.isin(filt_csigs)].pivot(index="real_date", columns="fid", values="value")
+    pivot_returns: pd.DataFrame = df.loc[df.ticker.isin(filt_xrs)].pivot(index="real_date", columns="fid", values="value")
+    assert set(pivot_signals.columns) == set(pivot_returns.columns)
 
-    if df.empty:
-        raise ValueError(
-            "No data available for the given strategy and contract identifiers."
-            "Please check the inputs. \n"
-            f"Strategy: {sname}\nContract identifiers: {fids} \n"
-        )
+    # TODO the same?
+    assert all(pivot_signals.columns == pivot_returns.columns)
 
     hist_port_vol: pd.DataFrame = _hist_vol(
-        df=df,
+        pivot_returns=pivot_returns,
+        pivot_signals=pivot_signals,
         sname=sname,
         rstring=rstring,
         est_freq=est_freq,
@@ -418,11 +378,11 @@ if __name__ == "__main__":
     )
 
     df.loc[(df["cid"] == "USD") & (df["xcat"] == "SIG"), "value"] = 1.0
-    ctypes = ["FXXR", "EQXR"]
+    ctypes = ["FX", "EQ"]
     cscales = [1.0, 0.5]
     csigns = [1, -1]
 
-    hbasket = ["GBP_FXXR", "EUR_FXXR"]
+    hbasket = ["GBP_FX", "EUR_FX"]
     hscales = [0.7, 0.3]
 
     df_cs: pd.DataFrame = contract_signals(
@@ -439,39 +399,39 @@ if __name__ == "__main__":
     )
 
     ## `df_cs` looks like:
-    #       real_date  cid               xcat         value
-    # 0     2000-01-03  AUD  EQXR_CSIG_mySTRAT     -0.009126
-    # 1     2000-01-03  AUD  FXXR_CSIG_mySTRAT      0.018252
-    # 2     2000-01-03  CAD  EQXR_CSIG_mySTRAT    -25.028669
-    # 3     2000-01-03  CAD  FXXR_CSIG_mySTRAT     50.057339
-    # 4     2000-01-03  EUR  EQXR_CSIG_mySTRAT    -50.000000
-    # ...          ...  ...                ...           ...
-    # 43827 2020-12-31  CAD  FXXR_CSIG_mySTRAT     50.000000
-    # 43828 2020-12-31  EUR  EQXR_CSIG_mySTRAT    -49.926954
-    # 43829 2020-12-31  EUR  FXXR_CSIG_mySTRAT   9088.903408
-    # 43830 2020-12-31  GBP  EQXR_CSIG_mySTRAT    -25.000000
-    # 43831 2020-12-31  GBP  FXXR_CSIG_mySTRAT  21024.448833
+    #       real_date  cid              xcat         value
+    # 0     2000-01-03  AUD  EQ_CSIG_mySTRAT     -0.009126
+    # 1     2000-01-03  AUD  FX_CSIG_mySTRAT      0.018252
+    # 2     2000-01-03  CAD  EQ_CSIG_mySTRAT    -25.028669
+    # 3     2000-01-03  CAD  FX_CSIG_mySTRAT     50.057339
+    # 4     2000-01-03  EUR  EQ_CSIG_mySTRAT    -50.000000
+    # ...          ...  ...              ...           ...
+    # 43827 2020-12-31  CAD  FX_CSIG_mySTRAT     50.000000
+    # 43828 2020-12-31  EUR  EQ_CSIG_mySTRAT    -49.926954
+    # 43829 2020-12-31  EUR  FX_CSIG_mySTRAT   9088.903408
+    # 43830 2020-12-31  GBP  EQ_CSIG_mySTRAT    -25.000000
+    # 43831 2020-12-31  GBP  FX_CSIG_mySTRAT  21024.448833
 
     df_xr = make_test_df(
         cids=cids,
-        xcats=["EQXR_XR", "FXXR_XR"],
+        xcats=["EQXR", "FXXR"],
         start=start,
         end=end,
     )
-
+    #   TODO returns need to be daily percent changes, and sensible values...
     ## `df_xr` looks like:
-    #         real_date  cid     xcat       value
-    # 0     2000-01-03  EUR  EQXR_XR  100.000000
-    # 1     2000-01-04  EUR  EQXR_XR   99.853908
-    # 2     2000-01-05  EUR  EQXR_XR   99.707816
-    # 3     2000-01-06  EUR  EQXR_XR   99.561724
-    # 4     2000-01-07  EUR  EQXR_XR   99.415632
-    # ...          ...  ...      ...         ...
-    # 43827 2020-12-25  CAD  FXXR_XR   99.269540
-    # 43828 2020-12-28  CAD  FXXR_XR   99.415632
-    # 43829 2020-12-29  CAD  FXXR_XR   99.561724
-    # 43830 2020-12-30  CAD  FXXR_XR   99.707816
-    # 43831 2020-12-31  CAD  FXXR_XR   99.853908
+    #         real_date  cid xcat       value
+    # 0     2000-01-03  EUR  EQXR  100.000000
+    # 1     2000-01-04  EUR  EQXR   99.853908
+    # 2     2000-01-05  EUR  EQXR   99.707816
+    # 3     2000-01-06  EUR  EQXR   99.561724
+    # 4     2000-01-07  EUR  EQXR   99.415632
+    # ...          ...  ...  ...         ...
+    # 43827 2020-12-25  CAD  FXXR   99.269540
+    # 43828 2020-12-28  CAD  FXXR   99.415632
+    # 43829 2020-12-29  CAD  FXXR   99.561724
+    # 43830 2020-12-30  CAD  FXXR   99.707816
+    # 43831 2020-12-31  CAD  FXXR   99.853908
 
     ...
 
@@ -481,6 +441,7 @@ if __name__ == "__main__":
     fids: List[str] = [f"{cid}_{ctype}" for cid in cids for ctype in ctypes]
     # fids = ['EUR_FXXR', 'EUR_EQXR', 'GBP_FXXR', 'GBP_EQXR', 'AUD_FXXR', 'AUD_EQXR', 'CAD_FXXR', 'CAD_EQXR']
 
+    
     df_vol: pd.DataFrame = historic_portfolio_vol(
         df=dfX,
         sname="mySTRAT",


### PR DESCRIPTION
Simplify calculation and out basic principles for portfolio volatility based on historical variance-covariance of returns and the contract signal weights