### PR TITLE
Feature: `InformationStateChanges`, add `score_by` parameter for z-scoring methods

### DIFF
--- a/macrosynergy/management/utils/sparse.py
+++ b/macrosynergy/management/utils/sparse.py
@@ -448,6 +448,7 @@ class InformationStateChanges(object):
         custom_method: Optional[Callable] = None,
         custom_method_kwargs: Dict = {},
         volatility_forecast: bool = True,
+        score_by: Literal["diff", "level"] = "diff",
     ):
         """
         Calculate score on sparse indicator for the InformationStateChanges object.
@@ -478,6 +479,11 @@ class InformationStateChanges(object):
         volatility_forecast : bool
             If True (default), the volatility forecast is shifted one period forward to
             align with the information state changes.
+        score_by : Literal["diff", "level"]
+            The method to use for scoring. If "diff" (default), the score is calculated
+            based on the difference between the information state changes. If "level", the
+            score is calculated based on the value ('level') of the information state
+            change.
 
         Returns
         -------
@@ -495,6 +501,7 @@ class InformationStateChanges(object):
             custom_method=custom_method,
             custom_method_kwargs=custom_method_kwargs,
             volatility_forecast=volatility_forecast,
+            score_by=score_by,
         )
         return self
 

--- a/macrosynergy/management/utils/sparse.py
+++ b/macrosynergy/management/utils/sparse.py
@@ -1432,7 +1432,7 @@ def _calculate_score_on_sparse_indicator_for_class(
 
     for key, v in cls.isc_dict.items():
         if not score_by_column in v.columns:
-            raise ValueError(f"Column {score_by_column} not in for ticker {key}")
+            raise ValueError(f"Column `{score_by_column}` not in for ticker {key}")
 
     curr_method: Callable[[pd.Series, Optional[Dict[str, Any]]], pd.Series]
     if custom_method is not None:

--- a/macrosynergy/management/utils/sparse.py
+++ b/macrosynergy/management/utils/sparse.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Any, Union, Optional, Callable, Tuple, Literal
+from typing import Dict, List, Any, Union, Optional, Callable, Tuple
 from collections.abc import KeysView, ValuesView, ItemsView
 from numbers import Number
 import json
@@ -448,7 +448,7 @@ class InformationStateChanges(object):
         custom_method: Optional[Callable] = None,
         custom_method_kwargs: Dict = {},
         volatility_forecast: bool = True,
-        score_by: Literal["diff", "level"] = "diff",
+        score_by: str = "diff",
     ):
         """
         Calculate score on sparse indicator for the InformationStateChanges object.
@@ -479,7 +479,7 @@ class InformationStateChanges(object):
         volatility_forecast : bool
             If True (default), the volatility forecast is shifted one period forward to
             align with the information state changes.
-        score_by : Literal["diff", "level"]
+        score_by : str
             The method to use for scoring. If "diff" (default), the score is calculated
             based on the difference between the information state changes. If "level", the
             score is calculated based on the value ('level') of the information state
@@ -1410,7 +1410,7 @@ def _calculate_score_on_sparse_indicator_for_class(
     custom_method: Optional[Callable] = None,
     custom_method_kwargs: Dict = {},
     volatility_forecast: bool = True,
-    score_by: Literal["diff", "level"] = "diff",
+    score_by: str = "diff",
 ):
     """
     Calculate score on sparse indicator for a class. Effectively a re-implementation of

--- a/tests/unit/management/test_sparse.py
+++ b/tests/unit/management/test_sparse.py
@@ -830,6 +830,20 @@ class TestInformationStateChangesScoreBy(unittest.TestCase):
         with self.assertRaises(ValueError):
             InformationStateChanges.from_qdf(qdf, score_by="banana")
 
+    def test_score_by_unplanned_method(self):
+        qdf = get_long_format_data(end="2015-01-01")
+        test_options = {"apple": "banana"}
+        expected_err = "Column `banana` not in"
+        with unittest.mock.patch(
+            "macrosynergy.management.utils.sparse.SCORE_BY_OPTIONS", test_options
+        ):
+            try:
+                InformationStateChanges.from_qdf(qdf, score_by="apple")
+            except ValueError as e:
+                self.assertIn(expected_err, str(e))
+            except Exception as e:
+                self.fail(f"Expected ValueError, got {type(e)}")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/management/test_sparse.py
+++ b/tests/unit/management/test_sparse.py
@@ -785,5 +785,51 @@ class TestInformationStateChanges(unittest.TestCase):
         self.assertTrue(outdf["xcat"].dtype.name == "object")
 
 
+class TestInformationStateChangesScoreBy(unittest.TestCase):
+    def test_score_by_diff(self):
+        qdf = get_long_format_data(end="2015-01-01")
+        isc: InformationStateChanges = InformationStateChanges.from_qdf(qdf)
+
+        isc_score_by_diff = InformationStateChanges.from_qdf(qdf, score_by="diff")
+
+        for ticker in isc.keys():
+            self.assertTrue(isc[ticker].equals(isc_score_by_diff[ticker]))
+
+    def test_score_by_level(self):
+        qdf = get_long_format_data(end="2015-01-01")
+
+        isc_score_by_level = InformationStateChanges.from_qdf(qdf, score_by="level")
+        isc_score_by_diff = InformationStateChanges.from_qdf(qdf, score_by="diff")
+
+        all_isna = []
+        for ticker in isc_score_by_diff.keys():
+            if isc_score_by_level[ticker]["zscore"].isna().all():
+                all_isna.append(ticker)
+                continue
+            self.assertFalse(
+                isc_score_by_diff[ticker].equals(isc_score_by_level[ticker])
+            )
+
+        if len(all_isna) == len(isc_score_by_diff.keys()):
+            self.fail("All tickers have NaNs in zscore when using score_by='level'")
+
+    def test_score_by_patch(self):
+        qdf = get_long_format_data(end="2015-01-01")
+
+        for sc_by in ["level", "diff"]:
+            with unittest.mock.patch(
+                "macrosynergy.management.utils.sparse._calculate_score_on_sparse_indicator_for_class"
+            ) as mock:
+                isc = InformationStateChanges.from_qdf(qdf, norm=True, score_by=sc_by)
+                mock.assert_called_once()
+                self.assertEqual(mock.call_args[1]["score_by"], sc_by)
+
+    def test_score_by_invalid_method(self):
+        qdf = get_long_format_data(end="2015-01-01")
+
+        with self.assertRaises(ValueError):
+            InformationStateChanges.from_qdf(qdf, score_by="banana")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Introduce a `score_by` parameter to the scoring methods, allowing selection between scoring based on the difference or the level of information state changes. This enhances flexibility in score calculation.

---
Closes #2219 