### PR TITLE
Feature: Implement `JPMorganOAuth` to provide common OAuth workflows

### DIFF
--- a/macrosynergy/download/dataquery.py
+++ b/macrosynergy/download/dataquery.py
@@ -28,6 +28,7 @@ from macrosynergy.download.exceptions import (
     NoContentError,
     KNOWN_EXCEPTIONS,
 )
+from macrosynergy.download.jpm_oauth import JPMorganOAuth
 from macrosynergy.management.utils import (
     is_valid_iso_date,
     form_full_url,
@@ -296,152 +297,28 @@ def request_wrapper(
     raise DownloadError(e_str)
 
 
-class OAuth(object):
-    """
-    Class for handling OAuth authentication for the DataQuery API.
-
-    Parameters
-    ----------
-    client_id : str
-        client ID for the OAuth application.
-    client_secret : str
-        client secret for the OAuth application.
-    proxy : dict
-        proxy to use for requests. Defaults to None.
-    token_url : str
-        URL for getting OAuth tokens.
-    dq_resource_id : str
-        resource ID for the JPMaQS Application.
-
-    Raises
-    ------
-    ValueError
-        if any of the parameters are semantically incorrect.
-    TypeError
-        if any of the parameters are of the wrong type.
-    Exception
-        other exceptions may be raised by underlying functions.
-    """
-
+class OAuth(JPMorganOAuth):
     def __init__(
         self,
         client_id: str,
         client_secret: str,
         proxy: Optional[dict] = None,
         token_url: str = OAUTH_TOKEN_URL,
+        dq_base_url: str = OAUTH_BASE_URL,
         dq_resource_id: str = OAUTH_DQ_RESOURCE_ID,
+        application_name: str = "DataQueryHttpAPI",
         **kwargs,
     ):
-        logger.debug("Instantiate OAuth pathway to DataQuery")
-        vars_types_zip: zip = zip(
-            [client_id, client_secret, token_url, dq_resource_id],
-            [
-                "client_id",
-                "client_secret",
-                "token_url",
-                "dq_resource_id",
-            ],
+        super().__init__(
+            client_id=client_id,
+            client_secret=client_secret,
+            auth_url=token_url,
+            root_url=dq_base_url,
+            resource=dq_resource_id,
+            proxies=proxy,
+            application_name=application_name,
+            **kwargs,
         )
-
-        for varx, namex in vars_types_zip:
-            if not isinstance(varx, str):
-                raise TypeError(f"{namex} must be a <str> and not {type(varx)}.")
-
-        if not isinstance(proxy, dict) and proxy is not None:
-            raise TypeError(f"proxy must be a <dict> and not {type(proxy)}.")
-
-        self.token_url: str = token_url
-        self.proxy: Optional[dict] = proxy
-
-        self._stored_token: Optional[dict] = None
-        self.token_data = {
-            "grant_type": "client_credentials",
-            "client_id": client_id,
-            "client_secret": client_secret,
-            "aud": dq_resource_id,
-        }
-
-        self.kwargs = kwargs
-
-    def _valid_token(self) -> bool:
-        """
-        Method to check if the stored token is valid.
-
-        Returns
-        -------
-        bool
-            True if the token is valid, False otherwise.
-        """
-
-        if self._stored_token is None:
-            logger.debug("No token stored")
-            return False
-
-        created: datetime = self._stored_token["created_at"]  # utc time of creation
-        expires: datetime = created + timedelta(
-            seconds=self._stored_token["expires_in"] * TOKEN_EXPIRY_BUFFER
-        )
-
-        utcnow = datetime.now(timezone.utc)
-        is_active: bool = expires > utcnow
-
-        logger.debug(
-            "Active token: %s, created: %s, expires: %s, now: %s",
-            is_active,
-            created,
-            expires,
-            utcnow,
-        )
-
-        return is_active
-
-    def _get_token(self) -> str:
-        """
-        Method to get a new OAuth token.
-
-        Returns
-        -------
-        str
-            OAuth token.
-        """
-
-        if not self._valid_token():
-            logger.debug("Request new OAuth token")
-            js = request_wrapper(
-                url=self.token_url,
-                data=self.token_data,
-                method="post",
-                proxy=self.proxy,
-                tracking_id=OAUTH_TRACKING_ID,
-                user_id=self._get_user_id(),
-                **self.kwargs,
-            )
-            # on failure, exception will be raised by request_wrapper
-
-            # NOTE : use UTC time for token expiry
-            self._stored_token: dict = {
-                "created_at": datetime.now(timezone.utc),
-                "access_token": js["access_token"],
-                "expires_in": js["expires_in"],
-            }
-
-        return self._stored_token["access_token"]
-
-    def _get_user_id(self) -> str:
-        return "OAuth_ClientID - " + self.token_data["client_id"]
-
-    def get_auth(self) -> Dict[str, Union[str, Optional[Tuple[str, str]]]]:
-        """
-        Returns a dictionary with the authentication information, in the same format as
-        the `macrosynergy.download.dataquery.CertAuth.get_auth()` method.
-        """
-
-        headers: Dict = {"Authorization": "Bearer " + self._get_token()}
-        return {
-            "headers": headers,
-            "cert": None,
-            "user_id": self._get_user_id(),
-        }
 
 
 class CertAuth(object):
@@ -496,6 +373,9 @@ class CertAuth(object):
         self.password: str = password
         self.proxy: Optional[dict] = proxy
 
+    def _get_user_id(self) -> str:
+        return "CertAuth_Username - " + self.username
+
     def get_auth(self) -> Dict[str, Union[str, Optional[Tuple[str, str]]]]:
         """
         Returns a dictionary with the authentication information, in the same format as
@@ -503,11 +383,9 @@ class CertAuth(object):
         """
 
         headers = {"Authorization": f"Basic {self.auth:s}"}
-        user_id = "CertAuth_Username - " + self.username
         return {
             "headers": headers,
             "cert": (self.crt, self.key),
-            "user_id": user_id,
         }
 
 
@@ -898,14 +776,14 @@ class DataQueryInterface(object):
                 ):
                     raise NoContentError(
                         f"Content was not found for the request: {response}\n"
-                        f"User ID: {self.auth.get_auth()['user_id']}\n"
+                        f"User ID: {self.auth._get_user_id()}\n"
                         f"URL: {form_full_url(url, params)}\n"
                         f"Timestamp (UTC): {datetime.now(timezone.utc).isoformat()}"
                     )
 
             raise InvalidResponseError(
                 f"Invalid response from DataQuery: {response}\n"
-                f"User ID: {self.auth.get_auth()['user_id']}\n"
+                f"User ID: {self.auth._get_user_id()}\n"
                 f"URL: {form_full_url(url, params)}"
                 f"Timestamp (UTC): {datetime.now(timezone.utc).isoformat()}"
             )
@@ -1299,7 +1177,7 @@ class DataQueryInterface(object):
                     HeartbeatError(
                         f"Heartbeat failed. Timestamp (UTC):"
                         f" {datetime.now(timezone.utc).isoformat()}\n"
-                        f"User ID: {self.auth.get_auth()['user_id']}\n"
+                        f"User ID: {self.auth._get_user_id()}\n"
                     )
                 )
             time.sleep(delay_param)

--- a/macrosynergy/download/dataquery.py
+++ b/macrosynergy/download/dataquery.py
@@ -15,7 +15,7 @@ import uuid
 import io
 import warnings
 import requests
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from typing import List, Optional, Dict, Union, Tuple, Any
 from tqdm import tqdm
 

--- a/macrosynergy/download/dataquery.py
+++ b/macrosynergy/download/dataquery.py
@@ -205,7 +205,8 @@ def request_wrapper(
     # insert tracking info in headers
     if headers is None:
         headers: Dict = {}
-    headers["User-Agent"] = f"MacrosynergyPackage/{ms_version_info}"
+    if "User-Agent" not in headers:
+        headers["User-Agent"] = f"MacrosynergyPackage/{ms_version_info}"
 
     uuid_str: str = str(uuid.uuid4())
     if (tracking_id is None) or (tracking_id == ""):
@@ -703,7 +704,7 @@ class DataQueryInterface(object):
             proxy=self.proxy,
             tracking_id=HEARTBEAT_TRACKING_ID,
             verify=self.verify,
-            **self.auth.get_auth(),
+            headers=self.auth.get_auth(),
         )
 
         result: bool = True
@@ -764,7 +765,7 @@ class DataQueryInterface(object):
             proxy=self.proxy,
             tracking_id=tracking_id,
             verify=self.verify,
-            **self.auth.get_auth(),
+            headers=self.auth.get_auth(),
         )
 
         if (response is None) or ("instruments" not in response.keys()):

