### PR TITLE
Bugfix: Fix variable name in `msv.timelines()` function

### DIFF
--- a/macrosynergy/visuals/timelines.py
+++ b/macrosynergy/visuals/timelines.py
@@ -151,7 +151,7 @@ def timelines(
     if xcats is None:
         if xcat_labels:
             raise ValueError("`xcat_labels` requires `xcats` to be defined.")
-        xcats: List[str] = df["xcats"].unique().tolist()
+        xcats: List[str] = df["xcat"].unique().tolist()
 
     if cids is None:
         cids: List[str] = df["cid"].unique().tolist()


### PR DESCRIPTION
This pull request fixes a variable name in the timelines function. The variable name "xcats" was mistakenly used instead of "xcat". This fix ensures that the correct variable name is used, preventing any potential errors or confusion in the code.