### PR TITLE
Feature: Make `pnl_cats` parameter optional in `NaivePnL.evaluate_pnls()`

### DIFF
--- a/macrosynergy/pnl/naive_pnl.py
+++ b/macrosynergy/pnl/naive_pnl.py
@@ -1125,7 +1125,7 @@ class NaivePnL:
 
     def evaluate_pnls(
         self,
-        pnl_cats: List[str],
+        pnl_cats: Optional[List[str]] = None,
         pnl_cids: List[str] = ["ALL"],
         start: Optional[str] = None,
         end: Optional[str] = None,
@@ -1145,8 +1145,9 @@ class NaivePnL:
 
         Parameters
         ----------
-        pnl_cats : List[str]
-            list of PnL categories that should be plotted.
+        pnl_cats : List[str], optional
+            list of PnL categories that should be plotted. Default is None and all
+            available PnL categories are used.
         pnl_cids : List[str]
             list of cross-sections to be plotted; default is 'ALL' (global PnL). Note:
             one can only have multiple PnL categories or multiple cross-sections, not both.
@@ -1166,10 +1167,15 @@ class NaivePnL:
 
         error_cids = "List of cross-sections expected."
         error_xcats = "List of PnL categories expected."
-        assert isinstance(pnl_cids, list), error_cids
-        assert isinstance(pnl_cats, list), error_xcats
-        assert all([isinstance(elem, str) for elem in pnl_cids]), error_cids
-        assert all([isinstance(elem, str) for elem in pnl_cats]), error_xcats
+        if not isinstance(pnl_cids, list):
+            raise TypeError(error_cids)
+        if not isinstance(pnl_cats, (list, type(None))):
+            raise TypeError(error_xcats)
+        if pnl_cats is not None:
+            if not all([isinstance(elem, str) for elem in pnl_cats]):
+                raise TypeError(error_xcats)
+        if not all([isinstance(elem, str) for elem in pnl_cids]):
+            raise TypeError(error_cids)
 
         if pnl_cats is None:
             # The field, self.pnl_names, is a data structure that stores the name of the
@@ -1178,15 +1184,15 @@ class NaivePnL:
             # logical method: ('PNL_' + sig) if pnl_name is None else pnl_name. Each
             # category will be held in the data structure.
             pnl_cats = self.pnl_names
-        else:
-            if not set(pnl_cats) <= set(self.pnl_names):
-                missing = [pnl for pnl in pnl_cats if pnl not in self.pnl_names]
-                pnl_error = (
-                    f"Received PnL categories have not been defined. The PnL "
-                    f"category(s) which has not been defined is: {missing}. "
-                    f"The produced PnL category(s) are {self.pnl_names}."
-                )
-                raise ValueError(pnl_error)
+
+        if not set(pnl_cats) <= set(self.pnl_names):
+            missing = [pnl for pnl in pnl_cats if pnl not in self.pnl_names]
+            pnl_error = (
+                f"Received PnL categories have not been defined. The PnL "
+                f"category(s) which has not been defined is: {missing}. "
+                f"The produced PnL category(s) are {self.pnl_names}."
+            )
+            raise ValueError(pnl_error)
 
         assert (len(pnl_cats) == 1) | (len(pnl_cids) == 1)
 

--- a/tests/unit/pnl/test_naive_pnl.py
+++ b/tests/unit/pnl/test_naive_pnl.py
@@ -460,12 +460,16 @@ class TestAll(unittest.TestCase):
         # Confirm the direct negative correlation across the two PnLs. By adding the
         # correlation coefficients with the benchmarks, the value should equate to
         # zero.
-        df_eval = pnl.evaluate_pnls(
-            pnl_cats=["PNL_INFL", "PNL_INFL_NEG"],
-        )
+        df_eval = pnl.evaluate_pnls(pnl_cats=["PNL_INFL", "PNL_INFL_NEG"])
 
         bm_correl = df_eval.loc[[b + " correl" for b in bms], :]
         self.assertTrue(np.all(bm_correl.sum(axis=1).to_numpy()) == 0)
+
+        # test it works with no pnl_cats input
+        try:
+            pnl.evaluate_pnls()
+        except Exception as e:
+            self.fail(f"evaluate_pnls raised {e} unexpectedly")
 
     def test_make_long_pnl(self):
         ret = "EQXR"

--- a/tests/unit/pnl/test_naive_pnl.py
+++ b/tests/unit/pnl/test_naive_pnl.py
@@ -580,6 +580,17 @@ class TestAll(unittest.TestCase):
         )
         pnl.make_long_pnl(vol_scale=None, label=None)
 
+    def test_evaluate_pnls_type_checks(self):
+        ret = "EQXR"
+        sigs = ["CRY", "GROWTH", "INFL"]
+
+        pnl = NaivePnL(self.dfd, ret=ret, sigs=sigs)
+
+        for arg in ["pnl_cids", "pnl_cats"]:
+            for argval in [1, "A", [1]]:
+                with self.assertRaises(TypeError):
+                    pnl.evaluate_pnls(**{arg: argval})
+
     def test_plotting_methods(self):
         plt.close("all")
         mock_plt = patch("matplotlib.pyplot.show").start()

--- a/tests/unit/pnl/test_naive_pnl.py
+++ b/tests/unit/pnl/test_naive_pnl.py
@@ -595,6 +595,11 @@ class TestAll(unittest.TestCase):
                 with self.assertRaises(TypeError):
                     pnl.evaluate_pnls(**{arg: argval})
 
+        # pass a random pnl_cat
+        with self.assertRaises(ValueError):
+            pnl.evaluate_pnls(pnl_cats=["banana"])
+
+
     def test_plotting_methods(self):
         plt.close("all")
         mock_plt = patch("matplotlib.pyplot.show").start()


### PR DESCRIPTION
Update the evaluate_pnls method to make the pnl_cats parameter optional and enhance validation logic with type checks. Added tests to ensure functionality with and without pnl_cats input.