### PR TITLE
Feature: heatmap axis labels and footnote on single_statistic_table

### DIFF
--- a/macrosynergy/signal/signal_return_relations.py
+++ b/macrosynergy/signal/signal_return_relations.py
@@ -1513,6 +1513,10 @@ class SignalReturnRelations:
         pval_stat: Optional[str] = None,
         round_pval: int = 3,
         significance_threshold: Optional[float] = 0.9,
+        xlabel: Optional[str] = None,
+        ylabel: Optional[str] = None,
+        footnote: Optional[str] = None,
+        footnote_fontsize: int = 10,
     ):
         """
         Creates a table which shows the specified statistic for each row and column
@@ -1587,6 +1591,21 @@ class SignalReturnRelations:
             highlights cells whose probability of significance exceeds 0.9
             (equivalently, raw p-value below 0.1). Only takes effect when
             ``pval_stat`` is set. Pass ``None`` to disable. Default is 0.9.
+        xlabel : str, optional
+            Label drawn beneath the heatmap columns, useful for naming
+            the target return (e.g. ``"Forward return (target)"``).
+            Default is None.
+        ylabel : str, optional
+            Label drawn beside the heatmap rows, useful for naming the
+            feature (e.g. ``"Factor (feature)"``). Default is None.
+        footnote : str, optional
+            Free-text caption rendered below the heatmap. Useful for
+            recording the significance test, panel scope, or annotation
+            legend (e.g. ``"Significance computed with the Macrosynergy
+            panel test."``). Multi-line strings are supported. Default
+            is None (no footnote).
+        footnote_fontsize : int, optional
+            Font size for the footnote text. Default is 10.
 
         Returns
         -------
@@ -1750,9 +1769,13 @@ class SignalReturnRelations:
                 figsize=figsize,
                 fmt=heatmap_fmt,
                 annot=heatmap_annot,
+                xlabel=xlabel,
+                ylabel=ylabel,
                 xticklabels=column_names,
                 yticklabels=row_names,
                 highlight_mask=highlight_mask,
+                footnote=footnote,
+                footnote_fontsize=footnote_fontsize,
             )
 
         return df_result
@@ -1831,6 +1854,10 @@ class SignalReturnRelations:
             highlights cells whose probability of significance exceeds 0.9
             (equivalently, raw p-value below 0.1). Only takes effect when
             ``pval_stat`` is set. Pass ``None`` to disable. Default is 0.9.
+        xlabel, ylabel, footnote, footnote_fontsize
+            Forwarded to :meth:`single_statistic_table` and only affect
+            the heatmap; accepted here for API symmetry even though this
+            wrapper renders no heatmap.
 
         Returns
         -------
@@ -1917,6 +1944,16 @@ class SignalReturnRelations:
             highlights cells whose probability of significance exceeds 0.9
             (equivalently, raw p-value below 0.1). Only takes effect when
             ``pval_stat`` is set. Pass ``None`` to disable. Default is 0.9.
+        xlabel : str, optional
+            Label drawn beneath the heatmap columns. Default is None.
+        ylabel : str, optional
+            Label drawn beside the heatmap rows. Default is None.
+        footnote : str, optional
+            Free-text caption rendered below the heatmap. Useful for
+            recording the significance test, panel scope, or annotation
+            legend. Multi-line strings are supported. Default is None.
+        footnote_fontsize : int, optional
+            Font size for the footnote text. Default is 10.
         """
         kwargs["show_heatmap"] = True
         self.single_statistic_table(*args, **kwargs)

--- a/macrosynergy/visuals/table.py
+++ b/macrosynergy/visuals/table.py
@@ -20,6 +20,8 @@ def view_table(
     fmt: str = ".2f",
     return_fig: bool = False,
     highlight_mask: Optional[Union[np.ndarray, pd.DataFrame]] = None,
+    footnote: Optional[str] = None,
+    footnote_fontsize: int = 10,
 ) -> Optional[plt.Figure]:
     """
     Display a numeric DataFrame as an annotated colour-coded heatmap table.
@@ -59,6 +61,12 @@ def view_table(
         DataFrame or 2D array of the same shape as ``df``. Cells where the
         mask is True have their annotation text rendered in black and bold.
         Has no effect when ``annot`` is False.
+    footnote : str, optional
+        Free-text caption rendered below the heatmap, useful for noting the
+        statistical test, the panel scope, or how to read the annotations.
+        Multi-line strings are supported. Default is None (no footnote).
+    footnote_fontsize : int, optional
+        Font size for the footnote text. Default is 10.
     """
 
     if not isinstance(df, pd.DataFrame):
@@ -128,6 +136,24 @@ def view_table(
     ax.set(xlabel=xlabel, ylabel=ylabel)
     ax.set_title(title, fontsize=title_fontsize)
     plt.tight_layout()
+
+    if footnote:
+        n_lines = footnote.count("\n") + 1
+        # Reserve bottom margin for the heatmap + tick labels + optional xlabel + footnote.
+        # Figure-relative units: tick labels ~0.06, xlabel ~0.04 if present, then footnote.
+        xlabel_pad = 0.04 if ax.get_xlabel() else 0.0
+        footnote_block = 0.04 * n_lines
+        fig.subplots_adjust(bottom=0.10 + xlabel_pad + footnote_block)
+        fig.text(
+            0.5,
+            0.02,
+            footnote,
+            ha="center",
+            va="bottom",
+            fontsize=footnote_fontsize,
+            style="italic",
+            wrap=True,
+        )
 
     if return_fig:
         return fig


### PR DESCRIPTION
## Summary

- Add ``xlabel`` / ``ylabel`` to ``view_table`` callers via ``single_statistic_table`` (and its two thin wrappers) so heatmaps can name the feature and target axes.
- Add ``footnote`` / ``footnote_fontsize`` to ``view_table`` and ``single_statistic_table`` for a free-text caption beneath the heatmap (e.g. naming the significance test, panel scope, or annotation legend).
- Strictly additive: every existing call site keeps current behaviour when the new kwargs are left at their ``None`` defaults.

## Motivation

Reviewer feedback on the Academy Power Factors notebooks asked for the predictive-power heatmaps to label features and targets explicitly, and to add a note that significance is computed using the Macrosynergy panel test. Both can now live on the chart itself rather than only in the surrounding markdown.

## Test plan

- [x] Existing unit tests in ``tests/unit/visual/test_view_table.py`` and ``tests/unit/signal/test_signal_return_relations.py`` (20 tests) pass unchanged.
- [x] Smoke-rendered a ``view_table`` call with both new label kwargs and a multi-line ``footnote``; verified the xlabel and footnote stack cleanly (bottom margin scales with footnote line count and ``xlabel`` presence).
- [x] Smoke-rendered ``view_table`` with no ``footnote`` and no labels; verified unchanged layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)