### PR TITLE
Bugfix: Change `update_df` to skip empty dataframes

### DIFF
--- a/macrosynergy/management/utils/df_utils.py
+++ b/macrosynergy/management/utils/df_utils.py
@@ -431,6 +431,11 @@ def update_df(df: pd.DataFrame, df_add: pd.DataFrame, xcat_replace: bool = False
     if all_cols != df_cols and all_cols != df_add_cols:
         raise ValueError(error_message)
 
+    if df.empty:
+        return df_add
+    elif df_add.empty:
+        return df
+
     if not xcat_replace:
         df = update_tickers(df, df_add)
 

--- a/tests/unit/management/test_update_df.py
+++ b/tests/unit/management/test_update_df.py
@@ -435,8 +435,17 @@ class TestAll(unittest.TestCase):
 
     def test_update_df_preserves_original(self):
         test_df = self.dfd.copy()
-        result_df = update_df(test_df, test_df)
+        _ = update_df(test_df, test_df)
         self.assertTrue(test_df.equals(self.dfd))
+
+    def test_update_df_empty_df(self):
+        test_df = self.dfd.copy()
+        empty_df = pd.DataFrame(columns=test_df.columns)
+        result_df = update_df(test_df, empty_df)
+        self.assertTrue(test_df.equals(result_df))
+
+        result_df = update_df(empty_df, test_df)
+        self.assertTrue(test_df.equals(result_df))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Currently `update_df` accepts and processes empty dataframes, which results in a warning from `pandas`: 

```bash
FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation.
```

simple fix:
```
if df_left.empty: return df_right
if df_right.empty: return df_left
```
