### PR TITLE
Feature: `JPMaQSDownload`, default `end_date` to use last business day instead of 2-days-ahead

### DIFF
--- a/macrosynergy/download/jpmaqs.py
+++ b/macrosynergy/download/jpmaqs.py
@@ -1410,13 +1410,8 @@ class JPMaQSDownload(DataQueryInterface):
                 metrics = self.valid_metrics
 
         if end_date is None:
-            end_date = (datetime.datetime.today() + pd.offsets.BusinessDay(2)).strftime(
-                "%Y-%m-%d"
-            )
-            # NOTE : due to timezone conflicts, we choose to request data for 2 days in
-            # the future.
-            # NOTE : DataQuery specifies YYYYMMDD as the date format, but we use
-            # YYYY-MM-DD for consistency.
+            _today = datetime.datetime.today()
+            end_date = pd.bdate_range(end=_today, periods=2)[0].strftime("%Y-%m-%d")
             # This is date is cast to YYYYMMDD in macrosynergy.download.dataquery.py.
 
         # Validate arguments.

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,8 @@ if sys.version_info[:2] < (3, 7):
 
 MAJOR = 1
 MINOR = 1
-MICRO = 0
-ISRELEASED = True
+MICRO = 1
+ISRELEASED = False
 VERSION = "%d.%d.%d" % (MAJOR, MINOR, MICRO)
 
 if sys.version_info >= (3, 13):


### PR DESCRIPTION
Update the default behavior for end_date to use the last business day instead of a date two days ahead.
This change is being made to prevent issues with zn-scoring in notebooks, as it can happen that we download a few select series for today and then form the scored average over these few series or even a single series This would distort factors and signals and the end of the timeline.