### PR TITLE
Feature: Add `extend_dates` parameter to `apply_slip` utility

### DIFF
--- a/macrosynergy/management/utils/df_utils.py
+++ b/macrosynergy/management/utils/df_utils.py
@@ -360,12 +360,13 @@ def apply_slip(
     xcats: Optional[List[str]] = None,
     tickers: Optional[List[str]] = None,
     metrics: List[str] = ["value"],
+    extend_dates: bool = False,
     raise_error: bool = True,
 ) -> QuantamentalDataFrame:
     """
-    Applies a "slip" to the DataFrame for the given cross-sections and categories, on the 
+    Applies a "slip" to the DataFrame for the given cross-sections and categories, on the
     given metrics. A slip shifts the specified category n-days fowards in time, where n
-    is the slip value. This is identical to a lag, but is measured in days, and must 
+    is the slip value. This is identical to a lag, but is measured in days, and must
     always be applied before any resampling.
 
     Parameters
@@ -380,6 +381,9 @@ def apply_slip(
         List of target categories.
     metrics : List[str]
         List of metrics to which the slip is applied.
+    extend_dates : bool
+        If True, includes the dates added by the slip in the DataFrame. If False, only the
+        input dates are included. Default is False.
     raise_error : bool
         If True, raises an error if the slip cannot be applied to all xcats in the target
         DataFrame. If False, raises a warning instead.
@@ -409,6 +413,18 @@ def apply_slip(
     if tickers is not None:
         if cids is not None or xcats is not None:
             raise ValueError("Cannot specify both `tickers` and `cids`/`xcats`.")
+    if not isinstance(extend_dates, bool):
+        raise TypeError("`extend_dates` must be a boolean.")
+
+    if not isinstance(metrics, list) or (
+        isinstance(metrics, list) and not all(isinstance(m, str) for m in metrics)
+    ):
+        raise TypeError("`metrics` must be a list of strings.")
+
+    missing_metrics = sorted(set(metrics) - set(df.columns))
+    if missing_metrics:
+        raise ValueError(f"Metrics {missing_metrics} are not present in the DataFrame.")
+
     if cids is None:
         cids = df["cid"].unique()
     if xcats is None:
@@ -435,6 +451,32 @@ def apply_slip(
             raise ValueError(_err_str)
         else:
             warnings.warn(_err_str)
+
+    if extend_dates:
+        found_metrics = set(df.columns) - set(QuantamentalDataFrame.IndexCols)
+        found_metrics = list(found_metrics - {"ticker"})
+        new_dfs: List[QuantamentalDataFrame] = []
+        for (ticker, cid, xcat), idx in df.groupby(
+            ["ticker", "cid", "xcat"], observed=True
+        ).groups.items():
+            last_date = df.loc[idx, "real_date"].max()
+            new_dts = pd.bdate_range(start=last_date, periods=slip + 1)[1:]
+            assert set(new_dts).isdisjoint(set(df.loc[idx, "real_date"].unique()))
+            dct = {"real_date": new_dts, "cid": cid, "xcat": xcat, "ticker": ticker}
+            dct = {**dct, **{metric: np.nan for metric in found_metrics}}
+            new_dfs.append(pd.DataFrame(dct))
+
+        # new_df = pd.concat(new_dfs, axis=0, ignore_index=True)
+        if is_categorical_qdf(df):
+            new_df = QuantamentalDataFrame.from_qdf_list(new_dfs)
+        else:
+            new_df = pd.concat(new_dfs, axis=0, ignore_index=True)
+        if is_categorical_qdf(df):
+            df = QuantamentalDataFrame(df).update_df(df_add=new_df)
+        else:
+            df = pd.concat([df, new_df], axis=0, ignore_index=True)
+
+        df = df.sort_values(by=["cid", "xcat", "real_date"])
 
     for col in metrics:
         tks_isin = df["ticker"].isin(sel_tickers)
@@ -501,7 +543,7 @@ def downsample_df_on_real_date(
         .groupby(groupby_columns, observed=True)[non_groupby_columns]
         .resample(freq)
     )
-    if PD_OLD_RESAMPLE: # pragma: no cover
+    if PD_OLD_RESAMPLE:  # pragma: no cover
         # resample only if the column is numeric
         res = res.agg(
             {

--- a/macrosynergy/management/utils/df_utils.py
+++ b/macrosynergy/management/utils/df_utils.py
@@ -466,7 +466,6 @@ def apply_slip(
             dct = {**dct, **{metric: np.nan for metric in found_metrics}}
             new_dfs.append(pd.DataFrame(dct))
 
-        # new_df = pd.concat(new_dfs, axis=0, ignore_index=True)
         if is_categorical_qdf(df):
             new_df = QuantamentalDataFrame.from_qdf_list(new_dfs)
         else:


### PR DESCRIPTION
Introduce the `extend_dates` parameter to control date inclusion in the `apply_slip` function. Updated unit tests to validate the new behavior and error handling.