### PR TITLE
Feature: Update `temporary_seed` functionality to handle None and non-integer seeds

### DIFF
--- a/macrosynergy/management/simulate/simulate_quantamental_data.py
+++ b/macrosynergy/management/simulate/simulate_quantamental_data.py
@@ -94,10 +94,13 @@ def dataframe_generator(
 
 
 @contextlib.contextmanager
-def temporary_seed(seed: int):
+def temporary_seed(seed: Optional[int]):
     """
     A context manager that temporarily sets the seed for both NumPy and Python's random.
     """
+    if seed is None or not isinstance(seed, int):
+        return  # no seed - do nothing.
+
     np_state = np.random.get_state()
     random_state = random.getstate()
 

--- a/macrosynergy/management/simulate/simulate_quantamental_data.py
+++ b/macrosynergy/management/simulate/simulate_quantamental_data.py
@@ -99,6 +99,7 @@ def temporary_seed(seed: Optional[int]):
     A context manager that temporarily sets the seed for both NumPy and Python's random.
     """
     if seed is None or not isinstance(seed, int):
+        yield
         return  # no seed - do nothing.
 
     np_state = np.random.get_state()

--- a/tests/simulate.py
+++ b/tests/simulate.py
@@ -32,10 +32,13 @@ def simulate_ar(nobs: int, mean: float = 0, sd_mult: float = 1, ar_coef: float =
 
 
 @contextlib.contextmanager
-def temporary_seed(seed: int):
+def temporary_seed(seed: Optional[int]):
     """
     A context manager that temporarily sets the seed for both NumPy and Python's random.
     """
+    if seed is None or not isinstance(seed, int):
+        return  # no seed - do nothing.
+
     np_state = np.random.get_state()
     random_state = random.getstate()
 

--- a/tests/simulate.py
+++ b/tests/simulate.py
@@ -37,6 +37,7 @@ def temporary_seed(seed: Optional[int]):
     A context manager that temporarily sets the seed for both NumPy and Python's random.
     """
     if seed is None or not isinstance(seed, int):
+        yield
         return  # no seed - do nothing.
 
     np_state = np.random.get_state()


### PR DESCRIPTION
Modify the `temporary_seed` function to gracefully handle cases where the seed is None or not an integer, ensuring no action is taken in such scenarios.