### PR TITLE
Feature: Change preferred sorting order for standard QDF

### DIFF
--- a/macrosynergy/download/jpmaqs.py
+++ b/macrosynergy/download/jpmaqs.py
@@ -22,6 +22,7 @@ import pandas as pd
 from macrosynergy.download.dataquery import DataQueryInterface, API_DELAY_PARAM
 from macrosynergy.download.exceptions import HeartbeatError, InvalidDataframeError
 from macrosynergy.management.utils import is_valid_iso_date, standardise_dataframe
+from macrosynergy.management.constants import JPMAQS_METRICS
 from macrosynergy.management.types import QuantamentalDataFrame
 
 logger = logging.getLogger(__name__)
@@ -558,7 +559,7 @@ class JPMaQSDownload(DataQueryInterface):
                 "`crt`, `key`, `username`, and `password` for certificate based authentication."
             )
 
-        self.valid_metrics: List[str] = ["value", "grading", "eop_lag", "mop_lag"]
+        self.valid_metrics: List[str] = JPMAQS_METRICS
         self.msg_errors: List[str] = []
         self.msg_warnings: List[str] = []
         self.unavailable_expressions: List[str] = []
@@ -1190,6 +1191,7 @@ if __name__ == "__main__":
         data = jpmaqs.download(
             cids=cids,
             xcats=xcats,
+            metrics="all",
             start_date=start_date,
             end_date=end_date,
             show_progress=True,

--- a/macrosynergy/management/__init__.py
+++ b/macrosynergy/management/__init__.py
@@ -12,7 +12,7 @@ from .simulate import simulate_vintage_data, simulate_quantamental_data
 from .simulate.simulate_vintage_data import VintageData
 from .simulate.simulate_quantamental_data import make_qdf
 from .utils import common_cids, update_df, reduce_df, categories_df, reduce_df_by_ticker
-from . import utils, types, decorators, simulate
+from . import utils, types, decorators, simulate, constants
 from .validation import validate_and_reduce_qdf
 
 __all__ = [
@@ -34,6 +34,7 @@ __all__ = [
     "types",
     "decorators",
     "simulate",
+    "constants",
     # Module-as-methods
     "check_availability",
     "simulate_vintage_data",

--- a/macrosynergy/management/constants.py
+++ b/macrosynergy/management/constants.py
@@ -11,3 +11,4 @@ FREQUENCY_MAP = {
     "Q": "BQ",
     "A": "BA",
 }
+JPMAQS_METRICS: list[str] = ["value", "grading", "eop_lag", "mop_lag"]

--- a/macrosynergy/management/utils/df_utils.py
+++ b/macrosynergy/management/utils/df_utils.py
@@ -15,6 +15,7 @@ import pandas as pd
 import datetime
 import requests
 import requests.compat
+import macrosynergy.management.constants as ms_constants
 from macrosynergy.management.utils.core import (
     get_cid,
     get_xcat,
@@ -37,7 +38,7 @@ def standardise_dataframe(
     :raises <ValueError>: If the input DataFrame is not in the correct format.
     """
     idx_cols: List[str] = QuantamentalDataFrame.IndexCols
-    metric_columns: List[str] = ["value", "grading", "eop_lag", "mop_lag"]
+    metric_columns: List[str] = ms_constants.JPMAQS_METRICS
 
     # Check if the input DF contains the standard columns
     if not set(df.columns).issuperset(set(idx_cols)):
@@ -78,22 +79,22 @@ def standardise_dataframe(
     # Sort the 'remaining' columns
     ## No more row-reordering or shape changes after this point
 
-    remaining_cols: Set[str] = set(df.columns) - set(idx_cols)
-    df = df[idx_cols + sorted(remaining_cols)]
+    jpmaqs_metrics = [mtr for mtr in metric_columns if mtr in df.columns]
+    non_jpmaqs_metrics = (set(df.columns) - set(jpmaqs_metrics)) - set(idx_cols)
+    col_order = idx_cols + jpmaqs_metrics + sorted(list(non_jpmaqs_metrics))
+    df = df[col_order]
 
     # for every remaining col, try to convert to float
-    for col in remaining_cols:
+    for col in col_order:
         try:
             df[col] = df[col].astype(float)
         except:
             pass
 
-    non_idx_cols: list = sorted(list(set(df.columns) - set(idx_cols)))
-    return_df: pd.DataFrame = df[idx_cols + non_idx_cols]
     assert isinstance(
-        return_df, QuantamentalDataFrame
+        df, QuantamentalDataFrame
     ), "Failed to standardize DataFrame"
-    return return_df
+    return df
 
 
 def drop_nan_series(

--- a/macrosynergy/management/utils/df_utils.py
+++ b/macrosynergy/management/utils/df_utils.py
@@ -68,10 +68,10 @@ def standardise_dataframe(
     df["real_date"] = pd.to_datetime(df["real_date"], format="%Y-%m-%d")
     df["cid"] = df["cid"].astype(str)
     df["xcat"] = df["xcat"].astype(str)
-
+    # sort by cid, xcat and real_date to allow viewing stacked timeseries easily
     df = (
         df.drop_duplicates(subset=idx_cols, keep="last")
-        .sort_values(by=idx_cols)
+        .sort_values(by=["cid", "xcat", "real_date"])
         .reset_index(drop=True)
     )
 


### PR DESCRIPTION
As per @rsueppel 's request, this PR changes the preffered way of sorting a QDF from REAL_DATE, CID, XCAT to CID, XCAT, REAL_DATE.

This does not change the actual column order for the index columns, which still remains REAL_DATE, CID, XCAT, [M],...

The column order for standard JPMaQS metrics [value,grading,eop_lag,mop_lag] is now enforced, with non-standard metrics being sorted after all standard metrics present in the df.


New output of standardise_dataframe looks like:

![image](https://github.com/macrosynergy/macrosynergy/assets/23239946/a0eb4613-9dd6-47ed-a9e8-3b4aae923b94)


