### PR TITLE
Bugfix: Refactor `drop_nan_series` function to use the specified column

### DIFF
--- a/macrosynergy/management/utils/df_utils.py
+++ b/macrosynergy/management/utils/df_utils.py
@@ -119,7 +119,7 @@ def drop_nan_series(
     if not column in df.columns:
         raise ValueError(f"Column {column} not present in DataFrame.")
 
-    if not df["value"].isna().any():
+    if not df[column].isna().any():
         return df
 
     if not isinstance(raise_warning, bool):
@@ -129,7 +129,7 @@ def drop_nan_series(
     for cd, xc in df_orig.groupby(["cid", "xcat"]).groups:
         sel_series: pd.Series = df_orig[
             (df_orig["cid"] == cd) & (df_orig["xcat"] == xc)
-        ]["value"]
+        ][column]
         if sel_series.isna().all():
             if raise_warning:
                 warnings.warn(


### PR DESCRIPTION
The `drop_nan_series` function has been refactored to use the specified column instead of hardcoding "value". This change ensures that the function is more flexible and can be used with any column in the DataFrame.