### PR TITLE
Feature: Adding `get_releases` and `to_json` methods for `InformationStateChanges` class

### DIFF
--- a/macrosynergy/management/utils/sparse.py
+++ b/macrosynergy/management/utils/sparse.py
@@ -10,6 +10,7 @@ from macrosynergy.management.utils import (
     concat_single_metric_qdfs,
     get_cid,
     get_xcat,
+    is_valid_iso_date,
 )
 from macrosynergy.management.types import QuantamentalDataFrame
 
@@ -365,7 +366,7 @@ def infer_frequency(df: QuantamentalDataFrame) -> pd.Series:
     :return: A Series with the inferred frequency for each ticker in the QuantamentalDataFrame.
     """
     if not isinstance(df, QuantamentalDataFrame):
-        raise ValueError("`df` must be a QuantamentalDataFrame")
+        raise TypeError("`df` must be a QuantamentalDataFrame")
     if not "eop_lag" in df.columns:
         raise ValueError("`df` must contain an `eop_lag` column")
 
@@ -816,9 +817,9 @@ class InformationStateChanges(object):
         if excl_xcats is not None:
             excl_xcat_err = "`excl_xcats` must be a list of strings"
             if not isinstance(excl_xcats, list):
-                raise ValueError(excl_xcat_err)
+                raise TypeError(excl_xcat_err)
             if not all(isinstance(x, str) for x in excl_xcats):
-                raise ValueError(excl_xcat_err)
+                raise TypeError(excl_xcat_err)
 
         if not isinstance(latest_only, bool):
             raise ValueError("`latest_only` must be a boolean")
@@ -826,7 +827,9 @@ class InformationStateChanges(object):
         dt_err = "`{varname}` must be a `pd.Timestamp` or an ISO formatted date"
         for var_name in ["from_date", "to_date"]:
             if not isinstance(eval(var_name), (pd.Timestamp, str, type(None))):
-                raise ValueError(dt_err.format(varname=var_name))
+                raise TypeError(dt_err.format(varname=var_name))
+            if isinstance(eval(var_name), str):
+                is_valid_iso_date(eval(var_name))
 
         if from_date is None:
             from_date = self._min_period

--- a/macrosynergy/management/utils/sparse.py
+++ b/macrosynergy/management/utils/sparse.py
@@ -778,7 +778,6 @@ class InformationStateChanges(object):
     ) -> Dict[
         str, Union[List[Tuple[str, float, str, float]], Tuple[str, str, str], str]
     ]:
-        # TODO store as arrays instead: [{"data": {"real_date": [], "value": [], "eop": [], "grading": []}}]
         data = [
             (f"{index:%Y-%m-%d}", row.value, f"{row.eop:%Y-%m-%d}", row.grading)
             for index, row in self[ticker][["value", "eop", "grading"]].iterrows()
@@ -859,8 +858,6 @@ class InformationStateChanges(object):
                 }
             )
 
-        # TODO: return all cols, or only these? (currently all)
-        # ["ticker", "real_date", "eop", "value", "change", "version"]
         rel = (
             pd.DataFrame(store)
             .sort_values(by=["real_date", "eop", "ticker"])
@@ -869,7 +866,6 @@ class InformationStateChanges(object):
         )
 
         if excl_xcats:
-            # rel = rel[~rel["ticker"].str.contains("|".join(excl_xcats))]
             rel = rel[~pd.Series(get_xcat(rel["ticker"])).isin(excl_xcats)]
 
         if latest_only:

--- a/macrosynergy/management/utils/sparse.py
+++ b/macrosynergy/management/utils/sparse.py
@@ -811,7 +811,6 @@ class InformationStateChanges(object):
         :param <List[str]> excl_xcats: A list of xcats to exclude from the releases.
         :param <bool> latest_only: If True, only the latest release for each ticker is
             returned. Default is True.
-        # TODO : verify `latest_only` behavior
         """
 
         if excl_xcats is not None:

--- a/macrosynergy/management/utils/sparse.py
+++ b/macrosynergy/management/utils/sparse.py
@@ -816,16 +816,16 @@ class InformationStateChanges(object):
                 s = s[s.index >= from_date]
                 s = s[s.index <= to_date]
 
-            real_date: pd.Timestamp = s.last_valid_index()
+            last_valid_index = s.last_valid_index()
 
             store.append(
                 (
                     k,
-                    real_date,
-                    s["eop"].iloc[0],
-                    s["value"].iloc[0],
-                    s["diff"].iloc[0],
-                    s["version"].iloc[0],
+                    last_valid_index,
+                    s["eop"].loc[last_valid_index],
+                    s["value"].loc[last_valid_index],
+                    s["diff"].loc[last_valid_index],
+                    s["version"].loc[last_valid_index],
                 )
             )
 

--- a/macrosynergy/management/utils/sparse.py
+++ b/macrosynergy/management/utils/sparse.py
@@ -837,6 +837,13 @@ class InformationStateChanges(object):
             from_date, to_date = to_date, from_date
 
         rel: pd.DataFrame = self.get_latest_releases(excl_xcats=excl_xcats)
