### PR TITLE
Bugfix: Change the definition of "slip" in `apply_slip`

### DIFF
--- a/macrosynergy/management/utils/df_utils.py
+++ b/macrosynergy/management/utils/df_utils.py
@@ -363,8 +363,9 @@ def apply_slip(
     raise_error: bool = True,
 ) -> QuantamentalDataFrame:
     """
-    Applies a slip, i.e. a negative lag, to the DataFrame for the given cross-sections
-    and categories, on the given metrics.
+    Applies a "slip" to the DataFrame for the given cross-sections
+    and categories, on the given metrics. A slip is identical to a lag, but is measured in
+    days, and must always be applied before any resampling.
 
     Parameters
     ----------
@@ -433,8 +434,6 @@ def apply_slip(
             raise ValueError(_err_str)
         else:
             warnings.warn(_err_str)
-
-    slip: int = slip.__neg__()
 
     for col in metrics:
         tks_isin = df["ticker"].isin(sel_tickers)

--- a/macrosynergy/management/utils/df_utils.py
+++ b/macrosynergy/management/utils/df_utils.py
@@ -363,9 +363,10 @@ def apply_slip(
     raise_error: bool = True,
 ) -> QuantamentalDataFrame:
     """
-    Applies a "slip" to the DataFrame for the given cross-sections
-    and categories, on the given metrics. A slip is identical to a lag, but is measured in
-    days, and must always be applied before any resampling.
+    Applies a "slip" to the DataFrame for the given cross-sections and categories, on the 
+    given metrics. A slip shifts the specified category n-days fowards in time, where n
+    is the slip value. This is identical to a lag, but is measured in days, and must 
+    always be applied before any resampling.
 
     Parameters
     ----------

--- a/macrosynergy/panel/category_relations.py
+++ b/macrosynergy/panel/category_relations.py
@@ -76,11 +76,9 @@ class CategoryRelations(object):
         winsorized!). Default is None for both. Trimming is applied after all other
         transformations.
     slip : int
-        implied slippage of feature availability for relationship with the target
-        category. This mimics the relationship between trading signals and returns, which is
-        often characterized by a delay due to the setup of positions. Technically, this is a
-        negative lag (early arrival) of the target category in working days prior to any
-        frequency conversion. Default is 0.
+        number of periods to 'slip' the explanatory variable, i.e. the first category.
+        Here, slip mimics the late arrival of the data, or the time it takes
+        to act on the data. Default is 0. 
     """
 
     def __init__(
@@ -150,11 +148,12 @@ class CategoryRelations(object):
             metrics_found: List[str] = list(
                 set(df.columns) - set(["cid", "xcat", "real_date"])
             )
+            # here, the slip is applied to the the first xcat (explanatory variable)
             df = self.apply_slip(
                 df=df,
                 slip=self.slip,
                 cids=self.cids,
-                xcats=[self.xcats[1]],
+                xcats=[self.xcats[0]],
                 metrics=metrics_found,
             )
 
@@ -886,7 +885,7 @@ class CategoryRelations(object):
 
             if remove_zero_predictor:
                 dfx = dfx[dfx.loc[:, self.xcats[0]] != 0]
-                
+
             sns.regplot(
                 data=dfx,
                 x=self.xcats[0],
@@ -1013,7 +1012,7 @@ if __name__ == "__main__":
     dfdx = dfd[~(filt1 | filt2)].copy()
     dfdx["ERA"] = "before 2007"
     dfdx.loc[dfdx["real_date"].dt.year > 2007, "ERA"] = "from 2010"
-    
+
     def modify_cry_values(group):
         if group.name[1] == "CRY":  # Check if xcat is "cry"
             mask = np.ones(len(group), dtype=bool)
@@ -1022,7 +1021,6 @@ if __name__ == "__main__":
         return group
 
     dfdx = dfdx.groupby(["cid", "xcat"], group_keys=False).apply(modify_cry_values)
-
 
     cidx = ["AUD", "CAD", "GBP", "USD", "PRY"]
 

--- a/macrosynergy/signal/signal_return_relations.py
+++ b/macrosynergy/signal/signal_return_relations.py
@@ -88,11 +88,9 @@ class SignalReturnRelations:
         conceptually corresponds to the holding period of a position in accordance with the
         signal.
     slip : int
-        implied slippage of feature availability for relationship with the target
-        category. This mimics the relationship between trading signals and returns, which is
-        often characterized by a delay due to the setup of positions. Technically, this is a
-        negative lag (early arrival) of the target category in working days prior to any
-        frequency conversion. Default is 0.
+        Default is 0, implied slippage of feature availability for relationship with the 
+        target category. See :func:`macrosynergy.management.df_utils.apply_slip` for more
+        information. 
     ms_panel_test : bool
         if True the Macrosynergy Panel test is calculated. Please note that this is a
         very time-consuming operation and should be used only if you require the result.
@@ -726,11 +724,12 @@ class SignalReturnRelations:
         metric_cols: List[str] = list(
             set(dfd.columns.tolist()) - set(["real_date", "xcat", "cid", "ticker"])
         )
+        # here, the slip is applied to the the first xcat (explanatory variable)
         dfd: pd.DataFrame = self.apply_slip(
             df=dfd,
             slip=self.slip,
             cids=cids,
-            xcats=[xcat[-1]],
+            xcats=[xcat[0]],
             metrics=metric_cols,
         )
 

--- a/macrosynergy/signal/signal_return_relations.py
+++ b/macrosynergy/signal/signal_return_relations.py
@@ -405,7 +405,7 @@ class SignalReturnRelations:
             ret = self.rets[0]
 
         self.df = self.original_df.copy()
-        self.manipulate_df(xcat=sigs + [ret], freq=freq, agg_sig=agg_sig)
+        self.manipulate_df(xcats=sigs + [ret], freq=freq, agg_sig=agg_sig)
 
         for i in range(len(sigs)):
             if not sigs[i] in self.sigs:
@@ -539,7 +539,7 @@ class SignalReturnRelations:
             sigs = [sigs]
 
         self.manipulate_df(
-            xcat=sigs + [ret],
+            xcats=sigs + [ret],
             freq=freq,
             agg_sig=self.agg_sigs[0],
         )
@@ -692,7 +692,7 @@ class SignalReturnRelations:
             isinstance(item, str) for item in variable
         )
 
-    def manipulate_df(self, xcat: str, freq: str, agg_sig: str):
+    def manipulate_df(self, xcats: List[str], freq: str, agg_sig: str):
         """
         Used to manipulate the DataFrame to the desired format for the analysis. Firstly
         reduces the dataframe to only include data outside of the blacklist and data
