### PR TITLE
Bugfix: Fixing bug in `FacetPlot.lineplot()`

### DIFF
--- a/macrosynergy/visuals/facetplot.py
+++ b/macrosynergy/visuals/facetplot.py
@@ -506,17 +506,22 @@ class FacetPlot(Plotter):
                     }
                     # plot_dict[i * len(_xcats) + j] --> Dict[str, List[str]]
 
+        if not any([cid_grid, xcat_grid, cid_xcat_grid]):
+            for i, (key, plt_dct) in enumerate(plot_dict.items()):
+                plt_dct["title"] = plt_dct["Y"][0] + " vs " + plt_dct["X"][0]
+
         if len(plot_dict) == 0:
             raise ValueError("Unable to resolve plot settings.")
 
-        # sort by the title
-        _plot_dict: Dict[str, Dict[str, Union[str, List[str]]]] = dict(
-            sorted(plot_dict.items(), key=lambda x: x[1]["title"])
-        )
-        _plot_dict: Dict[str, Dict[str, Union[str, List[str]]]] = {
-            i: ditem for i, ditem in enumerate(_plot_dict.values())
-        }
-        plot_dict: Dict[str, Dict[str, Union[str, List[str]]]] = _plot_dict.copy()
+        # sort by the title - only
+        if all("title" in ditem.keys() for ditem in plot_dict.values()):
+            _plot_dict: Dict[str, Dict[str, Union[str, List[str]]]] = dict(
+                sorted(plot_dict.items(), key=lambda x: x[1]["title"])
+            )
+            _plot_dict: Dict[str, Dict[str, Union[str, List[str]]]] = {
+                i: ditem for i, ditem in enumerate(_plot_dict.values())
+            }
+            plot_dict: Dict[str, Dict[str, Union[str, List[str]]]] = _plot_dict.copy()
 
         ##############################
         # Plotting


### PR DESCRIPTION
Current implemenetation raises an error due to missing plot titles when neither of `cid_grid`, `xcat_grid`, `cid_xcat_grid` = True.