### PR TITLE
Feature: Restrict pandas version to <3.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ requires-python = ">=3.7"
 dependencies = [
   "seaborn>=0.13.0",
   "matplotlib>=3.6.0",
-  "pandas>=1.3.5",
+  "pandas>=1.3.5,<3.0.0",
   "statsmodels>=0.13.2",
   "scikit-learn>=1.2.2",
   "numpy>=1.21.6",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 seaborn >= 0.11.2
 matplotlib >= 3.6.0
-pandas >= 1.3.5
+pandas >= 1.3.5,< 3.0.0
 statsmodels >= 0.13.2
 scikit-learn >= 1.2.2
 numpy >= 1.21.6


### PR DESCRIPTION
Limit the pandas dependency to versions below 3.0.0 in both `pyproject.toml` and `requirements.txt` to ensure compatibility.