### PR TITLE
Bugfix: Revert "Bugfix: `get_eops` - fix `dates=None` behaviour"

### DIFF
--- a/macrosynergy/management/utils/df_utils.py
+++ b/macrosynergy/management/utils/df_utils.py
@@ -16,7 +16,6 @@ import requests
 import requests.compat
 from .core import get_cid, get_xcat, _map_to_business_day_frequency
 
-
 def standardise_dataframe(
     df: pd.DataFrame, verbose: bool = False
 ) -> QuantamentalDataFrame:
@@ -349,7 +348,6 @@ def update_df(df: pd.DataFrame, df_add: pd.DataFrame, xcat_replace: bool = False
         df = update_categories(df, df_add)
 
     return df.reset_index(drop=True)
-
 
 def update_tickers(df: pd.DataFrame, df_add: pd.DataFrame):
     """
@@ -849,9 +847,6 @@ def get_eops(
         raise ValueError(
             "Only one of `dates` or `start_date` and `end_date` must be passed."
         )
-
-    if dates is None:
-        dates = pd.bdate_range(start=start_date, end=end_date)
 
     dts: pd.DataFrame = (
         pd.DataFrame(dates, columns=["real_date"]).apply(pd.to_datetime, axis=1)

--- a/tests/unit/management/test_utils.py
+++ b/tests/unit/management/test_utils.py
@@ -675,7 +675,6 @@ class TestFunctions(unittest.TestCase):
         )
         self.assertEqual(expc_no_cycles, len(test_result_3) - 1)
         # -1 as len(test_result_3) includes the last index
-        set_test_result_3 = set(test_result_3)
 
         test_vals = [
             [pd.Timestamp("2023-01-31"), True],
@@ -687,28 +686,9 @@ class TestFunctions(unittest.TestCase):
             [pd.Timestamp("2005-12-30"), True],
             [pd.Timestamp("2000-12-29"), True],
         ]
+        set_test_result_3 = set(test_result_3)
         for tval in test_vals:
             self.assertEqual(tval[0] in set_test_result_3, tval[1])
-
-        test_start_date = "2000-01-01"
-        test_end_date = "2001-10-31"
-
-        test_result_4 = get_eops(
-            start_date=test_start_date, end_date=test_end_date, freq="Q"
-        )
-        expected_rs_4 = [
-            "2000-03-31",
-            "2000-06-30",
-            "2000-09-29",
-            "2000-12-29",
-            "2001-03-30",
-            "2001-06-29",
-            "2001-09-28",
-            "2001-10-31",
-        ]
-        self.assertTrue(
-            set(test_result_4) == set([pd.Timestamp(dx) for dx in expected_rs_4])
-        )
 
     def test_map_to_business_day_frequency(self):
         fm_copy = FREQUENCY_MAP.copy()
@@ -719,23 +699,22 @@ class TestFunctions(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             _map_to_business_day_frequency("X")
-
+            
         with self.assertRaises(TypeError):
             _map_to_business_day_frequency(1)
-
+        
         with self.assertRaises(ValueError):
             _map_to_business_day_frequency("D", valid_freqs=["W", "M"])
-
+            
         with self.assertRaises(ValueError):
             _map_to_business_day_frequency("D", valid_freqs=["X", "Y", "Z"])
-
+            
         # check reverse mapping
         for k, v in fm_copy.items():
             self.assertEqual(_map_to_business_day_frequency(v), v, f"Failed for {v}")
-
+            
         with self.assertRaises(TypeError):
             _map_to_business_day_frequency("M", valid_freqs=1)
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Reverts macrosynergy/macrosynergy#1523