@@ -702,8 +702,8 @@ class SignalReturnRelations:
 
         Parameters
         ----------
-        xcat : str
-            xcat to be analysed.
+        xcats : List[str]
+            list of xcats in df to apply slip.
         freq : str
             frequency to be used in analysis.
         agg_sig : str
@@ -715,7 +715,7 @@ class SignalReturnRelations:
         cids = None if self.cids is None else self.cids
         dfd = reduce_df(
             self.df,
-            xcats=xcat,
+            xcats=xcats,
             cids=cids,
             start=self.start,
             end=self.end,
@@ -729,18 +729,18 @@ class SignalReturnRelations:
             df=dfd,
             slip=self.slip,
             cids=cids,
-            xcats=[xcat[0]],
+            xcats=[xcats[0]],
             metrics=metric_cols,
         )
 
         if self.cosp and len(self.sigs) > 1:
-            dfd = self.__communal_sample__(df=dfd, signal=xcat[:-1], ret=xcat[-1])
+            dfd = self.__communal_sample__(df=dfd, signal=xcats[:-1], ret=xcats[-1])
 
         self.dfd = dfd
 
         df = categories_df(
             dfd,
-            xcats=xcat,
+            xcats=xcats,
             cids=cids,
             val="value",
             start=None,
@@ -1281,7 +1281,7 @@ class SignalReturnRelations:
         if not isinstance(agg_sigs, str):
             raise TypeError("agg_sigs must be a string")
 
-        self.manipulate_df(xcat=xcat, freq=freq, agg_sig=agg_sigs)
+        self.manipulate_df(xcats=xcat, freq=freq, agg_sig=agg_sigs)
 
         if not sig in self.sigs:
             sig = sig + "_NEG"
@@ -1425,7 +1425,7 @@ class SignalReturnRelations:
         for freq in freqs:
             for agg_sig in agg_sigs:
                 for ret in rets:
-                    self.manipulate_df(xcat=xcats + [ret], freq=freq, agg_sig=agg_sig)
+                    self.manipulate_df(xcats=xcats + [ret], freq=freq, agg_sig=agg_sig)
                     for xcat in xcats:
                         df_rows.append(
                             self.__output_table__(
@@ -1583,7 +1583,7 @@ class SignalReturnRelations:
         for ret, sig, freq, agg_sig in loop_tuples:
             # Prepare xcat and manipulate DataFrame
             xcat = [sig, ret]
-            self.manipulate_df(xcat=xcat, freq=freq, agg_sig=agg_sig)
+            self.manipulate_df(xcats=xcat, freq=freq, agg_sig=agg_sig)
             hash = f"{ret}/{sig}/{freq}/{agg_sig}"
 
             row = self.get_rowcol(hash, rows)

--- a/tests/unit/management/test_utils.py
+++ b/tests/unit/management/test_utils.py
@@ -988,7 +988,7 @@ class TestFunctions(unittest.TestCase):
                     .isna()
                     .sum()
                 )
-                assert inan_count == onan_count - test_slip
+                self.assertEqual(inan_count, onan_count - test_slip)
 
         # Test Case 2 - slip is greater than the number of unique dates for a cid, xcat pair
 

--- a/tests/unit/management/test_utils.py
+++ b/tests/unit/management/test_utils.py
@@ -976,7 +976,7 @@ class TestFunctions(unittest.TestCase):
         )
 
         # NOTE: casting df.vx to int as pandas casts it to float64
-        self.assertEqual(int(min(df["vx"])) + test_slip, int(min(out_df["vx"])))
+        self.assertEqual(int(df["vx"].max()) - test_slip, int(out_df["vx"].max()))
 
         for cid in sel_cids:
             for xcat in sel_xcats:
@@ -1054,7 +1054,7 @@ class TestFunctions(unittest.TestCase):
                     ]["value"] == df[(df["cid"] == cid) & (df["xcat"] == xcat)][
                         "value"
                     ].shift(
-                        -2
+                        2
                     )
                     self.assertTrue(
                         (

--- a/tests/unit/panel/test_category_relations.py
+++ b/tests/unit/panel/test_category_relations.py
@@ -580,7 +580,7 @@ class TestAll(unittest.TestCase):
         )
 
         # NOTE: casting df.vx to int as pandas casts it to float64
-        self.assertEqual(int(min(df["vx"])) + test_slip, int(min(out_df["vx"])))
+        self.assertEqual(int(df["vx"].max()) - test_slip, int(out_df["vx"].max()))
 
         for cid in sel_cids:
             for xcat in sel_xcats:
@@ -592,7 +592,7 @@ class TestAll(unittest.TestCase):
                     .isna()
                     .sum()
                 )