--- a/macrosynergy/download/dataquery.py
+++ b/macrosynergy/download/dataquery.py
@@ -297,7 +297,7 @@ def request_wrapper(
     raise DownloadError(e_str)
 
 
-class OAuth(JPMorganOAuth):
+class DataQueryOAuth(JPMorganOAuth):
     def __init__(
         self,
         client_id: str,
@@ -589,7 +589,7 @@ class DataQueryInterface(object):
             if not isinstance(varx, typex) and varx is not None:
                 raise TypeError(f"{namex} must be a {typex} and not {type(varx)}.")
 
-        self.auth: Optional[Union[CertAuth, OAuth]] = None
+        self.auth: Optional[Union[CertAuth, DataQueryOAuth]] = None
         if oauth and not all([client_id, client_secret]):
             warnings.warn(
                 "OAuth authentication requested but client ID and/or client secret "
@@ -607,7 +607,7 @@ class DataQueryInterface(object):
         self.verify: bool = verify
 
         if oauth:
-            self.auth: OAuth = OAuth(
+            self.auth: DataQueryOAuth = DataQueryOAuth(
                 client_id=client_id,
                 client_secret=client_secret,
                 token_url=token_url,

--- a/macrosynergy/download/dataquery.py
+++ b/macrosynergy/download/dataquery.py
@@ -321,7 +321,7 @@ class DataQueryOAuth(JPMorganOAuth):
         )
 
 
-class CertAuth(object):
+class DataQueryCertAuth(object):
     """
     Class for handling certificate based authentication for the DataQuery API.
 
@@ -589,7 +589,7 @@ class DataQueryInterface(object):
             if not isinstance(varx, typex) and varx is not None:
                 raise TypeError(f"{namex} must be a {typex} and not {type(varx)}.")
 
-        self.auth: Optional[Union[CertAuth, DataQueryOAuth]] = None
+        self.auth: Optional[Union[DataQueryCertAuth, DataQueryOAuth]] = None
         if oauth and not all([client_id, client_secret]):
             warnings.warn(
                 "OAuth authentication requested but client ID and/or client secret "
@@ -620,7 +620,7 @@ class DataQueryInterface(object):
             if base_url == OAUTH_BASE_URL:
                 base_url: str = CERT_BASE_URL
 
-            self.auth: CertAuth = CertAuth(
+            self.auth: DataQueryCertAuth = DataQueryCertAuth(
                 username=username,
                 password=password,
                 crt=crt,

--- a/macrosynergy/download/fusion_interface.py
+++ b/macrosynergy/download/fusion_interface.py
@@ -24,6 +24,7 @@ from macrosynergy import __version__ as ms_version_info
 
 from macrosynergy.management.types import QuantamentalDataFrame
 from macrosynergy.download.exceptions import NoContentError
+from macrosynergy.download.jpm_oauth import JPMorganOAuth
 
 FUSION_AUTH_URL: str = "https://authe.jpmorgan.com/as/token.oauth2"
 FUSION_ROOT_URL: str = "https://fusion.jpmorgan.com/api/v1"
@@ -35,71 +36,11 @@ LAST_API_CALL: Optional[datetime.datetime] = None
 logger = logging.getLogger(__name__)
 
 
-class FusionOAuth(object):
+class FusionOAuth(JPMorganOAuth):
     """
     A class to handle OAuth authentication for the JPMorgan Fusion API.
-    This class retrieves and manages access tokens for API requests.
-    It supports loading credentials from a JSON file or a dictionary.
-
-    Parameters
-    ----------
-    client_id : str
-        The client ID for the OAuth application.
-    client_secret : str
-        The client secret for the OAuth application.
-    resource : str
-        The resource ID for the Fusion API. Default is the global constant
-        FUSION_RESOURCE_ID.
-    application_name : str
-        The name of the application using the Fusion API. Default is "fusion".
-    root_url : str
-        The root URL for the Fusion API. Default is the global constant
-        FUSION_ROOT_URL.
-    auth_url : str
-        The URL for the OAuth authentication endpoint. Default is the global constant
-        FUSION_AUTH_URL.
-    proxies : Optional[Dict[str, str]]
-        Optional proxies to use for the HTTP requests. Default is None.
+    Uses the JPMorganOAuth class as a base.
     """
-
-    @staticmethod
-    def from_credentials_json(credentials_json: str):
-        """
-        Load OAuth credentials from a JSON file and return an instance of FusionOAuth.
-
-        Parameters
-        ----------
-        credentials_json : str
-            Path to the JSON file containing the OAuth credentials. This file must
-            contain the keys 'client_id' and 'client_secret'.
-
-        Returns
-        -------
-        FusionOAuth
-            An instance of the FusionOAuth class initialized with the credentials from the
-            JSON file.
-        """
-        with open(credentials_json, "r") as f:
-            credentials = json.load(f)
-        return FusionOAuth.from_credentials(credentials)
-
-    @staticmethod
-    def from_credentials(credentials: dict):
-        """
-        Create an instance of FusionOAuth from a dictionary of credentials.
-
-        Parameters
-        ----------
-        credentials : dict
-            A dictionary containing the OAuth credentials. It must include the keys
-            'client_id' and 'client_secret'.
-
-        Returns
-        -------
-        FusionOAuth
-            An instance of the FusionOAuth class initialized with the provided credentials.
-        """
-        return FusionOAuth(**credentials)
 
     def __init__(
         self,
@@ -111,91 +52,15 @@ class FusionOAuth(object):
         auth_url: str = FUSION_AUTH_URL,
         proxies: Optional[dict] = None,
     ):
-        self.client_id = client_id
-        self.client_secret = client_secret
-        self.resource = resource
-        self.application_name = application_name
-        self.root_url = root_url
-        self.auth_url = auth_url
-
-        # none of the above can be None
-        for attr_name, attr_val in [
-            ("client_id", self.client_id),
-            ("client_secret", self.client_secret),
-            ("resource", self.resource),
-            ("application_name", self.application_name),
-            ("root_url", self.root_url),
-            ("auth_url", self.auth_url),
-        ]:
-            if attr_val is None:
-                raise ValueError(f"{attr_name} must be provided and cannot be None.")
-
-        self.proxies = proxies or None
-
-        self.token_data = {
-            "grant_type": "client_credentials",
-            "aud": resource,
-            "client_id": client_id,
-            "client_secret": client_secret,
-        }
-
-        self._stored_token = None
-
-    def retrieve_token(self):
-        """
-        Retrieve an access token from the OAuth server and store it in the instance.
-
-        Equivalent cURL request:
-
-        .. code-block:: bash
-
-            curl -X POST "https://authe.jpmorgan.com/as/token.oauth2" \\
-                -d "grant_type=<FUSION_RESOURCE_ID>&client_id=<CLIENT_ID>&client_secret=<CLIENT_SECRET>"
-        """
-        try:
-            response = requests.post(
-                self.auth_url,
-                data=self.token_data,
-                proxies=self.proxies,
-            )
-            response.raise_for_status()
-            token_data = response.json()
-            self._stored_token = {
-                "created_at": datetime.datetime.now(),
-                "expires_in": token_data["expires_in"],
-                "access_token": token_data["access_token"],
-            }
-        except requests.exceptions.RequestException as e:
-            raise Exception(f"Error retrieving token: {e}") from e
-
-    def _is_valid_token(self):
-        if self._stored_token is None:
-            return False
-        return (
-            self._stored_token["created_at"]
-            + datetime.timedelta(seconds=self._stored_token["expires_in"])
-            > datetime.datetime.now()
+        super().__init__(
+            client_id=client_id,
+            client_secret=client_secret,
+            resource=resource,
+            application_name=application_name,
+            root_url=root_url,
+            auth_url=auth_url,
+            proxies=proxies,
         )
-
-    def _get_token(self):
-        if not self._is_valid_token():
-            self.retrieve_token()
-        return self._stored_token["access_token"]
-
-    def get_auth(self) -> dict:
-        """
-        Get the authorization headers for API requests.
-
-        Returns
-        -------
-        dict
-            A dictionary containing the authorization headers with the access token.
-        """
-        headers = {
-            "Authorization": f"Bearer {self._get_token()}",
-            "User-Agent": f"MacrosynergyPackage/{ms_version_info}",
-        }
-        return headers
 
 
 CachedType = TypeVar("CachedType", bound=Callable[..., Any])

--- a/macrosynergy/download/jpm_oauth.py
+++ b/macrosynergy/download/jpm_oauth.py
@@ -9,8 +9,8 @@ from macrosynergy import __version__ as ms_version_info
 
 class JPMorganOAuth(object):
     """
-    A lightweight helper for OAuth 2.0 (Client Credentials) authentication
-    against **any JPMorgan API**.
+    A lightweight helper for OAuth 2.0 (Client Credentials) authentication used by the
+    JPMorgan DataQuery API, DataQuery File API, and JPMorgan Fusion API.
 
     This class retrieves and manages access tokens for API requests and supports
     loading credentials from a JSON file or a dictionary.

--- a/macrosynergy/download/jpm_oauth.py
+++ b/macrosynergy/download/jpm_oauth.py
@@ -1,0 +1,178 @@
+import json
+import datetime
+from typing import Optional
+
+import requests
+
+from macrosynergy import __version__ as ms_version_info
+
+
+class JPMorganOAuth(object):
+    """
+    A lightweight helper for OAuth 2.0 (Client Credentials) authentication
+    against **any JPMorgan API**.
+
+    This class retrieves and manages access tokens for API requests and supports
+    loading credentials from a JSON file or a dictionary.
+
+    Parameters
+    ----------
+    client_id : str
+        The OAuth client ID issued by JPMorgan.
+    client_secret : str
+        The OAuth client secret issued by JPMorgan.
+    resource : str
+        The token audience (often sent as the `aud` parameter) identifying the
+        target JPMorgan API.
+    application_name : str
+        The name of the application using the API (used for identification/logging only).
+    root_url : str
+        The base URL for the target JPMorgan API (not required for token
+        retrieval but kept for completeness and potential future use).
+    auth_url : str
+        The full URL of the OAuth token endpoint for JPMorgan.
+    proxies : Optional[Dict[str, str]]
+        Optional proxies to use for the HTTP requests. Default is None.
+    """
+
+    @classmethod
+    def from_credentials_json(cls, credentials_json: str):
+        """
+        Load OAuth credentials from a JSON file and return an instance of JPMorganOAuth.
+
+        Parameters
+        ----------
+        credentials_json : str
+            Path to the JSON file containing the OAuth credentials. This file must
+            contain the keys 'client_id' and 'client_secret' and should include
+            'resource', 'application_name', 'root_url', and 'auth_url'.
+
+        Returns
+        -------
+        JPMorganOAuth
+            An instance of the JPMorganOAuth class initialized with the credentials from
+            the JSON file.
+        """
+        with open(credentials_json, "r") as f:
+            credentials = json.load(f)
+        return cls.from_credentials(credentials)
+
+    @classmethod
+    def from_credentials(cls, credentials: dict):
+        """
+        Create an instance of JPMorganOAuth from a dictionary of credentials.
+
+        Parameters
+        ----------
+        credentials : dict
+            A dictionary containing the OAuth credentials. It must include the keys
+            'client_id' and 'client_secret', and should include 'resource',
+            'application_name', 'root_url', and 'auth_url'.
+
+        Returns
+        -------
+        JPMorganOAuth
+            An instance of the JPMorganOAuth class initialized with the provided
+            credentials.
+        """
+        return cls(**credentials)
+
+    def __init__(
+        self,
+        client_id: str,
+        client_secret: str,
+        resource: str,
+        application_name: str,
+        root_url: str,
+        auth_url: str,
+        proxies: Optional[dict] = None,
+    ):
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.resource = resource
+        self.application_name = application_name
+        self.root_url = root_url
+        self.auth_url = auth_url
+
+        # none of the above can be None
+        for attr_name, attr_val in [
+            ("client_id", self.client_id),
+            ("client_secret", self.client_secret),
+            ("resource", self.resource),
+            ("application_name", self.application_name),
+            ("root_url", self.root_url),
+            ("auth_url", self.auth_url),
+        ]:
+            if attr_val is None:
+                raise ValueError(f"{attr_name} must be provided and cannot be None.")
+
+        self.proxies = proxies or None
+
+        # OAuth 2.0 Client Credentials grant payload
+        self.token_data = {
+            "grant_type": "client_credentials",
+            "aud": resource,
+            "client_id": client_id,
+            "client_secret": client_secret,
+        }
+
+        self._stored_token = None
+
+    def retrieve_token(self):
+        """
+        Retrieve an access token from the OAuth server and store it in the instance.
+
+        Equivalent cURL request:
+
+        .. code-block:: bash
+
+            curl -X POST "$AUTH_URL" \\
+                -d "grant_type=client_credentials" \\
+                -d "aud=$RESOURCE" \\
+                -d "client_id=$CLIENT_ID" \\
+                -d "client_secret=$CLIENT_SECRET"
+        """
+        try:
+            response = requests.post(
+                self.auth_url,
+                data=self.token_data,
+                proxies=self.proxies,
+            )
+            response.raise_for_status()
+            token_data = response.json()
+            self._stored_token = {
+                "created_at": datetime.datetime.now(),
+                "expires_in": token_data["expires_in"],
+                "access_token": token_data["access_token"],
+            }
+        except requests.exceptions.RequestException as e:
+            raise Exception(f"Error retrieving token: {e}") from e
+
+    def _is_valid_token(self):
+        if self._stored_token is None:
+            return False
+        return (
+            self._stored_token["created_at"]
+            + datetime.timedelta(seconds=self._stored_token["expires_in"])
+            > datetime.datetime.now()
+        )
+
+    def _get_token(self):
+        if not self._is_valid_token():
+            self.retrieve_token()
+        return self._stored_token["access_token"]
+
+    def get_auth(self) -> dict:
+        """
+        Get the authorization headers for API requests.
+
+        Returns
+        -------
+        dict
+            A dictionary containing the authorization headers with the access token.
+        """
+        headers = {
+            "Authorization": f"Bearer {self._get_token()}",
+            "User-Agent": f"MacrosynergyPackage/{self.application_name}/{ms_version_info}",
+        }
+        return headers

--- a/macrosynergy/download/jpm_oauth.py
+++ b/macrosynergy/download/jpm_oauth.py
@@ -162,6 +162,9 @@ class JPMorganOAuth(object):
             self.retrieve_token()
         return self._stored_token["access_token"]
 
+    def _get_user_id(self) -> str:
+        return "OAuth_ClientID - " + self.client_id
+
     def get_auth(self) -> dict:
         """
         Get the authorization headers for API requests.

--- a/tests/unit/download/test_dataquery.py
+++ b/tests/unit/download/test_dataquery.py
@@ -13,7 +13,7 @@ from macrosynergy.download.jpmaqs import JPMaQSDownload, construct_expressions
 from macrosynergy.download.dataquery import (
     DataQueryInterface,
     DataQueryOAuth,
-    CertAuth,
+    DataQueryCertAuth,
     request_wrapper,
     validate_response,
     validate_download_args,
@@ -211,7 +211,7 @@ class TestCertAuth(unittest.TestCase):
             with mock.patch(
                 "os.path.isfile", side_effect=lambda x: self.mock_isfile(x)
             ):
-                certauth: CertAuth = CertAuth(**self.good_args())
+                certauth: DataQueryCertAuth = DataQueryCertAuth(**self.good_args())
 
                 expctd_auth: str = base64.b64encode(
                     bytes(
@@ -231,18 +231,18 @@ class TestCertAuth(unittest.TestCase):
                 bad_args: Dict[str, str] = self.good_args().copy()
                 bad_args[key] = 1
                 with self.assertRaises(TypeError):
-                    CertAuth(**bad_args)
+                    DataQueryCertAuth(**bad_args)
 
         with mock.patch("os.path.isfile", side_effect=lambda x: self.mock_isfile(x)):
             for key in ["crt", "key"]:
                 bad_args: Dict[str, str] = self.good_args().copy()
                 bad_args[key] = "path/invalid_path"
                 with self.assertRaises(FileNotFoundError):
-                    CertAuth(**bad_args)
+                    DataQueryCertAuth(**bad_args)
 
     def test_get_auth(self):
         with mock.patch("os.path.isfile", side_effect=lambda x: self.mock_isfile(x)):
-            certauth: CertAuth = CertAuth(**self.good_args())
+            certauth: DataQueryCertAuth = DataQueryCertAuth(**self.good_args())
 
             expctd_auth: str = base64.b64encode(
                 bytes(
@@ -269,7 +269,7 @@ class TestCertAuth(unittest.TestCase):
             dq_interface: DataQueryInterface = DataQueryInterface(**cfg, oauth=False)
 
             # assert that dq_interface.auth is CertAuth type
-            self.assertIsInstance(dq_interface.auth, CertAuth)
+            self.assertIsInstance(dq_interface.auth, DataQueryCertAuth)
             # check that the base_url is cert_base url
             self.assertEqual(dq_interface.base_url, CERT_BASE_URL)
 

--- a/tests/unit/download/test_dataquery.py
+++ b/tests/unit/download/test_dataquery.py
@@ -12,7 +12,7 @@ import itertools
 from macrosynergy.download.jpmaqs import JPMaQSDownload, construct_expressions
 from macrosynergy.download.dataquery import (
     DataQueryInterface,
-    OAuth,
+    DataQueryOAuth,
     CertAuth,
     request_wrapper,
     validate_response,
@@ -288,7 +288,7 @@ class TestOAuth(unittest.TestCase):
         self.assertEqual(jpmaqs.base_url, OAUTH_BASE_URL)
 
         with self.assertRaises(TypeError):
-            OAuth(client_id="test-id", client_secret="SECRET", proxy="proxy")
+            DataQueryOAuth(client_id="test-id", client_secret="SECRET", proxy="proxy")
 
     def test_invalid_init_args(self):
         good_args: Dict[str, str] = {
@@ -302,10 +302,10 @@ class TestOAuth(unittest.TestCase):
             bad_args: Dict[str, str] = good_args.copy()
             bad_args[key] = 1
             with self.assertRaises(TypeError):
-                OAuth(**bad_args)
+                DataQueryOAuth(**bad_args)
 
         try:
-            oath_obj: OAuth = OAuth(**good_args)
+            oath_obj: DataQueryOAuth = DataQueryOAuth(**good_args)
 
             self.assertIsInstance(oath_obj.token_data, dict)
             expcted_token_data: Dict[str, str] = {
@@ -319,11 +319,11 @@ class TestOAuth(unittest.TestCase):
             self.fail(f"Unexpected exception raised: {e}")
 
     def test_valid_token(self):
-        oauth = OAuth(client_id="test-id", client_secret="SECRET")
+        oauth = DataQueryOAuth(client_id="test-id", client_secret="SECRET")
         self.assertFalse(oauth._is_valid_token())
 
     def test_get_token(self):
-        oauth = OAuth(client_id="test-id", client_secret="SECRET")
+        oauth = DataQueryOAuth(client_id="test-id", client_secret="SECRET")
 
         token_data: Dict[str, str] = {
             "access_token": "SOME_TOKEN",
@@ -335,7 +335,7 @@ class TestOAuth(unittest.TestCase):
             return_value=token_data,
         ):
             with mock.patch(
-                "macrosynergy.download.dataquery.OAuth._is_valid_token",
+                "macrosynergy.download.dataquery.DataQueryOAuth._is_valid_token",
                 return_value=False,
             ):
                 oauth._stored_token = token_data
@@ -410,7 +410,7 @@ class TestDataQueryInterface(unittest.TestCase):
                 )
 
     @mock.patch(
-        "macrosynergy.download.dataquery.OAuth._get_token",
+        "macrosynergy.download.dataquery.DataQueryOAuth._get_token",
         return_value=("SOME_TEST_TOKEN"),
     )
     @mock.patch(
@@ -451,7 +451,7 @@ class TestDataQueryInterface(unittest.TestCase):
                     dq.check_connection(raise_error=True)
 
     @mock.patch(
-        "macrosynergy.download.dataquery.OAuth._get_token",
+        "macrosynergy.download.dataquery.DataQueryOAuth._get_token",
         return_value=random_string(),
     )
     @mock.patch(
@@ -496,7 +496,7 @@ class TestDataQueryInterface(unittest.TestCase):
         # check that jpmaqs_download is a superclass of dataquery interface
         self.assertIsInstance(jpmaqs_download, DataQueryInterface)
 
-        self.assertIsInstance(jpmaqs_download.auth, OAuth)
+        self.assertIsInstance(jpmaqs_download.auth, DataQueryOAuth)
 
     def test_certauth_condition(self):
         # Second check is that the DataQuery instance is using an CertAuth Object if the
@@ -784,7 +784,7 @@ class TestDataQueryInterface(unittest.TestCase):
         }
 
         with mock.patch(
-            "macrosynergy.download.dataquery.OAuth.get_auth",
+            "macrosynergy.download.dataquery.DataQueryOAuth.get_auth",
             return_value={"headers": "headers", "cert": "cert"},
         ):
             with mock.patch(
@@ -942,7 +942,7 @@ class TestDataQueryInterface(unittest.TestCase):
             return_value=False,
         ):
             with mock.patch(
-                "macrosynergy.download.dataquery.OAuth.get_auth",
+                "macrosynergy.download.dataquery.DataQueryOAuth.get_auth",
                 return_value={"user_id": random_string()},
             ):
                 with self.assertRaises(ConnectionError):

--- a/tests/unit/download/test_fusion_interface.py
+++ b/tests/unit/download/test_fusion_interface.py
@@ -195,7 +195,8 @@ class TestFusionOAuth(unittest.TestCase):
     def test_is_valid_token_true_when_not_expired(self):
         oauth = FusionOAuth(**self.creds)
         oauth._stored_token = {
-            "created_at": datetime.datetime.now() - datetime.timedelta(seconds=10),
+            "created_at": datetime.datetime.now(datetime.timezone.utc)
+            - datetime.timedelta(seconds=10),
             "expires_in": 100,
             "access_token": "tok",
         }
@@ -204,7 +205,8 @@ class TestFusionOAuth(unittest.TestCase):
     def test_is_valid_token_false_when_expired(self):
         oauth = FusionOAuth(**self.creds)
         oauth._stored_token = {
-            "created_at": datetime.datetime.now() - datetime.timedelta(seconds=200),
+            "created_at": datetime.datetime.now(datetime.timezone.utc)
+            - datetime.timedelta(seconds=200),
             "expires_in": 100,
             "access_token": "tok",
         }
@@ -1857,9 +1859,9 @@ class TestJPMaQSFusionClientDownload(unittest.TestCase):
                     expected_dataset, action = local_seq[call_idx["i"]]
                     call_idx["i"] += 1
                     if expected_dataset is not None:
-                        assert dataset == expected_dataset, (
-                            f"Expected {expected_dataset}, got {dataset}"
-                        )
+                        assert (
+                            dataset == expected_dataset
+                        ), f"Expected {expected_dataset}, got {dataset}"
                     return _resolve_action(
                         action,
                         dataset,

--- a/tests/unit/download/test_jpmaqs.py
+++ b/tests/unit/download/test_jpmaqs.py
@@ -23,12 +23,7 @@ from macrosynergy.download.jpmaqs import (
 
 from macrosynergy.download.exceptions import InvalidDataframeError
 from macrosynergy.management.types import QuantamentalDataFrame
-from .mock_helpers import (
-    mock_jpmaqs_value,
-    mock_request_wrapper,
-    random_string,
-    MockDataQueryInterface,
-)
+from .mock_helpers import mock_request_wrapper, random_string
 
 
 class TestJPMaQSDownload(unittest.TestCase):
@@ -121,13 +116,7 @@ class TestJPMaQSDownload(unittest.TestCase):
         # If the connection to DataQuery is working, the response code will invariably be
         # 200. Therefore, use the Interface Object's method to check DataQuery
         # connections.
-
-        with JPMaQSDownload(
-            client_id="client1",
-            client_secret="123",
-            oauth=True,
-        ) as jpmaqs:
-            pass
+        JPMaQSDownload(client_id="client1", client_secret="123", oauth=True)
 
         mock_p_request.assert_called_once()
         mock_p_get_token.assert_called_once()

--- a/tests/unit/download/test_jpmaqs.py
+++ b/tests/unit/download/test_jpmaqs.py
@@ -108,7 +108,7 @@ class TestJPMaQSDownload(unittest.TestCase):
                 raise ValueError("Env. variables are set; raising error to pass test")
 
     @mock.patch(
-        "macrosynergy.download.dataquery.OAuth._get_token",
+        "macrosynergy.download.dataquery.DataQueryOAuth._get_token",
         return_value=("SOME_TEST_TOKEN"),
     )
     @mock.patch(

--- a/tests/unit/download/test_jpmaqs.py
+++ b/tests/unit/download/test_jpmaqs.py
@@ -109,7 +109,7 @@ class TestJPMaQSDownload(unittest.TestCase):
 
     @mock.patch(
         "macrosynergy.download.dataquery.DataQueryOAuth._get_token",
-        return_value=("SOME_TEST_TOKEN"),
+        return_value="SOME_TEST_TOKEN",
     )
     @mock.patch(
         "macrosynergy.download.dataquery.request_wrapper",
@@ -291,7 +291,6 @@ class TestJPMaQSDownload(unittest.TestCase):
             self.jpmaqs_download.validate_download_args(**bad_args)
 
     def test_filter_expressions_from_catalogue(self):
-
         catalogue = self.expressions.copy()
 
         with mock.patch(
@@ -310,7 +309,6 @@ class TestJPMaQSDownload(unittest.TestCase):
             )
 
     def test_chain_download_outputs(self):
-
         with self.assertRaises(TypeError):
             self.jpmaqs_download._chain_download_outputs("")
 
@@ -669,7 +667,6 @@ class TestFunctions(unittest.TestCase):
             self.assertIsNone(timeseries_to_qdf(dicts_list[0]))
 
     def test_timeseries_to_column(self):
-
         with self.assertRaises(TypeError):
             timeseries_to_column("")
 
@@ -791,21 +788,270 @@ class TestFunctions(unittest.TestCase):
             )
 
     def test_check_attributes_in_sync(self):
-        ts_list = [{"attributes": [{"expression": "DB(JPMAQS,CID_TEST,value)", "time-series": [["20240125", 0.1], ["20240126", -0.1], ["20240127", None], ["20240128", None], ["20240129", 0.8], ["20240130", -0.01], ["20240131", 1.5], ["20240201", 1.0], ["20240202", 1.0], ["20240203", None], ["20240204", None], ["20240205", 1.0]]}]}, 
-                   {"attributes": [{"expression": "DB(JPMAQS,CID_TEST,grading)", "time-series": [["20240125", 1.0], ["20240126", 1.0], ["20240127", None], ["20240128", None], ["20240129", 1.0], ["20240130", 1.0], ["20240131", 1.0], ["20240201", 1.0], ["20240202", 1.0], ["20240203", None], ["20240204", None], ["20240205", 1.0]]}]}, 
-                   {"attributes": [{"expression": "DB(JPMAQS,CID_TEST,mop_lag)", "time-series": [["20240125", 0.0], ["20240126", 0.0], ["20240127", None], ["20240128", None], ["20240129", 0.0], ["20240130", 0.0], ["20240131", 0.0], ["20240201", 0.0], ["20240202", 0.0], ["20240203", None], ["20240204", None], ["20240205", 0.0]]}]}, 
-                   {"attributes": [{"expression": "DB(JPMAQS,CID_TEST,eop_lag)", "time-series": [["20240125", 0.0], ["20240126", 0.0], ["20240127", None], ["20240128", None], ["20240129", 0.0], ["20240130", 0.0], ["20240131", 0.0], ["20240201", 0.0], ["20240202", 0.0], ["20240203", None], ["20240204", None], ["20240205", 0.0]]}]},
-                   {"attributes": [{"expression": "DB(JPMAQS,CID1_TEST,value)", "time-series": [["20240125", 0.1], ["20240126", -0.1], ["20240127", None], ["20240128", None], ["20240129", 0.8], ["20240130", -0.01], ["20240131", 1.5], ["20240201", 1.0], ["20240202", 1.0]]}]}, 
-                   {"attributes": [{"expression": "DB(JPMAQS,CID1_TEST,grading)", "time-series": [["20240125", 1.0], ["20240126", 1.0], ["20240127", None], ["20240128", None], ["20240129", 1.0], ["20240130", 1.0], ["20240131", 1.0], ["20240201", 1.0], ["20240202", 1.0]]}]}, 
-                   {"attributes": [{"expression": "DB(JPMAQS,CID1_TEST,mop_lag)", "time-series": [["20240125", 0.0], ["20240126", 0.0], ["20240127", None], ["20240128", None], ["20240129", 0.0], ["20240130", 0.0], ["20240131", 0.0], ["20240201", 0.0], ["20240202", 0.0]]}]}, 
-                   {"attributes": [{"expression": "DB(JPMAQS,CID1_TEST,eop_lag)", "time-series": [["20240125", 0.0], ["20240126", 0.0], ["20240127", None], ["20240128", None], ["20240129", 0.0], ["20240130", 0.0], ["20240131", 0.0], ["20240201", 0.0], ["20240202", 0.0]]}]},
-                   {"attributes": [{"expression": "DB(CFX,BGB,123,,FRW)", "time-series": [["20240125", 0.0], ["20240126", 0.0], ["20240127", None], ["20240128", None], ["20240129", 0.0], ["20240130", 0.0], ["20240131", 0.0], ["20240201", 0.0], ["20240202", 0.0]]}]}]
+        ts_list = [
+            {
+                "attributes": [
+                    {
+                        "expression": "DB(JPMAQS,CID_TEST,value)",
+                        "time-series": [
+                            ["20240125", 0.1],
+                            ["20240126", -0.1],
+                            ["20240127", None],
+                            ["20240128", None],
+                            ["20240129", 0.8],
+                            ["20240130", -0.01],
+                            ["20240131", 1.5],
+                            ["20240201", 1.0],
+                            ["20240202", 1.0],
+                            ["20240203", None],
+                            ["20240204", None],
+                            ["20240205", 1.0],
+                        ],
+                    }
+                ]
+            },
+            {
+                "attributes": [
+                    {
+                        "expression": "DB(JPMAQS,CID_TEST,grading)",
+                        "time-series": [
+                            ["20240125", 1.0],
+                            ["20240126", 1.0],
+                            ["20240127", None],
+                            ["20240128", None],
+                            ["20240129", 1.0],
+                            ["20240130", 1.0],
+                            ["20240131", 1.0],
+                            ["20240201", 1.0],
+                            ["20240202", 1.0],
+                            ["20240203", None],
+                            ["20240204", None],
+                            ["20240205", 1.0],
+                        ],
+                    }
+                ]
+            },
+            {
+                "attributes": [
+                    {
+                        "expression": "DB(JPMAQS,CID_TEST,mop_lag)",
+                        "time-series": [
+                            ["20240125", 0.0],
+                            ["20240126", 0.0],
+                            ["20240127", None],
+                            ["20240128", None],
+                            ["20240129", 0.0],
+                            ["20240130", 0.0],
+                            ["20240131", 0.0],
+                            ["20240201", 0.0],
+                            ["20240202", 0.0],
+                            ["20240203", None],
+                            ["20240204", None],
+                            ["20240205", 0.0],
+                        ],
+                    }
+                ]
+            },
+            {
+                "attributes": [
+                    {
+                        "expression": "DB(JPMAQS,CID_TEST,eop_lag)",
+                        "time-series": [
+                            ["20240125", 0.0],
+                            ["20240126", 0.0],
+                            ["20240127", None],
+                            ["20240128", None],
+                            ["20240129", 0.0],
+                            ["20240130", 0.0],
+                            ["20240131", 0.0],
+                            ["20240201", 0.0],
+                            ["20240202", 0.0],
+                            ["20240203", None],
+                            ["20240204", None],
+                            ["20240205", 0.0],
+                        ],
+                    }
+                ]
+            },
+            {
+                "attributes": [
+                    {
+                        "expression": "DB(JPMAQS,CID1_TEST,value)",
+                        "time-series": [
+                            ["20240125", 0.1],
+                            ["20240126", -0.1],
+                            ["20240127", None],
+                            ["20240128", None],
+                            ["20240129", 0.8],
+                            ["20240130", -0.01],
+                            ["20240131", 1.5],
+                            ["20240201", 1.0],
+                            ["20240202", 1.0],
+                        ],
+                    }
+                ]
+            },
+            {
+                "attributes": [
+                    {
+                        "expression": "DB(JPMAQS,CID1_TEST,grading)",
+                        "time-series": [
+                            ["20240125", 1.0],
+                            ["20240126", 1.0],
+                            ["20240127", None],
+                            ["20240128", None],
+                            ["20240129", 1.0],
+                            ["20240130", 1.0],
+                            ["20240131", 1.0],
+                            ["20240201", 1.0],
+                            ["20240202", 1.0],
+                        ],
+                    }
+                ]
+            },
+            {
+                "attributes": [
+                    {
+                        "expression": "DB(JPMAQS,CID1_TEST,mop_lag)",
+                        "time-series": [
+                            ["20240125", 0.0],
+                            ["20240126", 0.0],
+                            ["20240127", None],
+                            ["20240128", None],
+                            ["20240129", 0.0],
+                            ["20240130", 0.0],
+                            ["20240131", 0.0],
+                            ["20240201", 0.0],
+                            ["20240202", 0.0],
+                        ],
+                    }
+                ]
+            },
+            {
+                "attributes": [
+                    {
+                        "expression": "DB(JPMAQS,CID1_TEST,eop_lag)",
+                        "time-series": [
+                            ["20240125", 0.0],
+                            ["20240126", 0.0],
+                            ["20240127", None],
+                            ["20240128", None],
+                            ["20240129", 0.0],
+                            ["20240130", 0.0],
+                            ["20240131", 0.0],
+                            ["20240201", 0.0],
+                            ["20240202", 0.0],
+                        ],
+                    }
+                ]
+            },
+            {
+                "attributes": [
+                    {
+                        "expression": "DB(CFX,BGB,123,,FRW)",
+                        "time-series": [
+                            ["20240125", 0.0],
+                            ["20240126", 0.0],
+                            ["20240127", None],
+                            ["20240128", None],
+                            ["20240129", 0.0],
+                            ["20240130", 0.0],
+                            ["20240131", 0.0],
+                            ["20240201", 0.0],
+                            ["20240202", 0.0],
+                        ],
+                    }
+                ]
+            },
+        ]
         self.assertTrue(check_attributes_in_sync(ts_list))
 
-        out_of_sync_ts_list = [{"attributes": [{"expression": "DB(JPMAQS,CID_TEST,value)", "time-series": [["20240125", 0.1], ["20240126", -0.1], ["20240127", None], ["20240128", None], ["20240129", 0.8], ["20240130", -0.01], ["20240131", 1.5], ["20240201", 1.0], ["20240202", 1.0], ["20240203", None], ["20240204", None], ["20240205", None]]}]}, 
-                                {"attributes": [{"expression": "DB(JPMAQS,CID_TEST,grading)", "time-series": [["20240125", 1.0], ["20240126", 1.0], ["20240127", None], ["20240128", None], ["20240129", 1.0], ["20240130", 1.0], ["20240131", 1.0], ["20240201", 1.0], ["20240202", 1.0], ["20240203", None], ["20240204", None], ["20240205", 1.0]]}]}, 
-                                {"attributes": [{"expression": "DB(JPMAQS,CID_TEST,mop_lag)", "time-series": [["20240125", 0.0], ["20240126", 0.0], ["20240127", None], ["20240128", None], ["20240129", 0.0], ["20240130", 0.0], ["20240131", 0.0], ["20240201", 0.0], ["20240202", 0.0], ["20240203", None], ["20240204", None], ["20240205", 0.0]]}]}, 
-                                {"attributes": [{"expression": "DB(JPMAQS,CID_TEST,eop_lag)", "time-series": [["20240125", 0.0], ["20240126", 0.0], ["20240127", None], ["20240128", None], ["20240129", 0.0], ["20240130", 0.0], ["20240131", 0.0], ["20240201", 0.0], ["20240202", 0.0], ["20240203", None], ["20240204", None], ["20240205", 0.0]]}]}]
+        out_of_sync_ts_list = [
+            {
+                "attributes": [
+                    {
+                        "expression": "DB(JPMAQS,CID_TEST,value)",
+                        "time-series": [
+                            ["20240125", 0.1],
+                            ["20240126", -0.1],
+                            ["20240127", None],
+                            ["20240128", None],
+                            ["20240129", 0.8],
+                            ["20240130", -0.01],
+                            ["20240131", 1.5],
+                            ["20240201", 1.0],
+                            ["20240202", 1.0],
+                            ["20240203", None],
+                            ["20240204", None],
+                            ["20240205", None],
+                        ],
+                    }
+                ]
+            },
+            {
+                "attributes": [
+                    {
+                        "expression": "DB(JPMAQS,CID_TEST,grading)",
+                        "time-series": [
+                            ["20240125", 1.0],
+                            ["20240126", 1.0],
+                            ["20240127", None],
+                            ["20240128", None],
+                            ["20240129", 1.0],
+                            ["20240130", 1.0],
+                            ["20240131", 1.0],
+                            ["20240201", 1.0],
+                            ["20240202", 1.0],
+                            ["20240203", None],
+                            ["20240204", None],
+                            ["20240205", 1.0],
+                        ],
+                    }
+                ]
+            },
+            {
+                "attributes": [
+                    {
+                        "expression": "DB(JPMAQS,CID_TEST,mop_lag)",
+                        "time-series": [
+                            ["20240125", 0.0],
+                            ["20240126", 0.0],
+                            ["20240127", None],
+                            ["20240128", None],
+                            ["20240129", 0.0],
+                            ["20240130", 0.0],
+                            ["20240131", 0.0],
+                            ["20240201", 0.0],
+                            ["20240202", 0.0],
+                            ["20240203", None],
+                            ["20240204", None],
+                            ["20240205", 0.0],
+                        ],
+                    }
+                ]
+            },
+            {
+                "attributes": [
+                    {
+                        "expression": "DB(JPMAQS,CID_TEST,eop_lag)",
+                        "time-series": [
+                            ["20240125", 0.0],
+                            ["20240126", 0.0],
+                            ["20240127", None],
+                            ["20240128", None],
+                            ["20240129", 0.0],
+                            ["20240130", 0.0],
+                            ["20240131", 0.0],
+                            ["20240201", 0.0],
+                            ["20240202", 0.0],
+                            ["20240203", None],
+                            ["20240204", None],
+                            ["20240205", 0.0],
+                        ],
+                    }
+                ]
+            },
+        ]
         self.assertFalse(check_attributes_in_sync(out_of_sync_ts_list))
 
 


### PR DESCRIPTION
Implement the `JPMorganOAuth` class to provide common OAuth workflows for DataQuery API, DataQuery File API (see #2452), and Fusion API.