### PR TITLE
Chore: Update GitHub Actions to use ubuntu-latest for python3.7 unit tests

### DIFF
--- a/.github/actions/restore-pip-cache/action.yml
+++ b/.github/actions/restore-pip-cache/action.yml
@@ -23,6 +23,12 @@ runs:
       activate-environment: macrosynergy-env
       auto-activate-base: false
 
+  - name: Set pythonLocation for Miniconda
+    if: startsWith(inputs.python-version, '3.7')
+    shell: bash -l {0}
+    run: |
+      echo "pythonLocation=$(which python)" >> $GITHUB_ENV
+
   - name: Get Week Number
     shell: bash
     id: week

--- a/.github/actions/restore-pip-cache/action.yml
+++ b/.github/actions/restore-pip-cache/action.yml
@@ -9,10 +9,19 @@ inputs:
 runs:
   using: "composite"
   steps:
-  - name: Setup Python
+  - name: Setup Python (Python >= 3.8)
+    if: '!startsWith(inputs.python-version, "3.7")'
     uses: actions/setup-python@v5
     with:
       python-version: ${{ inputs.python-version }}
+
+  - name: Setup Miniconda (Python 3.7)
+    if: startsWith(inputs.python-version, "3.7")
+    uses: conda-incubator/setup-miniconda@v3
+    with:
+      python-version: ${{ inputs.python-version }}
+      activate-environment: macrosynergy-env
+      auto-activate-base: false
 
   - name: Get Week Number
     shell: bash
@@ -23,20 +32,18 @@ runs:
     id: cache
     uses: actions/cache@v4
     with:
-      # using OS-name + "pip" + hash of TOML + week number as key
       path: ${{ env.pythonLocation }}
       key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}-${{ env.week }}
       restore-keys: |
         ${{ runner.os }}-pip-
 
   - name: Install dependencies if cache was not found (Python 3.7)
-    shell: bash
+    shell: bash -l {0}
     if: steps.cache.outputs.cache-hit != 'true' && startsWith(inputs.python-version, '3.7')
     run: |
       pip install . --no-deps
       pip install -r tests/requirements-py37.txt
       pip uninstall -y macrosynergy
-      # No explicit caching step is needed as the cache action takes care of this 
 
   - name: Install dependencies if cache was not found (Python >= 3.8)
     shell: bash
@@ -44,4 +51,3 @@ runs:
     run: |
       pip install .[all,test]
       pip uninstall -y macrosynergy
-      # No explicit caching step is needed as the cache action takes care of this

--- a/.github/actions/restore-pip-cache/action.yml
+++ b/.github/actions/restore-pip-cache/action.yml
@@ -20,8 +20,8 @@ runs:
     uses: conda-incubator/setup-miniconda@v3
     with:
       python-version: ${{ inputs.python-version }}
-      activate-environment: macrosynergy-env
-      auto-activate-base: false
+      # activate-environment: macrosynergy-env
+      auto-activate-base: true
 
   - name: Set pythonLocation for Miniconda
     if: startsWith(inputs.python-version, '3.7')

--- a/.github/actions/restore-pip-cache/action.yml
+++ b/.github/actions/restore-pip-cache/action.yml
@@ -10,13 +10,13 @@ runs:
   using: "composite"
   steps:
   - name: Setup Python (Python >= 3.8)
-    if: '!startsWith(inputs.python-version, "3.7")'
+    if: "!startsWith(inputs.python-version, '3.7')"
     uses: actions/setup-python@v5
     with:
       python-version: ${{ inputs.python-version }}
 
   - name: Setup Miniconda (Python 3.7)
-    if: startsWith(inputs.python-version, "3.7")
+    if: startsWith(inputs.python-version, '3.7')
     uses: conda-incubator/setup-miniconda@v3
     with:
       python-version: ${{ inputs.python-version }}

--- a/.github/actions/restore-pip-cache/action.yml
+++ b/.github/actions/restore-pip-cache/action.yml
@@ -20,7 +20,7 @@ runs:
     uses: conda-incubator/setup-miniconda@v3
     with:
       python-version: ${{ inputs.python-version }}
-      # activate-environment: macrosynergy-env
+      activate-environment: base
       auto-activate-base: true
 
   - name: Set pythonLocation for Miniconda

--- a/.github/actions/restore-pip-cache/action.yml
+++ b/.github/actions/restore-pip-cache/action.yml
@@ -49,6 +49,7 @@ runs:
     run: |
       pip install . --no-deps
       pip install -r tests/requirements-py37.txt
+      pip install flake8
       pip uninstall -y macrosynergy
 
   - name: Install dependencies if cache was not found (Python >= 3.8)
@@ -57,3 +58,4 @@ runs:
     run: |
       pip install .[all,test]
       pip uninstall -y macrosynergy
+      # No explicit caching step is needed as the cache action takes care of this

--- a/.github/workflows/python-unit-tests-py37.yml
+++ b/.github/workflows/python-unit-tests-py37.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   prepare-matrix:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -21,7 +21,7 @@ jobs:
 
   run-unit-tests:
     needs: prepare-matrix
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         folder: ${{fromJson(needs.prepare-matrix.outputs.matrix)}}

--- a/.github/workflows/python-unit-tests-py37.yml
+++ b/.github/workflows/python-unit-tests-py37.yml
@@ -28,10 +28,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Restore caches - Python 3.7.9
+      - name: Restore caches - Python 3.7.13
         uses: ./.github/actions/restore-pip-cache
         with:
-          python-version: 3.7.9
+          python-version: 3.7.13
 
       - name: Check for sys.path.append
         run: |

--- a/.github/workflows/python-unit-tests-py37.yml
+++ b/.github/workflows/python-unit-tests-py37.yml
@@ -28,10 +28,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Restore caches - Python 3.7.13
+      - name: Restore caches - Python 3.7.9
         uses: ./.github/actions/restore-pip-cache
         with:
-          python-version: 3.7.13
+          python-version: 3.7.9
 
       - name: Check for sys.path.append
         run: |


### PR DESCRIPTION
Switch the GitHub Actions configuration to use `ubuntu-22.04` instead of `ubuntu-20.04` for running Python3.7 unit tests.

See https://github.com/actions/runner-images/issues/11101 for more info.

Also updating the Python version from `3.7.9` to `3.7.13`. This is because Python `3.7.9` is not available on `ubuntu-22.04`


Link to Python versions manifest used: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json