### PR TITLE
Feature: `InformationStateChanges` - update documentation, add warnings for missing 'eop_lag' column, and add winsorise (`thresh`) functionality

### DIFF
--- a/macrosynergy/management/utils/sparse.py
+++ b/macrosynergy/management/utils/sparse.py
@@ -1286,7 +1286,7 @@ def sparse_to_dense(
     tdf = _remove_insignificant_values(tdf, threshold=1e-12)
 
     wins_lower, wins_upper = None, None
-    if winsorise:
+    if winsorise is not None:
         if isinstance(winsorise, tuple):
             if len(winsorise) != 2 and not all(
                 isinstance(x, (int, float)) for x in winsorise

--- a/macrosynergy/management/utils/sparse.py
+++ b/macrosynergy/management/utils/sparse.py
@@ -1288,8 +1288,8 @@ def sparse_to_dense(
     wins_lower, wins_upper = None, None
     if winsorise is not None:
         if isinstance(winsorise, tuple):
-            if len(winsorise) != 2 and not all(
-                isinstance(x, (int, float)) for x in winsorise
+            if (len(winsorise) != 2) or not all(
+                isinstance(x, Number) for x in winsorise
             ):
                 raise ValueError(
                     "If `winsorise` is a tuple, it must contain two numeric values."

--- a/macrosynergy/management/utils/sparse.py
+++ b/macrosynergy/management/utils/sparse.py
@@ -775,6 +775,10 @@ def create_delta_data(
     if "value" not in df.columns:
         raise ValueError("`df` must contain a `value` column")
     if "eop_lag" not in df.columns:
+        warnings.warn(
+            "`df` does not contain an `eop_lag` column. Differences calculated will not be "
+            " based on end-of-period adjustments."
+        )
         df["eop_lag"] = np.nan
     if "grading" not in df.columns:
         df["grading"] = np.nan

--- a/macrosynergy/management/utils/sparse.py
+++ b/macrosynergy/management/utils/sparse.py
@@ -168,6 +168,11 @@ class InformationStateChanges(object):
         ----------
         qdf : QuantamentalDataFrame
             The QuantamentalDataFrame to create the InformationStateChanges object from.
+            This dataframe must contain a `value` column. Additionally, the `eop_lag`
+            column is required to calculate the correct `eop` and `version` information.
+            If not provided, the information state is assumed to be based on the value
+            only. The `grading` column is optional and will be preserved in the output if
+            provided.
         norm : bool
             If True, calculate the score for the information state changes.
         score_by : str
@@ -1522,5 +1527,6 @@ if __name__ == "__main__":
     with JPMaQSDownload() as jpmaqs:
         df = jpmaqs.download(tickers=tickers, metrics="all")
 
-    isc = InformationStateChanges.from_qdf(df)
-    usd_gpdppc_isc = isc["USD_GDPPC_SA"]
+    isc = InformationStateChanges.from_qdf(df[["cid", "xcat", "real_date", "value"]])
+
+    print(list(isc.keys()))

--- a/tests/unit/management/test_sparse.py
+++ b/tests/unit/management/test_sparse.py
@@ -160,7 +160,14 @@ class TestFunctions(unittest.TestCase):
             create_delta_data(df=qdf.drop(columns="value"))
 
         # test with missing eop_lag
-        create_delta_data(qdf.drop(columns="eop_lag"))
+        # should warn saying 'eop_lag' not found
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            create_delta_data(df=qdf.drop(columns="eop_lag"))
+            self.assertTrue(len(w) == 1)
+            self.assertTrue(
+                "`df` does not contain an `eop_lag` column" in str(w[-1].message)
+            )
 
     def test_calculate_score_on_sparse_indicator(self) -> None:
         qdf = self.qdf_small.copy()

--- a/tests/unit/management/test_sparse.py
+++ b/tests/unit/management/test_sparse.py
@@ -492,6 +492,31 @@ class TestInformationStateChanges(unittest.TestCase):
 
         self.assertTrue([str(u).endswith("$%A") for u in list(tdf["xcat"])])
 
+    def test_isc_to_qdf_metrics(self) -> None:
+        df = get_long_format_data(end="2012-01-01")
+        ## Test that the grading is not output when not asked for
+        tdf = InformationStateChanges.from_qdf(df).to_qdf(metrics=None, postfix="$%A")
+        self.assertTrue("value" in tdf.columns)
+        self.assertTrue("eop" not in tdf.columns)
+        self.assertTrue("eop_lag" not in tdf.columns)
+        self.assertTrue("grading" not in tdf.columns)
+
+    def test_isc_to_qdf_winsorise(self) -> None:
+        df = get_long_format_data(end="2012-01-01")
+        ## Test that the grading is not output when not asked for
+        isc: InformationStateChanges = InformationStateChanges.from_qdf(df)
+        win_df = isc.to_qdf(metrics=None, winsorise=0)
+        self.assertTrue(np.allclose(win_df["value"], 0))
+        win_df = isc.to_qdf(metrics=None, winsorise=(-0.01, 0.1))
+        self.assertFalse((win_df["value"] > 0.1).any())
+        self.assertFalse((win_df["value"] < -0.01).any())
+
+        with self.assertRaises(ValueError):
+            isc.to_qdf(metrics=None, winsorise="banana")
+
+        with self.assertRaises(ValueError):
+            isc.to_qdf(metrics=None, winsorise=(-0.01, "banana"))
+
     def test_temporal_aggregator_period(self) -> None:
         df = get_long_format_data(end="2012-01-01")
         iscobj = InformationStateChanges.from_qdf(df)


### PR DESCRIPTION
Introduce warnings when the 'eop_lag' column is missing in the `create_delta_data` function and its test. Update the `InformationStateChanges` documentation to specify the requirement of the 'eop_lag' column for accurate calculations. Also added an argument called `thresh` for winsorization on the output stage, implemented in the `sparse_to_dense` function