### PR TITLE
Bugfix: `msp.Basket.make_basket()`, errors when using `weight_meth="values"`

### DIFF
--- a/macrosynergy/panel/basket.py
+++ b/macrosynergy/panel/basket.py
@@ -120,11 +120,19 @@ class Basket(object):
             pfx = [pfx] if isinstance(pfx, str) else pfx
             self.__dict__[pf_name] = pfx
 
-            dfws_pfx = {}
+            dfws_pfx: Dict[str, pd.DataFrame] = {}
             for cat in pfx:
                 ticks = [con + cat for con in self.contracts]
                 self.__dict__["ticks_" + pf_name] += ticks
                 dfws_pfx[cat] = self.pivot_dataframe(df, ticks)
+                if dfws_pfx[cat].empty:
+                    raise ValueError(f"Empty dataframe for contract-type: {cat}")
+                missing = set(ticks) - set(dfws_pfx[cat].columns)
+                if missing:
+                    raise ValueError(
+                        f"Missing tickers in dataframe for contract-type: {cat}: {missing}"
+                    )
+
         else:
             dfws_pfx = None
 

--- a/macrosynergy/panel/basket.py
+++ b/macrosynergy/panel/basket.py
@@ -73,6 +73,9 @@ class Basket(object):
         c_error = "Contracts must be a list of strings."
         assert all(isinstance(c, str) for c in contracts), c_error
         assert isinstance(ret, str), "`ret` must be a string"
+        if isinstance(ewgts, str):
+            warnings.warn("Expects a list of strings for `ewgts`. Converted to list.")
+            ewgts = [ewgts]
 
         df = reduce_df_by_ticker(
             df, start=start, end=end, ticks=None, blacklist=blacklist


### PR DESCRIPTION
Add correct exception handling for missing data; type casting from string to list of strings for `ewgts` param.