### PR TITLE
Feature: `InformationStateChanges` option to score by level

### DIFF
--- a/tests/unit/management/test_sparse.py
+++ b/tests/unit/management/test_sparse.py
@@ -830,20 +830,6 @@ class TestInformationStateChangesScoreBy(unittest.TestCase):
         with self.assertRaises(ValueError):
             InformationStateChanges.from_qdf(qdf, score_by="banana")
 
-    def test_score_by_unplanned_method(self):
-        qdf = get_long_format_data(end="2015-01-01")
-        test_options = {"apple": "banana"}
-        expected_err = "Column `banana` not in"
-        with unittest.mock.patch(
-            "macrosynergy.management.utils.sparse.SCORE_BY_OPTIONS", test_options
-        ):
-            try:
-                InformationStateChanges.from_qdf(qdf, score_by="apple")
-            except ValueError as e:
-                self.assertIn(expected_err, str(e))
-            except Exception as e:
-                self.fail(f"Expected ValueError, got {type(e)}")
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Add the option to score information state changes by either `diff` (default) or `level`.

In a previous PR (https://github.com/macrosynergy/macrosynergy/pull/2235), we modified for the normalisation, but not how we filtered to new information. Hence new information was captured as: `abs(Y(t) - Y(t-1)) > 0`
 
Which proxies the levels, but isn't exactly capturing it. Now with the levels, we assume that all the non-change is represented by zero (hence the filter: `diff_mask = values_df.abs() > 1e-12`).