-                assert inan_count == onan_count - test_slip
+                self.assertEqual(inan_count, onan_count - test_slip)
 
         # Test Case 2 - slip is greater than the number of unique dates for a cid, xcat pair
 

--- a/tests/unit/signal/test_signal_return_relations.py
+++ b/tests/unit/signal/test_signal_return_relations.py
@@ -642,7 +642,25 @@ class TestAll(unittest.TestCase):
 
         self.assertTrue(set(sr.dfd["xcat"]) == set(["XR", "CRY"]))
 
-        self.assertTrue(sr.dfd["value"][0] != sr.df["value"][0])
+        # check that the return (XR) has not been shifted
+        self.assertTrue(
+            (
+                sr.dfd[sr.dfd["xcat"] == "XR"]["value"]
+                == sr.df[sr.df["xcat"] == "XR"]["value"]
+            ).all()
+        )
+        shifted_cry = sr.dfd[sr.dfd["xcat"] == "CRY"]["value"]
+        expected_shifted_cry = sr.df[sr.df["xcat"] == "CRY"]["value"].shift(1)
+        expected_isna = expected_shifted_cry.isna()
+        additional_isna = shifted_cry.isna()
+
+        # check all true for (shifted_cry == expected_shifted_cry) XOR expected_isna
+        self.assertTrue(
+            (
+                (shifted_cry == expected_shifted_cry)
+                ^ (expected_isna | additional_isna)
+            ).all()
+        )
 
         self.assertTrue(sr_no_slip.dfd["value"][0] == sr_no_slip.df["value"][0])
 
@@ -650,7 +668,26 @@ class TestAll(unittest.TestCase):
 
         self.assertTrue(set(sr.dfd["xcat"]) == set(["XR", "CRY"]))
 
