### PR TITLE
Bugfix: Change compatibility check for pd.DataFrame.applymap

### DIFF
--- a/macrosynergy/compat.py
+++ b/macrosynergy/compat.py
@@ -22,3 +22,7 @@ PD_NEW_DATE_FREQ: bool = version.parse(pd.__version__) > version.parse("2.1.4")
 PD_OLD_RESAMPLE: bool = version.parse(pd.__version__) < version.parse("1.5.0")
 
 PD_2_0_OR_LATER: bool = version.parse(pd.__version__) >= version.parse("2.0.0")
+
+# Availability of pd.DataFrame.applymap/map
+# https://pandas.pydata.org/pandas-docs/version/2.1/reference/api/pandas.DataFrame.map.html
+PD_APPLY_MAP: bool = version.parse(pd.__version__) >= version.parse("2.1.0")

--- a/macrosynergy/panel/adjust_weights.py
+++ b/macrosynergy/panel/adjust_weights.py
@@ -10,7 +10,7 @@ from numbers import Number
 from macrosynergy.management.utils import reduce_df, get_cid
 from macrosynergy.management.simulate import make_test_df
 from macrosynergy.management.types import QuantamentalDataFrame
-from macrosynergy.compat import PYTHON_3_8_OR_LATER
+from macrosynergy.compat import PD_APPLY_MAP
 
 
 def check_missing_cids_xcats(weights, adj_zns, cids, r_xcats, r_cids):
@@ -91,7 +91,7 @@ def adjust_weights_backend(
     assert set(df_weights_wide.columns) == set(df_adj_zns_wide.columns)
     assert set(df_weights_wide.index) == set(df_adj_zns_wide.index)
 
-    if PYTHON_3_8_OR_LATER:
+    if PD_APPLY_MAP:
         dfw_result = df_weights_wide * df_adj_zns_wide.map(method, **params)
     else:
         dfw_result = df_weights_wide * df_adj_zns_wide.applymap(method, **params)


### PR DESCRIPTION
Introduce a compatibility check for the availability of `pd.DataFrame.applymap` and refactor the `adjust_weights_backend` function to utilize this check for improved compatibility with different pandas versions.