### PR TITLE
Feature: Add single_scatter argument in reg_scatter, also implement bug fixes and format issues in reg_scatter

### DIFF
--- a/.github/scripts/run_notebooks.py
+++ b/.github/scripts/run_notebooks.py
@@ -3,7 +3,6 @@ import os
 import re
 import time
 from botocore.exceptions import ClientError
-import pandas as pd
 
 AWS_BUCKET_NAME = os.getenv('AWS_BUCKET_NAME', None)
 REGION_NAME = "eu-west-2"

--- a/.github/workflows/run-notebooks.yml
+++ b/.github/workflows/run-notebooks.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install boto3 paramiko pandas
+          pip install boto3
 
       - name: Configure AWS credentials from AWS account
         uses: aws-actions/configure-aws-credentials@v4

--- a/macrosynergy/panel/category_relations.py
+++ b/macrosynergy/panel/category_relations.py
@@ -871,51 +871,51 @@ if __name__ == "__main__":
 
     cidx = ["AUD", "CAD", "GBP", "USD", "PRY"]
 
-    # cr = CategoryRelations(
-    #     dfdx,
-    #     xcats=["CRY", "XR"],
-    #     freq="M",
-    #     lag=1,
-    #     cids=cidx,
-    #     xcat_aggs=["mean", "sum"],
-    #     start="2001-01-01",
-    #     blacklist=black,
-    #     years=None,
-    # )
+    cr = CategoryRelations(
+        dfdx,
+        xcats=["CRY", "XR"],
+        freq="M",
+        lag=1,
+        cids=cidx,
+        xcat_aggs=["mean", "sum"],
+        start="2001-01-01",
+        blacklist=black,
+        years=None,
+    )
 
-    # cr.reg_scatter(
-    #     labels=False,
-    #     separator=None,
-    #     title="Carry and Return",
-    #     xlab="Carry",
-    #     ylab="Return",
-    #     coef_box="lower left",
-    #     prob_est="map",
-    # )
+    cr.reg_scatter(
+        labels=False,
+        separator=None,
+        title="Carry and Return",
+        xlab="Carry",
+        ylab="Return",
+        coef_box="lower left",
+        prob_est="map",
+    )
 
-    # # years parameter
+    # years parameter
 
-    # cr = CategoryRelations(
-    #     dfdx,
-    #     xcats=["CRY", "XR"],
-    #     freq="M",
-    #     years=5,
-    #     lag=0,
-    #     cids=cidx,
-    #     xcat_aggs=["mean", "sum"],
-    #     start="2001-01-01",
-    #     blacklist=black,
-    # )
+    cr = CategoryRelations(
+        dfdx,
+        xcats=["CRY", "XR"],
+        freq="M",
+        years=5,
+        lag=0,
+        cids=cidx,
+        xcat_aggs=["mean", "sum"],
+        start="2001-01-01",
+        blacklist=black,
+    )
 
-    # cr.reg_scatter(
-    #     labels=False,
-    #     separator=None,
-    #     title="Carry and Return, 5-year periods",
-    #     xlab="Carry",
-    #     ylab="Return",
-    #     coef_box="lower left",
-    #     prob_est="map",
-    # )
+    cr.reg_scatter(
+        labels=False,
+        separator=None,
+        title="Carry and Return, 5-year periods",
+        xlab="Carry",
+        ylab="Return",
+        coef_box="lower left",
+        prob_est="map",
+    )
 
     cr = CategoryRelations(
         dfdx,
@@ -930,15 +930,15 @@ if __name__ == "__main__":
         years=None,
     )
 
-    # cr.reg_scatter(
-    #     labels=False,
-    #     separator=2010,
-    #     title="Carry and Return",
-    #     xlab="Carry",
-    #     ylab="Return",
-    #     coef_box="lower left",
-    #     ncol=5,
-    # )
+    cr.reg_scatter(
+        labels=False,
+        separator=2010,
+        title="Carry and Return",
+        xlab="Carry",
+        ylab="Return",
+        coef_box="lower left",
+        ncol=5,
+    )
     cr.reg_scatter(
         labels=False,
         separator="cids",
@@ -947,25 +947,24 @@ if __name__ == "__main__":
         ylab="Next month's return on 2-year IRS return, vol-targeted position, %",
         coef_box="lower left",
         ncol=2,
-        size=(12, 8),
-        #single_plot=True,
+        single_plot=True,
     )
 
-    # # Passing Axes object for a subplot
-    # fig, ax = plt.subplots(1, 2, figsize=(12, 8))
+    # Passing Axes object for a subplot
+    fig, ax = plt.subplots(1, 2, figsize=(12, 8))
 
-    # for i in range(2):
-    #     cr.reg_scatter(
-    #         labels=False,
-    #         separator=None,
-    #         title="Carry and Return",
-    #         xlab="Carry",
-    #         ylab="Return",
-    #         coef_box="lower left",
-    #         prob_est="map",
-    #         ax=ax[i],
-    #     )
-    # plt.show()
+    for i in range(2):
+        cr.reg_scatter(
+            labels=False,
+            separator=None,
+            title="Carry and Return",
+            xlab="Carry",
+            ylab="Return",
+            coef_box="lower left",
+            prob_est="map",
+            ax=ax[i],
+        )
+    plt.show()
 
-    # cr.ols_table(type="pool")
-    # cr.ols_table(type="re")
+    cr.ols_table(type="pool")
+    cr.ols_table(type="re")


### PR DESCRIPTION
Allows all cross sections in the dataframe to be plotted on one plot in reg_scatter: 

![image](https://github.com/macrosynergy/macrosynergy/assets/146712777/4cc4f56f-b57c-4b77-9b0a-28f7a1f6c460)

Bug fix is to prevent an error from being thrown when single_chart = True is called

Format change allows size adjustment of Facetplot reg scatter