-        self.assertTrue(sr.dfd["value"][0] != sr.df["value"][0])
+        # check that the return (XR) has not been shifted
+        self.assertTrue(
+            (
+                sr.dfd[sr.dfd["xcat"] == "XR"]["value"]
+                == sr.df[sr.df["xcat"] == "XR"]["value"]
+            ).all()
+        )
+
+        shifted_cry = sr.dfd[sr.dfd["xcat"] == "CRY"]["value"]
+        expected_shifted_cry = sr.df[sr.df["xcat"] == "CRY"]["value"].shift(1)
+        expected_isna = expected_shifted_cry.isna()
+        additional_isna = shifted_cry.isna()
+
+        # check all true for (shifted_cry == expected_shifted_cry) XOR expected_isna
+        self.assertTrue(
+            (
+                (shifted_cry == expected_shifted_cry)
+                ^ (expected_isna | additional_isna)
+            ).all()
+        )
 
         # Test Negative signs are correctly handled
 

--- a/tests/unit/signal/test_signal_return_relations.py
+++ b/tests/unit/signal/test_signal_return_relations.py
@@ -204,7 +204,7 @@ class TestAll(unittest.TestCase):
         srr = SignalReturnRelations(
             self.dfd, sigs=signal, rets="XR", freqs="D", blacklist=self.blacklist
         )
-        srr.manipulate_df(xcat=[signal, "XR"], freq="D", agg_sig="last")
+        srr.manipulate_df(xcats=[signal, "XR"], freq="D", agg_sig="last")
         df = srr.df.dropna(how="any").copy()
 
         # First, test cross-sectional basis.
@@ -245,7 +245,7 @@ class TestAll(unittest.TestCase):
         srr = SignalReturnRelations(
             self.dfd, sigs=signal, rets=return_, freqs="D", blacklist=self.blacklist
         )
-        srr.manipulate_df(xcat=[signal, return_], freq="D", agg_sig="last")
+        srr.manipulate_df(xcats=[signal, return_], freq="D", agg_sig="last")
         df_cs = srr.__output_table__(cs_type="cids")
 
         # The lagged signal & returns have been reduced to[-1, 1] which are interpreted
@@ -347,7 +347,7 @@ class TestAll(unittest.TestCase):
             blacklist=self.blacklist,
         )
         srr.manipulate_df(
-            xcat=[primary_signal] + rival_signals + ["XR"], freq="D", agg_sig="last"
+            xcats=[primary_signal] + rival_signals + ["XR"], freq="D", agg_sig="last"
         )
 
         df_sigs = srr.__rival_sigs__(ret="XR")
@@ -371,7 +371,7 @@ class TestAll(unittest.TestCase):
         srr = SignalReturnRelations(
             self.dfd, sigs=signal, rets=return_, freqs="D", blacklist=self.blacklist
         )
-        srr.manipulate_df(xcat=[signal, return_], freq="D", agg_sig="last")
+        srr.manipulate_df(xcats=[signal, return_], freq="D", agg_sig="last")
         df_cs = srr.__output_table__(cs_type="cids")
         dfx = df_cs[~df_cs.index.isin(["PosRatio"])]
         dfx_acc = dfx.loc[:, ["accuracy", "bal_accuracy"]]

--- a/tests/unit/signal/test_signal_return_relations.py
+++ b/tests/unit/signal/test_signal_return_relations.py
@@ -426,7 +426,7 @@ class TestAll(unittest.TestCase):
         )
 
         # NOTE: casting df.vx to int as pandas casts it to float64
-        self.assertEqual(int(min(df["vx"])) + test_slip, int(min(out_df["vx"])))
+        self.assertEqual(int(df["vx"].max()) - test_slip, int(out_df["vx"].max()))
 
         for cid in sel_cids:
             for xcat in sel_xcats:
@@ -438,7 +438,7 @@ class TestAll(unittest.TestCase):
                     .isna()
                     .sum()
                 )
-                assert inan_count == onan_count - test_slip
+                self.assertEqual(inan_count, onan_count - test_slip)
 
         # Test Case 2 - slip is greater than the number of unique dates for a cid, xcat pair
 


### PR DESCRIPTION
Clarify the definition of "slip" in the code and adjust its application in the `CategoryRelations` and `SignalReturnRelations` classes