### PR TITLE
Bugfix: `CategoryRelations.reg_scatter()` for case with `labels=None, separator="cids"`

### DIFF
--- a/macrosynergy/panel/category_relations.py
+++ b/macrosynergy/panel/category_relations.py
@@ -607,7 +607,11 @@ class CategoryRelations(object):
         if coef_box is not None:
             assert isinstance(coef_box, str), coef_box_loc_error
 
-        assert prob_est in ["pool", "map", "kendall"], "prob_est must be 'pool', 'kendall' or 'map'"
+        assert prob_est in [
+            "pool",
+            "map",
+            "kendall",
+        ], "prob_est must be 'pool', 'kendall' or 'map'"
 
         sns.set_theme(style="whitegrid")
         dfx = self.df.copy()
@@ -937,7 +941,8 @@ class CategoryRelations(object):
         else:
             ValueError("Separator must be either a valid year <int> or 'cids' <str>.")
 
-        ax.tick_params(axis='both', labelsize=tick_fontsize)
+        if isinstance(ax, plt.Axes):
+            ax.tick_params(axis="both", labelsize=tick_fontsize)
         plt.tight_layout()
         if show_plot:
             plt.show()

--- a/tests/unit/panel/test_category_relations.py
+++ b/tests/unit/panel/test_category_relations.py
@@ -804,6 +804,37 @@ class TestAll(unittest.TestCase):
                 "CategoryRelations failed when using seperator=2012, xcat1_chg=diff"
             )
 
+    def test_reg_scatter_no_label(self):
+        try:
+            cids_test = ["USD", "GBP", "JPY", "EUR"]
+            xcats_test = ["XCAT1", "XCAT2"]
+
+            dfx = make_test_df(cids=cids_test, xcats=xcats_test, start="2010-01-01")
+
+            cr = CategoryRelations(
+                df=dfx,
+                xcats=xcats_test,
+                cids=cids_test,
+                freq="M",  # TODO in principle select monthly to get more accurate picture...
+                lag=0,
+                xcat_aggs=["last", "last"],
+                start="2000-01-01",
+                xcat_trims=[None, None],
+            )
+
+            cr.reg_scatter(
+                labels=False,
+                coef_box="upper left",
+                title="FX consistent core CPI excess inflation",
+                xlab="ZN-scored signal",
+                ylab="signal",
+                separator="cids",
+            )
+        except:
+            self.fail(
+                "CategoryRelations failed when using seperator=cids, labels=False"
+            )
+
     def test_int_seperator(self):
         try:
             cids_test = ["USD", "GBP", "JPY", "EUR"]


### PR DESCRIPTION
Address a minor bug in the `reg_scatter` function and introduce a test for the case where labels are set to None and the separator is 'cids'.