### PR TITLE
Bugfix: improve `repr` of InformationStateChanges class

### DIFF
--- a/macrosynergy/management/utils/sparse.py
+++ b/macrosynergy/management/utils/sparse.py
@@ -813,10 +813,10 @@ class InformationStateChanges(object):
         self.isc_dict[key] = value
 
     def __str__(self):
-        return str(self.isc_dict)
+        return f"InformationStateChanges object with tickers: {list(self.keys())}"
 
     def __repr__(self):
-        return repr(self.isc_dict)
+        return f"InformationStateChanges object with {len(self.keys())} tickers"
 
     def __add__(self, other):
         if not isinstance(other, InformationStateChanges):

--- a/tests/unit/management/test_sparse.py
+++ b/tests/unit/management/test_sparse.py
@@ -373,8 +373,6 @@ class TestInformationStateChanges(unittest.TestCase):
 
         self.assertEqual(set(isc.isc_dict.keys()), set(isc.keys()))
         # can't directly check the values and items as they are not hashable
-        self.assertEqual(str(isc), str(isc.isc_dict))
-        self.assertEqual(repr(isc), repr(isc.isc_dict))
 
         first_dict_key = list(isc.isc_dict.keys())[0]
         self.assertTrue((isc[first_dict_key]).equals(isc.isc_dict[first_dict_key]))

--- a/tests/unit/management/test_sparse.py
+++ b/tests/unit/management/test_sparse.py
@@ -367,13 +367,18 @@ class TestInformationStateChanges(unittest.TestCase):
     def test_class_methods(self) -> None:
         # test the class methods
         qdf = get_long_format_data(end="2012-01-01")
-        isc = InformationStateChanges.from_qdf(qdf)
+        isc: InformationStateChanges = InformationStateChanges.from_qdf(qdf)
         self.assertTrue(isinstance(isc, InformationStateChanges))
         self.assertTrue(isinstance(isc.isc_dict, dict))
 
         self.assertEqual(set(isc.isc_dict.keys()), set(isc.keys()))
         # can't directly check the values and items as they are not hashable
 
+        tks = (qdf["cid"] + "_" + qdf["xcat"]).unique().tolist()
+        self.assertTrue(str(tks) in str(isc))
+        self.assertEqual(
+            repr(isc), f"InformationStateChanges object with {len(tks)} tickers"
+        )
         first_dict_key = list(isc.isc_dict.keys())[0]
         self.assertTrue((isc[first_dict_key]).equals(isc.isc_dict[first_dict_key]))
 


### PR DESCRIPTION
Currently, the `InformationStateChanges.__repr__` loads the entire dict with DataFrames in the repr, this can take ~1 second for larger objects