### PR TITLE
Feature: Adding argument `blacklist_fillna` to `reduce_df()`

### DIFF
--- a/macrosynergy/management/utils/df_utils.py
+++ b/macrosynergy/management/utils/df_utils.py
@@ -411,6 +411,7 @@ def reduce_df(
     start: str = None,
     end: str = None,
     blacklist: dict = None,
+    blacklist_fillna: bool = False,
     out_all: bool = False,
     intersect: bool = False,
 ):
@@ -428,6 +429,8 @@ def reduce_df(
     :param <dict> blacklist: cross-sections with date ranges that should be excluded from
         the data frame. If one cross-section has several blacklist periods append numbers
         to the cross-section code.
+    :param <bool> blacklist_fillna: if True, the function fills NaNs in the DataFrame
+        where the blacklist is applied. Default is False.
     :param <bool> out_all: if True the function returns reduced dataframe and selected/
         available xcats and cids.
         Default is False, i.e. only the DataFrame is returned
@@ -461,7 +464,10 @@ def reduce_df(
 
         if masks:
             combined_mask = pd.concat(masks, axis=1).any(axis=1)
-            dfx = dfx[~combined_mask]
+            if blacklist_fillna:
+                dfx.loc[combined_mask, "value"] = np.nan
+            else:
+                dfx = dfx[~combined_mask]
 
     xcats_in_df = dfx["xcat"].unique()
     if xcats is None:

--- a/macrosynergy/management/validation.py
+++ b/macrosynergy/management/validation.py
@@ -32,6 +32,7 @@ def validate_and_reduce_qdf(
     intersect: Optional[bool] = False,
     tickers: Optional[List[str]] = None,
     blacklist: Optional[Dict[str, List[str]]] = None,
+    blacklist_fillna: Optional[bool] = False,
     start: Optional[str] = None,
     end: Optional[str] = None,
 ):
@@ -55,6 +56,8 @@ def validate_and_reduce_qdf(
     :param <dict> blacklist: cross-sections with date ranges that should be excluded from
         the data frame. If one cross-section has several blacklist periods append numbers
         to the cross-section code.
+    :param <bool> blacklist_fillna: if True, fills in missing dates in the blacklist
+        with the previous date. Default is False.
     :param <str> start: ISO-8601 formatted date string. Select data from
         this date onwards. If None, all dates are selected.
     :param <str> end: ISO-8601 formatted date string. Select data up to
@@ -97,6 +100,7 @@ def validate_and_reduce_qdf(
         start=start,
         end=end,
         blacklist=blacklist,
+        blacklist_fillna=blacklist_fillna,
         out_all=True,
     )
 

--- a/macrosynergy/visuals/facetplot.py
+++ b/macrosynergy/visuals/facetplot.py
@@ -445,10 +445,10 @@ class FacetPlot(Plotter):
                 tks: List[str] = [ticker]
                 if compare_series is not None:
                     tks.append(compare_series)
-                plot_dict[i]: Dict[str, Union[str, List[str]]] = {
+                plot_dict[i] = {
                     "X": "real_date",
                     "Y": tks,
-                }
+                }  #  tks: Union[str, List[str]]
 
         if cid_grid or xcat_grid:
             # flipper handles resolution between cid_grid and xcat_grid for binary
@@ -481,11 +481,11 @@ class FacetPlot(Plotter):
                 if tks == [compare_series]:
                     continue
 
-                plot_dict[i]: Dict[str, Union[str, List[str]]] = {
+                plot_dict[i] = {
                     "X": "real_date",
                     "Y": tks + ([compare_series] if compare_series else []),
                     "title": facet_titles[i],
-                }
+                } #  tks: Union[str, List[str]]
 
         if cid_xcat_grid:
             # NB : legend goes away in cid_xcat_grid
@@ -494,7 +494,7 @@ class FacetPlot(Plotter):
             for i, cid in enumerate(_cids):
                 for j, xcat in enumerate(_xcats):
                     tk: str = "_".join([cid, xcat])
-                    plot_dict[i * len(_xcats) + j]: Dict[str, List[str]] = {
+                    plot_dict[i * len(_xcats) + j] = {
                         "X": "real_date",
                         "Y": [tk],
                         "title": tk,
@@ -590,7 +590,9 @@ class FacetPlot(Plotter):
 
                 plot_func_args = {}
                 if legend_color_map:
-                    plot_func_args["color"] = legend_color_map.get(xcatx if cid_grid else cidx)
+                    plot_func_args["color"] = legend_color_map.get(
+                        xcatx if cid_grid else cidx
+                    )
 
                 if y == compare_series:
                     plot_func_args["color"] = "red"
@@ -637,12 +639,12 @@ class FacetPlot(Plotter):
 
         self.df.reset_index(inplace=True)
 
-        for ax in ax_list[len(plot_dict):]:
+        for ax in ax_list[len(plot_dict) :]:
             fig.delaxes(ax)
-        ax_list = ax_list[:len(plot_dict)]
-        
+        ax_list = ax_list[: len(plot_dict)]
+
         if share_x:
-            for target_ax in ax_list[(len(plot_dict) - grid_dim[0]):]:
+            for target_ax in ax_list[(len(plot_dict) - grid_dim[0]) :]:
                 target_ax.xaxis.set_tick_params(labelbottom=True)
 
         if legend:
@@ -658,8 +660,14 @@ class FacetPlot(Plotter):
                 frameon=legend_frame,
             )
 
-            leg_width, leg_height = leg.get_window_extent().width, leg.get_window_extent().height
-            fig_width, fig_height = fig.get_window_extent().width, fig.get_window_extent().height
+            leg_width, leg_height = (
+                leg.get_window_extent().width,
+                leg.get_window_extent().height,
+            )
+            fig_width, fig_height = (
+                fig.get_window_extent().width,
+                fig.get_window_extent().height,
+            )
 
             if "lower" in legend_loc:
                 re_adj[1] += leg_height / fig_height
@@ -764,7 +772,7 @@ if __name__ == "__main__":
             title="Another test title",
             # save_to_file="test_1.png",
             show=True,
-            share_x=True
+            share_x=True,
         )
         fp.lineplot(
             cids=cids_C,

--- a/macrosynergy/visuals/plotter.py
+++ b/macrosynergy/visuals/plotter.py
@@ -84,6 +84,7 @@ class Plotter(metaclass=PlotterMetaClass):
         intersect: Optional[bool] = False,
         tickers: Optional[List[str]] = None,
         blacklist: Optional[Dict[str, List[str]]] = None,
+        blacklist_fillna: Optional[bool] = False,
         start: Optional[str] = None,
         end: Optional[str] = None,
         backend: Optional[str] = "matplotlib",
@@ -96,6 +97,7 @@ class Plotter(metaclass=PlotterMetaClass):
             intersect=intersect,
             tickers=tickers,
             blacklist=blacklist,
+            blacklist_fillna=blacklist_fillna,
             start=start,
             end=end,
         )

--- a/macrosynergy/visuals/timelines.py
+++ b/macrosynergy/visuals/timelines.py
@@ -162,7 +162,13 @@ def timelines(
 
     if cumsum:
         df = reduce_df(
-            df, xcats=xcats, cids=cids, start=start, end=end, blacklist=blacklist
+            df,
+            xcats=xcats,
+            cids=cids,
+            start=start,
+            end=end,
+            blacklist=blacklist,
+            blacklist_fillna=True,
         )
         df[val] = (
             df.sort_values(["cid", "xcat", "real_date"])[["cid", "xcat", val]]
@@ -173,7 +179,13 @@ def timelines(
     cross_mean_series: Optional[str] = f"mean_{xcats[0]}" if cs_mean else None
     if cs_mean:
         df = reduce_df(
-            df, xcats=xcats, cids=cids, start=start, end=end, blacklist=blacklist
+            df,
+            xcats=xcats,
+            cids=cids,
+            start=start,
+            end=end,
+            blacklist=blacklist,
+            blacklist_fillna=True,
         )
         if len(xcats) > 1:
             raise ValueError("`cs_mean` cannot be True for multiple categories.")
@@ -385,6 +397,11 @@ if __name__ == "__main__":
             .copy()
         )
 
+    blacklist = {
+        "USD": ["2010-01-01", "2013-12-31"],
+        "GBP": ["2010-01-01", "2013-12-31"],
+    }
+
     import time
 
     # timer_start: float = time.time()
@@ -396,6 +413,7 @@ if __name__ == "__main__":
         square_grid=True,
         cids=sel_cids[1],
         # single_chart=True,
+        blacklist=blacklist,
     )
 
     timelines(
@@ -405,6 +423,7 @@ if __name__ == "__main__":
         # cs_mean=True,
         # xcat_grid=False,
         single_chart=True,
+        blacklist=blacklist,
         cs_mean=True,
     )
 
@@ -417,4 +436,5 @@ if __name__ == "__main__":
             "Plotting multiple cross sections for a single category \n with different "
             "y-axis!"
         ),
+        blacklist=blacklist,
     )


### PR DESCRIPTION
Intended to solve for https://github.com/macrosynergy/macrosynergy/issues/1530.

Adds a boolean argument `blacklist_fillna`, which allows the user to fill missing dates with NAs rather than drop the entries entirely. This is very useful for visual functions as they would otherwise linearly interpolate adjacent values that may be far on `real_date`