+
+        # BUG: the user is cannot query any other period except for the latest release.
+        # -- let's say the latest release is for 2021-09-30,
+        # and the user requests a date range that does not include this date,
+        # then this function is redundant; same functionality can be achieved by
+        # using the `get_latest_releases` method.
+        
         mask = (rel["real_date"] >= from_date) & (rel["real_date"] <= to_date)
 
         return rel.loc[mask].set_index("ticker")

--- a/macrosynergy/management/utils/sparse.py
+++ b/macrosynergy/management/utils/sparse.py
@@ -1,5 +1,6 @@
-from typing import Dict, List, Any, Union, Optional, Callable
+from typing import Dict, List, Any, Union, Optional, Callable, Tuple
 from numbers import Number
+import json
 
 import pandas as pd
 import numpy as np
@@ -761,6 +762,62 @@ class InformationStateChanges(object):
             postfix=postfix,
             metrics=metrics,
         )
+
+    def to_dict(
+            self, ticker: str
+        ) -> Dict[str, Union[List[Tuple[str, float, str, float]], Tuple[str, str, str], str]]:
+        # TODO store as arrays instead: [{"data": {"real_date": [], "value": [], "eop": [], "grading": []}}]
+        data = [
+            (f"{index:%Y-%m-%d}", row.value, f"{row.eop:%Y-%m-%d}", row.grading)
+            for index, row in self[ticker][["value", "eop", "grading"]].iterrows()
+        ]
+
+        columns = ("real_date", "value", "eop", "grading")
+        return_dict = {
+            "data": data,
+            "columns": columns,
+            "last_real_date": f"{self._max_period:%Y-%m-%d}",
+            "ticker": ticker
+        }
+        return return_dict
+
+    def to_json(self, ticker: str) -> str:
+        return json.dumps(self.to_dict(ticker))
+
+    def get_releases(
+        self,
+        from_date: pd.Timestamp = pd.Timestamp.today().normalize() - pd.offsets.BDay(1),
+        to_date: pd.Timestamp = pd.Timestamp.today().normalize(),
+        excl_xcats: List[str] = None,
+    ) -> pd.DataFrame:
+        store = []
+        for k, v in self.items():
+            real_date = v.index.max()
+            s = v[v.index == real_date]
+            store.append(
+                (
+                    k,
+                    real_date,
+                    s.eop.iloc[0],
+                    s.value.iloc[0],
+                    s['diff'].iloc[0],
+                    s.version.iloc[0]
+                )
+            )
+
+        rel = pd.DataFrame(
+            store,
+            columns=["ticker", "real_date", "eop", "value", "change", "version"]
+        ).sort_values(by=["real_date", "eop", "ticker"]).reset_index(drop=True)
+
+        mask = (
+            (rel.real_date >= from_date)
+            & (rel.real_date <= to_date)
+        )
+        if excl_xcats:
+            mask &= ~rel.ticker.str.contains("|".join(excl_xcats))
+        
+        return rel.loc[mask].set_index("ticker")
 
     def temporal_aggregator_period(
         self,

--- a/tests/unit/management/test_sparse.py
+++ b/tests/unit/management/test_sparse.py
@@ -530,6 +530,19 @@ class TestInformationStateChanges(unittest.TestCase):
         missing_cols: Set[str] = set(expc_cols) - set(res.columns)
         self.assertTrue(len(missing_cols) == 0, f"Missing columns: {missing_cols}")
 
+        # test get_releases warning when dates are swapped
+        with self.assertWarns(UserWarning):
+            isc_obj.get_releases(from_date=to_date, to_date=from_date)
+
+        with self.assertRaises(ValueError):
+            isc_obj.get_releases(from_date="banana")
+
+        with self.assertRaises(ValueError):
+            isc_obj.get_releases(latest_only="banana")
+
+        # test with dates=None
+        res = isc_obj.get_releases(from_date=None, to_date=None)
+
     def test_get_releases_latest(self):
         qdf = get_long_format_data(
             start="2020-01-01",

--- a/tests/unit/management/test_sparse.py
+++ b/tests/unit/management/test_sparse.py
@@ -483,8 +483,10 @@ class TestInformationStateChanges(unittest.TestCase):
             isc_obj.calculate_score(**{**argsdict, "std": "banana"})
 
     def test_get_releases(self):
-        ...
-        # TODO
+        qdf = get_long_format_data(end="2012-01-01")
+        isc_obj = InformationStateChanges.from_qdf(qdf)
+        res = isc_obj.get_latest_releases()
+        self.assertTrue(isinstance(res, pd.DataFrame))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add three methods to the class:

* `to_dict`: creates a dictionary of the sparse data for a specific ticker.
* `to_json`: creates a JSON string from the output of `to_dict`.
* `get_releases`: extract the data release between two dates (defaults is all release from last business day till today).