### PR TITLE
Feature: Removing `msm.types.Numeric`

### DIFF
--- a/macrosynergy/management/decorators.py
+++ b/macrosynergy/management/decorators.py
@@ -19,7 +19,7 @@ from typing import (
     get_origin,
 )
 from inspect import signature
-from macrosynergy.management.types import Numeric, NoneType
+from macrosynergy.management.types import NoneType
 import pandas as pd
 import numpy as np
 from packaging import version
@@ -145,7 +145,7 @@ def is_matching_subscripted_type(value: Any, type_hint: Type[Any]) -> bool:
     if origin in [tuple, Tuple]:
         if not isinstance(value, tuple) or len(value) != len(args):
             return False
-        # don't switch order of get_origin and is_matching_subscripted_type, is 
+        # don't switch order of get_origin and is_matching_subscripted_type, is
         # short-circuiting
         return all(
             [

--- a/macrosynergy/management/types.py
+++ b/macrosynergy/management/types.py
@@ -8,31 +8,6 @@ import numpy as np
 import pandas as pd
 
 
-class NumericType(type):
-    """
-    MetaClass to support type checks across `int`, `float`, `np.int64`, `np.float64`,
-    `SupportsInt`, and `SupportsFloat`.
-    """
-
-    # A tuple of the desired types
-    _numeric_types = (int, float, np.int64, np.float64)
-
-    def __instancecheck__(cls, instance):
-        # if type(instance) not in cls._numeric_types:
-        #     return False
-        return isinstance(instance, cls._numeric_types)
-
-
-class Numeric(metaclass=NumericType):
-    """
-    Custom class definition for a numeric type that supports type checks across `int`,
-    `float`, `np.int64`, `np.float64`, `SupportsInt`, and `SupportsFloat`.
-    """
-
-    # Alternatively, use `numbers.Number` directly
-    pass
-
-
 class NoneTypeMeta(type):
     """
     MetaClass to support type checks for `None`.

--- a/macrosynergy/panel/make_zn_scores.py
+++ b/macrosynergy/panel/make_zn_scores.py
@@ -1,6 +1,7 @@
 """
 Module for calculating z-scores for a panel around a neutral level ("zn scores").
 """
+
 import numpy as np
 import pandas as pd
 from typing import List, Union
@@ -11,7 +12,7 @@ from macrosynergy.management.utils import (
     reduce_df,
     _map_to_business_day_frequency,
 )
-from macrosynergy.management.types import Numeric
+from numbers import Number
 
 
 def expanding_stat(
@@ -186,7 +187,7 @@ def make_zn_scores(
 
     if thresh is not None:
         err: str = "The `thresh` parameter must a numerical value >= 1.0."
-        if not isinstance(thresh, Numeric):
+        if not isinstance(thresh, Number):
             raise TypeError(err)
         elif thresh < 1.0:
             raise ValueError(err)
@@ -198,7 +199,7 @@ def make_zn_scores(
         "The `pan_weight` parameter must be a numerical value between 0 and 1 "
         "(inclusive)."
     )
-    if not isinstance(pan_weight, Numeric):
+    if not isinstance(pan_weight, Number):
         raise TypeError(err)
     elif not (0 <= pan_weight <= 1):
         raise ValueError(err)

--- a/macrosynergy/visuals/README.md
+++ b/macrosynergy/visuals/README.md
@@ -14,17 +14,13 @@ The `macrosynergy.visuals` subpackage features the following functionality:
 
 ### User-facing functions:
 
-- `view.*` functions: A set of preset methods to view data in commonly used contexts.
-
-  - `timelines()`: A function for viewing time-series data as line plots. Settings include viewing grouped by `cids`, `xcats`, or both.
-
-  To be implemented:
-  - `availability()`: A function for viewing data availability. Plots a heatmap of the data availability for each `cid` and `xcat`.
-  - `correlation()`: A function for viewing correlation matrices.
-  - `metrics()`: A function for viewing metrics. Designed to view any on a heatmap; not ideal for viewing `value`.
-  - `ranges()`: A function for viewing ranges with box plots and bar charts.
-  - `reg_scatter()`: A function for viewing scatter plots with regression lines.
-  - `distribution()`: A function for viewing distributions as histograms or scatter plots. Can be extended to view distributions for a `reg_scatter` plot.
+- `timelines()`: A function for viewing time-series data as line plots.
+- `metrics()`: A function for viewing metrics as heatmaps.
+- `ranges()`: A function for viewing ranges with box plots and bar charts.
+- `multiple_reg_scatter()`: A function for viewing multiple scatter plots with regression lines.
+- `metrics()`: A function for viewing metrics. Designed to view any on a heatmap; not ideal for viewing `value`.
+- `grading()`: A function for viewing grading data.
+- `correlation()`: A function for viewing correlation matrices.
 
 ### Backend functions:
 
@@ -33,6 +29,7 @@ The `macrosynergy.visuals` subpackage features the following functionality:
   - `.lineplot()`: A method for creating line plots.
 
   To be implemented:
+
   - `.scatterplot()`: A method for creating scatter plots.
   - `.from_subplots()`: A method for copying and arranging a list of individual subplots (of any type) into a facet plot.
 
@@ -123,7 +120,7 @@ We use a direct subset of `matplotlib`'s functions, with some renaming where con
 Here are the generic arguments that behave the same across all plotting methods:
 
 ```text
-:param <Tuple[Numeric, Numeric]> figsize: a tuple of floats specifying the width and height of the figure.
+:param <Tuple[Number, Number]> figsize: a tuple of floats specifying the width and height of the figure.
 
 :param <str> title: the title of the plot.
 
@@ -161,28 +158,7 @@ Here are the generic arguments that behave the same across all plotting methods:
 Type hinting is used extensively, and allows for syntax validation across almost all utilities. The validation is done by `argvalidation`. It uses a series of "tricks" to allow for type hinting of arguments, and to validate them against their type hints. These are better explained by reading the code itself. (See `macrosynergy.visuals.plotter`)
 
 One problem with type hinting is that it can quickly become too verbose, and therefore unreadable.
-To mitigate situations such as:
-
-```python
-...
-figsize: Tuple[Union[int, float, np.int64, np.float64], Union[int, float, np.int64, np.float64]] = (12, 8)
-# or even
-facet_size: Tuple[Union[SupportsFloat, np.int64, np.float64], Union[SupportsFloat, np.int64, np.float64]] = (12, 8)
-...
-```
-
-two generic type-aliases are defined in `macrosynergy.visuals.common`:
-
-```python
-NoneType = type(None)
-Numeric = Union[int, float, np.int64, np.float64, SupportsInt, SupportsFloat]
-# used as:
-...
-figsize: Tuple[Numeric, Numeric] = (12, 8)
-```
-
-This will most likely be extendable for a package/subpackage-wide type-alias file in the future. (`macrosynergy.typing`, or
-`macrosynergy.visuals.typing` etc.)
+To mitigate situations it is recommended we use more generic type hints where possible (such as Iterable (over list), and Number (over Union[int, float]).
 
 ### Arg Copying and `argcopy`
 

--- a/macrosynergy/visuals/facetplot.py
+++ b/macrosynergy/visuals/facetplot.py
@@ -445,10 +445,11 @@ class FacetPlot(Plotter):
                 tks: List[str] = [ticker]
                 if compare_series is not None:
                     tks.append(compare_series)
-                plot_dict[i]: Dict[str, Union[str, List[str]]] = {
+                plot_dict[i] = {
                     "X": "real_date",
                     "Y": tks,
                 }
+                # plot_dict[i] --> Dict[str, Union[str, List[str]]]
 
         if cid_grid or xcat_grid:
             # flipper handles resolution between cid_grid and xcat_grid for binary
@@ -481,11 +482,12 @@ class FacetPlot(Plotter):
                 if tks == [compare_series]:
                     continue
 
-                plot_dict[i]: Dict[str, Union[str, List[str]]] = {
+                plot_dict[i] = {
                     "X": "real_date",
                     "Y": tks + ([compare_series] if compare_series else []),
                     "title": facet_titles[i],
                 }
+                # plot_dict[i] --> Dict[str, Union[str, List[str]]]
 
         if cid_xcat_grid:
             # NB : legend goes away in cid_xcat_grid
@@ -494,11 +496,12 @@ class FacetPlot(Plotter):
             for i, cid in enumerate(_cids):
                 for j, xcat in enumerate(_xcats):
                     tk: str = "_".join([cid, xcat])
-                    plot_dict[i * len(_xcats) + j]: Dict[str, List[str]] = {
+                    plot_dict[i * len(_xcats) + j] = {
                         "X": "real_date",
                         "Y": [tk],
                         "title": tk,
                     }
+                    # plot_dict[i * len(_xcats) + j] --> Dict[str, List[str]]
 
         if len(plot_dict) == 0:
             raise ValueError("Unable to resolve plot settings.")

--- a/macrosynergy/visuals/facetplot.py
+++ b/macrosynergy/visuals/facetplot.py
@@ -590,7 +590,9 @@ class FacetPlot(Plotter):
 
                 plot_func_args = {}
                 if legend_color_map:
-                    plot_func_args["color"] = legend_color_map.get(xcatx if cid_grid else cidx)
+                    plot_func_args["color"] = legend_color_map.get(
+                        xcatx if cid_grid else cidx
+                    )
 
                 if y == compare_series:
                     plot_func_args["color"] = "red"
@@ -637,12 +639,12 @@ class FacetPlot(Plotter):
 
         self.df.reset_index(inplace=True)
 
-        for ax in ax_list[len(plot_dict):]:
+        for ax in ax_list[len(plot_dict) :]:
             fig.delaxes(ax)
-        ax_list = ax_list[:len(plot_dict)]
-        
+        ax_list = ax_list[: len(plot_dict)]
+
         if share_x:
-            for target_ax in ax_list[(len(plot_dict) - grid_dim[0]):]:
+            for target_ax in ax_list[(len(plot_dict) - grid_dim[0]) :]:
                 target_ax.xaxis.set_tick_params(labelbottom=True)
 
         if legend:
@@ -658,8 +660,14 @@ class FacetPlot(Plotter):
                 frameon=legend_frame,
             )
 
-            leg_width, leg_height = leg.get_window_extent().width, leg.get_window_extent().height
-            fig_width, fig_height = fig.get_window_extent().width, fig.get_window_extent().height
+            leg_width, leg_height = (
+                leg.get_window_extent().width,
+                leg.get_window_extent().height,
+            )
+            fig_width, fig_height = (
+                fig.get_window_extent().width,
+                fig.get_window_extent().height,
+            )
 
             if "lower" in legend_loc:
                 re_adj[1] += leg_height / fig_height
@@ -764,7 +772,7 @@ if __name__ == "__main__":
             title="Another test title",
             # save_to_file="test_1.png",
             show=True,
-            share_x=True
+            share_x=True,
         )
         fp.lineplot(
             cids=cids_C,

--- a/macrosynergy/visuals/facetplot.py
+++ b/macrosynergy/visuals/facetplot.py
@@ -14,7 +14,7 @@ import pandas as pd
 from matplotlib.gridspec import GridSpec
 
 from macrosynergy.visuals.plotter import Plotter
-from macrosynergy.management.types import Numeric, NoneType
+from numbers import Number
 
 
 def _get_square_grid(
@@ -169,30 +169,30 @@ class FacetPlot(Plotter):
     #     xcats: Optional[List[str]] = None,
     #     metric: Optional[str] = None,
     #     # fig arguments
-    #     figsize: Tuple[Numeric, Numeric] = (16.0, 9.0),
+    #     figsize: Tuple[Number, Number] = (16.0, 9.0),
     #     ncols: int = 3,
     #     attempt_square: bool = False,
     #     # xcats_mean: bool = False,
     #     # title arguments
     #     title: Optional[str] = None,
     #     title_fontsize: int = 20,
-    #     title_xadjust: Optional[Numeric] = None,
-    #     title_yadjust: Optional[Numeric] = None,
+    #     title_xadjust: Optional[Number] = None,
+    #     title_yadjust: Optional[Number] = None,
     #     # subplot axis arguments
     #     ax_grid: bool = True,
     #     ax_hline: bool = False,
-    #     ax_hline_val: Numeric = 0.0,
+    #     ax_hline_val: Number = 0.0,
     #     ax_vline: bool = False,
-    #     ax_vline_val: Numeric = 0.0,
+    #     ax_vline_val: Number = 0.0,
     #     x_axis_label: Optional[str] = None,
     #     y_axis_label: Optional[str] = None,
     #     axis_fontsize: int = 12,
     #     # subplot arguments
-    #     facet_size: Optional[Tuple[Numeric, Numeric]] = None,
+    #     facet_size: Optional[Tuple[Number, Number]] = None,
     #     facet_titles: Optional[List[str]] = None,
     #     facet_title_fontsize: int = 12,
-    #     facet_title_xadjust: Numeric = 0.5,
-    #     facet_title_yadjust: Numeric = 1.0,
+    #     facet_title_xadjust: Number = 0.5,
+    #     facet_title_yadjust: Number = 1.0,
     #     facet_xlabel: Optional[str] = None,
     #     facet_ylabel: Optional[str] = None,
     #     facet_label_fontsize: int = 12,
@@ -201,7 +201,7 @@ class FacetPlot(Plotter):
     #     legend_labels: Optional[List[str]] = None,
     #     legend_loc: str = "upper center",
     #     legend_ncol: int = 1,
-    #     legend_bbox_to_anchor: Optional[Tuple[Numeric, Numeric]] = None,  # (1.0, 0.5),
+    #     legend_bbox_to_anchor: Optional[Tuple[Number, Number]] = None,  # (1.0, 0.5),
     #     legend_frame: bool = True,
     #     # return args
     #     show: bool = True,
@@ -244,24 +244,24 @@ class FacetPlot(Plotter):
         share_x: bool = False,
         # xcats_mean: bool = False,
         # title arguments
-        figsize: Tuple[Numeric, Numeric] = (16.0, 9.0),
+        figsize: Tuple[Number, Number] = (16.0, 9.0),
         title: Optional[str] = None,
         title_fontsize: int = 22,
-        title_xadjust: Optional[Numeric] = None,
-        title_yadjust: Optional[Numeric] = None,
+        title_xadjust: Optional[Number] = None,
+        title_yadjust: Optional[Number] = None,
         # subplot axis arguments
         ax_grid: bool = False,
-        ax_hline: Optional[Numeric] = 0.0,
+        ax_hline: Optional[Number] = 0.0,
         ax_vline: Optional[str] = None,
         x_axis_label: Optional[str] = None,
         y_axis_label: Optional[str] = None,
         axis_fontsize: int = 12,
         # subplot arguments
-        facet_size: Optional[Tuple[Numeric, Numeric]] = None,
+        facet_size: Optional[Tuple[Number, Number]] = None,
         facet_titles: Optional[List[str]] = None,
         facet_title_fontsize: int = 14,
-        facet_title_xadjust: Numeric = 0.5,
-        facet_title_yadjust: Numeric = 1.0,
+        facet_title_xadjust: Number = 0.5,
+        facet_title_yadjust: Number = 1.0,
         facet_xlabel: Optional[str] = None,
         facet_ylabel: Optional[str] = None,
         # legend arguments
@@ -270,7 +270,7 @@ class FacetPlot(Plotter):
         legend_loc: Optional[str] = "lower center",
         legend_fontsize: int = 12,
         legend_ncol: int = 1,
-        legend_bbox_to_anchor: Optional[Tuple[Numeric, Numeric]] = None,  # (1.0, 0.5),
+        legend_bbox_to_anchor: Optional[Tuple[Number, Number]] = None,  # (1.0, 0.5),
         legend_frame: bool = True,
         # return args
         show: bool = True,
@@ -312,7 +312,7 @@ class FacetPlot(Plotter):
             `True`.
         :param <bool> share_x: whether to share the x-axis across all plots. Default is
             `True`.
-        :param <Tuple[Numeric, Numeric]> figsize: a tuple of floats specifying the width
+        :param <Tuple[Number, Number]> figsize: a tuple of floats specifying the width
             and height of the figure. Default is `(16.0, 9.0)`.
         :param <str> title: the title of the plot. Default is `None`.
         :param <int> title_fontsize: the font size of the title. Default is `20`.
@@ -320,7 +320,7 @@ class FacetPlot(Plotter):
         :param <float> title_yadjust: the y-adjustment of the title. Default is `None`.
         :param <bool> ax_grid: whether to show the grid on the axes, applied to all plots.
             Default is `True`.
-        :param <Numeric> ax_hline: the value of the horizontal line on the axes, applied
+        :param <Number> ax_hline: the value of the horizontal line on the axes, applied
             to all plots. Default is `None`, meaning no horizontal line will be shown.
         :param <str> ax_vline: the value of the vertical line on the axes, applied
             to all plots. The value must be a ISO-8601 formatted date-string.
@@ -328,7 +328,7 @@ class FacetPlot(Plotter):
         :param <str> x_axis_label: the label for the x-axis. Default is `None`.
         :param <str> y_axis_label: the label for the y-axis. Default is `None`.
         :param <int> axis_fontsize: the font size of the axis labels. Default is `12`.
-        :param <Tuple[Numeric, Numeric]> facet_size: a tuple of floats specifying the
+        :param <Tuple[Number, Number]> facet_size: a tuple of floats specifying the
             width and height of each facet. Default is `None`, meaning the facet size will
             be inferred from the `figsize` argument. If specified, the `figsize` argument
             will be ignored and the figure size will be inferred from the dimensions of

--- a/macrosynergy/visuals/heatmap.py
+++ b/macrosynergy/visuals/heatmap.py
@@ -13,8 +13,7 @@ from typing import Union
 from macrosynergy.management.utils import downsample_df_on_real_date
 
 from macrosynergy.visuals.plotter import Plotter
-from macrosynergy.management.types import Numeric, NoneType
-
+from numbers import Number
 from macrosynergy.management.simulate import make_test_df
 
 
@@ -64,16 +63,16 @@ class Heatmap(Plotter):
     def _plot(
         self,
         df: pd.DataFrame,
-        figsize: Tuple[Numeric, Numeric] = (12, 8),
+        figsize: Tuple[Number, Number] = (12, 8),
         x_axis_label: Optional[str] = None,
         y_axis_label: Optional[str] = None,
         axis_fontsize: int = 14,
         title: Optional[str] = None,
         title_fontsize: int = 22,
-        title_xadjust: Numeric = 0.5,
-        title_yadjust: Numeric = 1.0,
-        vmin: Optional[Numeric] = None,
-        vmax: Optional[Numeric] = None,
+        title_xadjust: Number = 0.5,
+        title_yadjust: Number = 1.0,
+        vmin: Optional[Number] = None,
+        vmax: Optional[Number] = None,
         show: bool = True,
         save_to_file: Optional[str] = None,
         dpi: int = 300,
@@ -81,8 +80,8 @@ class Heatmap(Plotter):
         on_axis: Optional[plt.Axes] = None,
         max_xticks: int = 50,
         cmap: Optional[Union[str, mpl.colors.Colormap]] = None,
-        rotate_xticks: Optional[Numeric] = 0,
-        rotate_yticks: Optional[Numeric] = 0,
+        rotate_xticks: Optional[Number] = 0,
+        rotate_yticks: Optional[Number] = 0,
         show_tick_lines: Optional[bool] = True,
         show_colorbar: Optional[bool] = True,
         show_annotations: Optional[bool] = False,
@@ -248,16 +247,16 @@ class Heatmap(Plotter):
         end=None,
         freq=None,
         agg="mean",
-        figsize: Optional[Tuple[Numeric, Numeric]] = (12, 8),
+        figsize: Optional[Tuple[Number, Number]] = (12, 8),
         x_axis_label: Optional[str] = None,
         y_axis_label: Optional[str] = None,
         axis_fontsize: int = 14,
         title: Optional[str] = None,
         title_fontsize: int = 22,
-        title_xadjust: Numeric = 0.5,
-        title_yadjust: Numeric = 1.0,
-        vmin: Optional[Numeric] = None,
-        vmax: Optional[Numeric] = None,
+        title_xadjust: Number = 0.5,
+        title_yadjust: Number = 1.0,
+        vmin: Optional[Number] = None,
+        vmax: Optional[Number] = None,
         show: bool = True,
         save_to_file: Optional[str] = None,
         dpi: int = 300,
@@ -265,8 +264,8 @@ class Heatmap(Plotter):
         on_axis: Optional[plt.Axes] = None,
         max_xticks: int = 50,
         cmap: Optional[Union[str, mpl.colors.Colormap]] = None,
-        rotate_xticks: Optional[Numeric] = 0,
-        rotate_yticks: Optional[Numeric] = 0,
+        rotate_xticks: Optional[Number] = 0,
+        rotate_yticks: Optional[Number] = 0,
         show_tick_lines: Optional[bool] = True,
         show_colorbar: Optional[bool] = True,
         show_annotations: Optional[bool] = False,

--- a/macrosynergy/visuals/heatmap.py
+++ b/macrosynergy/visuals/heatmap.py
@@ -315,7 +315,7 @@ class Heatmap(Plotter):
         vmax: float = max(1, df[metric].max())
         vmin: float = min(0, df[metric].min())
 
-        df["real_date"]: pd.Series = df["real_date"].dt.strftime("%Y-%m-%d")
+        df["real_date"] = df["real_date"].dt.strftime("%Y-%m-%d")
 
         df = df.pivot_table(index=y_axis_column, columns=x_axis_column, values=metric)
 
@@ -380,7 +380,7 @@ if __name__ == "__main__":
 
     heatmap = Heatmap(df=dfx, xcats=["FX"])
 
-    heatmap.df["real_date"]: pd.Series = heatmap.df["real_date"].dt.strftime("%Y-%m-%d")
+    heatmap.df["real_date"] = heatmap.df["real_date"].dt.strftime("%Y-%m-%d")
     heatmap.df = heatmap.df.pivot_table(
         index="cid", columns="real_date", values="grading"
     )

--- a/macrosynergy/visuals/lineplot.py
+++ b/macrosynergy/visuals/lineplot.py
@@ -8,8 +8,7 @@ from typing import List, Dict, Tuple, Optional
 import matplotlib.pyplot as plt
 
 from macrosynergy.visuals.plotter import Plotter
-from macrosynergy.management.types import Numeric, NoneType
-
+from numbers import Number
 from macrosynergy.management.simulate import make_test_df
 
 
@@ -69,9 +68,9 @@ class LinePlot(Plotter):
         compare_series: Optional[str] = None,
         # Plotting specific arguments
         # fig args
-        figsize: Tuple[Numeric, Numeric] = (12, 8),
-        aspect: Numeric = 1.618,
-        height: Numeric = 0.8,
+        figsize: Tuple[Number, Number] = (12, 8),
+        aspect: Number = 1.618,
+        height: Number = 0.8,
         # plot args
         grid: bool = True,
         x_axis_label: Optional[str] = None,
@@ -80,8 +79,8 @@ class LinePlot(Plotter):
         # title args
         title: Optional[str] = None,
         title_fontsize: int = 16,
-        title_xadjust: Numeric = 0.5,
-        title_yadjust: Numeric = 1.05,
+        title_xadjust: Number = 0.5,
+        title_yadjust: Number = 1.05,
         # legend args
         legend: bool = True,
         legend_labels: Optional[List[str]] = None,
@@ -89,7 +88,7 @@ class LinePlot(Plotter):
         legend_loc: Optional[str] = "best",
         legend_fontsize: int = 14,
         legend_ncol: int = 1,
-        legend_bbox_to_anchor: Optional[Tuple[Numeric, Numeric]] = None,
+        legend_bbox_to_anchor: Optional[Tuple[Number, Number]] = None,
         legend_frame: bool = True,
         # return args
         show: bool = True,

--- a/macrosynergy/visuals/timelines.py
+++ b/macrosynergy/visuals/timelines.py
@@ -20,10 +20,11 @@ import pandas as pd
 
 from macrosynergy.management.utils import standardise_dataframe, reduce_df
 from macrosynergy.visuals import FacetPlot, LinePlot
-from macrosynergy.management.types import Numeric
+from numbers import Number
 import time
 
 IDX_COLS: List[str] = ["cid", "xcat", "real_date"]
+
 
 def timelines(
     df: pd.DataFrame,
@@ -48,9 +49,9 @@ def timelines(
     title_xadj: float = 0.5,
     title_fontsize: int = 22,
     cs_mean: bool = False,
-    size: Tuple[Numeric, Numeric] = (12, 7),
-    aspect: Numeric = 1.7,
-    height: Numeric = 3.0,
+    size: Tuple[Number, Number] = (12, 7),
+    aspect: Number = 1.7,
+    height: Number = 3.0,
     legend_fontsize: int = 12,
 ):
     """Displays a facet grid of time line charts of one or more categories.
@@ -89,20 +90,20 @@ def timelines(
     :param <bool> cs_mean: if True this adds a line of cross-sectional averages to
         the line charts. This is only allowed for function calls with a single
         category. Default is False.
-    :param <Tuple[Numeric, Numeric]> size: two-element tuple setting width/height
+    :param <Tuple[Number, Number]> size: two-element tuple setting width/height
         of single cross section plot. Default is (12, 7). This is irrelevant for facet
         grid.
-    :param <Numeric> aspect: width-height ratio for plots in facet. Default is 1.7.
-    :param <Numeric> height: height of plots in facet. Default is 3.
+    :param <Number> aspect: width-height ratio for plots in facet. Default is 1.7.
+    :param <Number> height: height of plots in facet. Default is 3.
     :param <int> legend_fontsize: font size of legend. Default is 12.
 
     """
     if not isinstance(df, pd.DataFrame):
         raise TypeError("`df` must be a pandas DataFrame.")
-    
+
     if len(df.columns) < 4:
         df = df.copy().reset_index()
-    
+
     if val not in df.columns:
         if len(df.columns) == len(IDX_COLS) + 1:
             val: str = list(set(df.columns) - set(IDX_COLS))[0]
@@ -156,10 +157,11 @@ def timelines(
 
     if cumsum:
         df = reduce_df(df, xcats=xcats, cids=cids, start=start, end=end)
-        df[val] = (df.sort_values(["cid", "xcat", "real_date"])
-            [["cid", "xcat", val]]
+        df[val] = (
+            df.sort_values(["cid", "xcat", "real_date"])[["cid", "xcat", val]]
             .groupby(["cid", "xcat"])
-            .cumsum())
+            .cumsum()
+        )
 
     cross_mean_series: Optional[str] = f"mean_{xcats[0]}" if cs_mean else None
     if cs_mean:
@@ -219,7 +221,7 @@ def timelines(
             start=start,
             end=end,
         ) as fp:
-            
+
             fp.lineplot(
                 share_y=same_y,
                 share_x=not all_xticks,

--- a/tests/unit/management/test_types.py
+++ b/tests/unit/management/test_types.py
@@ -3,27 +3,11 @@ import numpy as np
 import pandas as pd
 
 from typing import Any, List
-from macrosynergy.management.types import Numeric, NoneType, QuantamentalDataFrame
+from macrosynergy.management.types import NoneType, QuantamentalDataFrame
 from macrosynergy.management.simulate import make_test_df
 
 
 class TestTypes(unittest.TestCase):
-    def test_numeric_type(self):
-        true_cases: List[Any] = [1, 1.0, np.int64(1), np.float64(1)]
-
-        for case in true_cases:
-            self.assertTrue(isinstance(case, Numeric), msg=f"Failed for {case}")
-
-        false_cases: List[Any] = [
-            "1",
-            None,
-            object(),
-            pd.DataFrame(),
-            pd.Series(dtype=int),
-        ]
-
-        for case in false_cases:
-            self.assertFalse(isinstance(case, Numeric), msg=f"Failed for {case}")
 
     def test_none_type(self):
         self.assertTrue(isinstance(None, NoneType))


### PR DESCRIPTION
All type-hints and docstrings using `msm.types.Numeric` will now use `numbers.Number`