### PR TITLE
Feature: collapse constant index levels + xcat_labels / axis_label_levels on single_statistic_table heatmap

### DIFF
--- a/macrosynergy/signal/signal_return_relations.py
+++ b/macrosynergy/signal/signal_return_relations.py
@@ -1516,6 +1516,7 @@ class SignalReturnRelations:
         significance_threshold: Optional[float] = 0.9,
         xlabel: Optional[str] = None,
         ylabel: Optional[str] = None,
+        collapse_constant_levels: bool = False,
         axis_label_levels: Optional[List[str]] = None,
         footnote: Optional[str] = None,
         footnote_fontsize: int = 10,
@@ -1608,30 +1609,44 @@ class SignalReturnRelations:
         xlabel : str, optional
             Label drawn beneath the heatmap columns, useful for naming
             the target return (e.g. ``"Forward return (target)"``).
-            Default is None, in which case any column-index levels whose
+            Default is None. When ``collapse_constant_levels=True`` and
+            the caller leaves this None, any column-index levels whose
             values are constant across the table are auto-collapsed into
             this label (joined by ``" · "``). See ``axis_label_levels``
             to restrict which constant levels feed into the label.
         ylabel : str, optional
             Label drawn beside the heatmap rows, useful for naming the
-            feature (e.g. ``"Factor (feature)"``). Default is None, in
-            which case any row-index levels whose values are constant
-            across the table are auto-collapsed into this label (joined
-            by ``" · "``). For instance, a table whose rows iterate over
+            feature (e.g. ``"Factor (feature)"``). Default is None. When
+            ``collapse_constant_levels=True`` and the caller leaves this
+            None, any row-index levels whose values are constant across
+            the table are auto-collapsed into this label (joined by
+            ``" · "``). For instance, a table whose rows iterate over
             one signal, one aggregation, and several frequencies will
             display only the frequencies as y-tick labels and place
             ``"<signal> · <aggregation>"`` on the y-axis label. See
             ``axis_label_levels`` to restrict which constant levels
             feed into the label.
+        collapse_constant_levels : bool, optional
+            When True, row/column index levels whose values are constant
+            across the table are stripped from the tick labels and
+            promoted to the corresponding axis label (joined by
+            ``" · "``) when the caller did not pass ``xlabel``/``ylabel``
+            (or ``row_names``/``column_names``) explicitly. The returned
+            DataFrame is unchanged in every case. Default is False (raw
+            MultiIndex tuples appear as tick labels, matching the
+            historical rendering). Required to be True before passing
+            ``axis_label_levels``.
         axis_label_levels : List[str], optional
             Subset of ``["xcat", "ret", "freq", "agg_sigs"]`` naming the
             level keys eligible for promotion into the auto x/y-axis
             label. Constant levels not in this list still collapse from
-            the tick labels but do not appear in the axis label. Default
-            is None, which promotes every collapsed level into the label
-            (the original behaviour). Pass e.g. ``["xcat", "ret"]`` to
-            keep the auto-label limited to the signal/return identity
-            and drop the aggregation/frequency suffix.
+            the tick labels but do not appear in the axis label. Only
+            takes effect when ``collapse_constant_levels=True``; raises
+            ``ValueError`` otherwise. Default is None, which promotes
+            every collapsed level into the label. Pass e.g.
+            ``["xcat", "ret"]`` to keep the auto-label limited to the
+            signal/return identity and drop the aggregation/frequency
+            suffix.
         footnote : str, optional
             Free-text caption rendered below the heatmap. Useful for
             recording the significance test, panel scope, or annotation
@@ -1679,6 +1694,10 @@ class SignalReturnRelations:
             raise ValueError(f"Columns must only contain {rows_values}")
 
         if axis_label_levels is not None:
+            if not collapse_constant_levels:
+                raise ValueError(
+                    "axis_label_levels requires collapse_constant_levels=True."
+                )
             if not all(x in rows_values for x in axis_label_levels):
                 raise ValueError(
                     f"axis_label_levels must only contain {rows_values}"
@@ -1812,46 +1831,49 @@ class SignalReturnRelations:
             if df_psig is not None and significance_threshold is not None:
                 highlight_mask = df_psig > float(significance_threshold)
 
-            # Collapse row/column index levels whose values are constant so
-            # they don't clutter the tick labels. The collapsed values are
-            # promoted to the corresponding axis label when the caller did
-            # not provide one. ``df_result`` itself is left untouched.
-            display_yticks, constant_y = self._collapse_constant_levels(
-                df_result.index
-            )
-            display_xticks, constant_x = self._collapse_constant_levels(
-                df_result.columns
-            )
-
-            yticklabels_to_pass = (
-                row_names if row_names is not None else display_yticks
-            )
-            xticklabels_to_pass = (
-                column_names if column_names is not None else display_xticks
-            )
-
-            # Filter which collapsed levels feed into the auto axis label.
-            # ``axis_label_levels`` is expressed in the same vocabulary as
-            # ``rows`` / ``columns`` (``"xcat"``, ``"ret"``, ``"freq"``,
-            # ``"agg_sigs"``); translate to the display level names used in
-            # the MultiIndex.
-            label_dict = {
-                "xcat": "Signal",
-                "ret": "Return",
-                "freq": "Frequency",
-                "agg_sigs": "Aggregation",
-            }
-            if axis_label_levels is not None:
-                allowed = {label_dict[k] for k in axis_label_levels}
-                constant_y = [(n, v) for n, v in constant_y if n in allowed]
-                constant_x = [(n, v) for n, v in constant_x if n in allowed]
-
+            yticklabels_to_pass = row_names
+            xticklabels_to_pass = column_names
             ylabel_to_pass = ylabel
-            if ylabel_to_pass is None and constant_y:
-                ylabel_to_pass = " · ".join(v for _, v in constant_y)
             xlabel_to_pass = xlabel
-            if xlabel_to_pass is None and constant_x:
-                xlabel_to_pass = " · ".join(v for _, v in constant_x)
+
+            if collapse_constant_levels:
+                # Strip row/column index levels whose values are constant
+                # so they don't clutter the tick labels. The collapsed
+                # values are promoted to the corresponding axis label
+                # when the caller did not provide one. ``df_result``
+                # itself is left untouched.
+                display_yticks, constant_y = self._collapse_constant_levels(
+                    df_result.index
+                )
+                display_xticks, constant_x = self._collapse_constant_levels(
+                    df_result.columns
+                )
+
+                if yticklabels_to_pass is None:
+                    yticklabels_to_pass = display_yticks
+                if xticklabels_to_pass is None:
+                    xticklabels_to_pass = display_xticks
+
+                # Filter which collapsed levels feed into the auto axis
+                # label. ``axis_label_levels`` is expressed in the same
+                # vocabulary as ``rows`` / ``columns`` (``"xcat"``,
+                # ``"ret"``, ``"freq"``, ``"agg_sigs"``); translate to
+                # the display level names used in the MultiIndex.
+                label_dict = {
+                    "xcat": "Signal",
+                    "ret": "Return",
+                    "freq": "Frequency",
+                    "agg_sigs": "Aggregation",
+                }
+                if axis_label_levels is not None:
+                    allowed = {label_dict[k] for k in axis_label_levels}
+                    constant_y = [(n, v) for n, v in constant_y if n in allowed]
+                    constant_x = [(n, v) for n, v in constant_x if n in allowed]
+
+                if ylabel_to_pass is None and constant_y:
+                    ylabel_to_pass = " · ".join(v for _, v in constant_y)
+                if xlabel_to_pass is None and constant_x:
+                    xlabel_to_pass = " · ".join(v for _, v in constant_x)
 
             msv.view_table(
                 df_result,

--- a/macrosynergy/signal/signal_return_relations.py
+++ b/macrosynergy/signal/signal_return_relations.py
@@ -1505,6 +1505,7 @@ class SignalReturnRelations:
         column_names: Optional[List[str]] = None,
         signal_name_dict: Optional[Dict[str, str]] = None,
         return_name_dict: Optional[Dict[str, str]] = None,
+        xcat_labels: Optional[Dict[str, str]] = None,
         min_color: Optional[float] = None,
         max_color: Optional[float] = None,
         figsize: Tuple[float, float] = (14, 8),
@@ -1515,6 +1516,7 @@ class SignalReturnRelations:
         significance_threshold: Optional[float] = 0.9,
         xlabel: Optional[str] = None,
         ylabel: Optional[str] = None,
+        axis_label_levels: Optional[List[str]] = None,
         footnote: Optional[str] = None,
         footnote_fontsize: int = 10,
     ):
@@ -1556,10 +1558,22 @@ class SignalReturnRelations:
             of the generated DataFrame are used.
         signal_name_dict : dict, optional
             dictionary mapping the signal names to the desired names in the heatmap.
-            Default is None, in which case the signal names are used.
+            Default is None, in which case the signal names are used. Renamed
+            values flow through to the auto axis label produced by the
+            constant-level collapse described under ``ylabel``.
         return_name_dict : dict, optional
             dictionary mapping the return names to the desired names in the heatmap.
-            Default is None, in which case the return names are used.
+            Default is None, in which case the return names are used. Renamed
+            values flow through to the auto axis label produced by the
+            constant-level collapse described under ``xlabel``.
+        xcat_labels : dict, optional
+            Unified rename dictionary covering both signal and return
+            ``xcat``\s. Internally split by membership in ``self.sigs`` /
+            ``self.rets`` and routed through ``signal_name_dict`` /
+            ``return_name_dict``; xcats not listed in the dict are kept
+            verbatim. Mutually exclusive with the two legacy kwargs — pass
+            either ``xcat_labels`` or ``signal_name_dict`` /
+            ``return_name_dict``, not both. Default is None (no rename).
         min_color : float, optional
             minimum value of the color scale. Default is None, in which case the minimum
             value of the table is used.
@@ -1596,7 +1610,8 @@ class SignalReturnRelations:
             the target return (e.g. ``"Forward return (target)"``).
             Default is None, in which case any column-index levels whose
             values are constant across the table are auto-collapsed into
-            this label (joined by ``" · "``).
+            this label (joined by ``" · "``). See ``axis_label_levels``
+            to restrict which constant levels feed into the label.
         ylabel : str, optional
             Label drawn beside the heatmap rows, useful for naming the
             feature (e.g. ``"Factor (feature)"``). Default is None, in
@@ -1605,7 +1620,18 @@ class SignalReturnRelations:
             by ``" · "``). For instance, a table whose rows iterate over
             one signal, one aggregation, and several frequencies will
             display only the frequencies as y-tick labels and place
-            ``"<signal> · <aggregation>"`` on the y-axis label.
+            ``"<signal> · <aggregation>"`` on the y-axis label. See
+            ``axis_label_levels`` to restrict which constant levels
+            feed into the label.
+        axis_label_levels : List[str], optional
+            Subset of ``["xcat", "ret", "freq", "agg_sigs"]`` naming the
+            level keys eligible for promotion into the auto x/y-axis
+            label. Constant levels not in this list still collapse from
+            the tick labels but do not appear in the axis label. Default
+            is None, which promotes every collapsed level into the label
+            (the original behaviour). Pass e.g. ``["xcat", "ret"]`` to
+            keep the auto-label limited to the signal/return identity
+            and drop the aggregation/frequency suffix.
         footnote : str, optional
             Free-text caption rendered below the heatmap. Useful for
             recording the significance test, panel scope, or annotation
@@ -1651,6 +1677,24 @@ class SignalReturnRelations:
 
         if not all([x in rows_values for x in columns]):
             raise ValueError(f"Columns must only contain {rows_values}")
+
+        if axis_label_levels is not None:
+            if not all(x in rows_values for x in axis_label_levels):
+                raise ValueError(
+                    f"axis_label_levels must only contain {rows_values}"
+                )
+
+        if xcat_labels is not None:
+            if signal_name_dict is not None or return_name_dict is not None:
+                raise ValueError(
+                    "Pass either xcat_labels or "
+                    "signal_name_dict/return_name_dict, not both."
+                )
+            # Build identity-filled rename dicts so existing keys preserve
+            # their position and unrenamed xcats are not dropped by the
+            # downstream reorder.
+            signal_name_dict = {s: xcat_labels.get(s, s) for s in self.sigs}
+            return_name_dict = {r: xcat_labels.get(r, r) for r in self.rets}
 
         rows_dict = {
             "xcat": self.sigs,
@@ -1786,12 +1830,28 @@ class SignalReturnRelations:
                 column_names if column_names is not None else display_xticks
             )
 
+            # Filter which collapsed levels feed into the auto axis label.
+            # ``axis_label_levels`` is expressed in the same vocabulary as
+            # ``rows`` / ``columns`` (``"xcat"``, ``"ret"``, ``"freq"``,
+            # ``"agg_sigs"``); translate to the display level names used in
+            # the MultiIndex.
+            label_dict = {
+                "xcat": "Signal",
+                "ret": "Return",
+                "freq": "Frequency",
+                "agg_sigs": "Aggregation",
+            }
+            if axis_label_levels is not None:
+                allowed = {label_dict[k] for k in axis_label_levels}
+                constant_y = [(n, v) for n, v in constant_y if n in allowed]
+                constant_x = [(n, v) for n, v in constant_x if n in allowed]
+
             ylabel_to_pass = ylabel
             if ylabel_to_pass is None and constant_y:
-                ylabel_to_pass = " · ".join(constant_y)
+                ylabel_to_pass = " · ".join(v for _, v in constant_y)
             xlabel_to_pass = xlabel
             if xlabel_to_pass is None and constant_x:
-                xlabel_to_pass = " · ".join(constant_x)
+                xlabel_to_pass = " · ".join(v for _, v in constant_x)
 
             msv.view_table(
                 df_result,
@@ -1852,10 +1912,22 @@ class SignalReturnRelations:
             of the generated DataFrame are used.
         signal_name_dict : dict, optional
             dictionary mapping the signal names to the desired names in the heatmap.
-            Default is None, in which case the signal names are used.
+            Default is None, in which case the signal names are used. Renamed
+            values flow through to the auto axis label produced by the
+            constant-level collapse described under ``ylabel``.
         return_name_dict : dict, optional
             dictionary mapping the return names to the desired names in the heatmap.
-            Default is None, in which case the return names are used.
+            Default is None, in which case the return names are used. Renamed
+            values flow through to the auto axis label produced by the
+            constant-level collapse described under ``xlabel``.
+        xcat_labels : dict, optional
+            Unified rename dictionary covering both signal and return
+            ``xcat``\s. Internally split by membership in ``self.sigs`` /
+            ``self.rets`` and routed through ``signal_name_dict`` /
+            ``return_name_dict``; xcats not listed in the dict are kept
+            verbatim. Mutually exclusive with the two legacy kwargs — pass
+            either ``xcat_labels`` or ``signal_name_dict`` /
+            ``return_name_dict``, not both. Default is None (no rename).
         min_color : float, optional
             minimum value of the color scale. Default is None, in which case the minimum
             value of the table is used.
@@ -1942,10 +2014,22 @@ class SignalReturnRelations:
             of the generated DataFrame are used.
         signal_name_dict : dict, optional
             dictionary mapping the signal names to the desired names in the heatmap.
-            Default is None, in which case the signal names are used.
+            Default is None, in which case the signal names are used. Renamed
+            values flow through to the auto axis label produced by the
+            constant-level collapse described under ``ylabel``.
         return_name_dict : dict, optional
             dictionary mapping the return names to the desired names in the heatmap.
-            Default is None, in which case the return names are used.
+            Default is None, in which case the return names are used. Renamed
+            values flow through to the auto axis label produced by the
+            constant-level collapse described under ``xlabel``.
+        xcat_labels : dict, optional
+            Unified rename dictionary covering both signal and return
+            ``xcat``\s. Internally split by membership in ``self.sigs`` /
+            ``self.rets`` and routed through ``signal_name_dict`` /
+            ``return_name_dict``; xcats not listed in the dict are kept
+            verbatim. Mutually exclusive with the two legacy kwargs — pass
+            either ``xcat_labels`` or ``signal_name_dict`` /
+            ``return_name_dict``, not both. Default is None (no rename).
         min_color : float, optional
             minimum value of the color scale. Default is None, in which case the minimum
             value of the table is used.
@@ -2024,7 +2108,7 @@ class SignalReturnRelations:
 
     def _collapse_constant_levels(
         self, idx: pd.Index
-    ) -> Tuple[Optional[List[str]], List[str]]:
+    ) -> Tuple[Optional[List[str]], List[Tuple[str, str]]]:
         """
         Strip levels of a MultiIndex whose values are constant across the
         index and surface those values for axis-label use.
@@ -2037,33 +2121,36 @@ class SignalReturnRelations:
 
         Returns
         -------
-        Tuple[Optional[List[str]], List[str]]
-            ``(display_labels, constant_values)``.
+        Tuple[Optional[List[str]], List[Tuple[str, str]]]
+            ``(display_labels, constant_pairs)``.
             ``display_labels`` is a list of tick labels with constant levels
             removed, joined by ``" · "`` when more than one level survives.
             It is ``None`` when no collapse applies (plain ``Index``, single
             level, no constant levels, or all levels constant — in which
-            case the existing tick labels are kept). ``constant_values`` is
-            the ordered list of the collapsed level values, suitable for
-            building an auto axis label.
+            case the existing tick labels are kept). ``constant_pairs`` is
+            an ordered list of ``(level_name, value)`` for each collapsed
+            level, suitable for filtering and joining into an auto axis
+            label.
         """
         if not isinstance(idx, pd.MultiIndex) or idx.nlevels < 2:
             return None, []
 
         constant_level_nos: List[int] = []
-        constant_values: List[str] = []
+        constant_pairs: List[Tuple[str, str]] = []
         for level_no in range(idx.nlevels):
             uniq = idx.get_level_values(level_no).unique()
             if len(uniq) == 1:
                 constant_level_nos.append(level_no)
-                constant_values.append(str(uniq[0]))
+                constant_pairs.append(
+                    (str(idx.names[level_no]), str(uniq[0]))
+                )
 
         if not constant_level_nos:
             return None, []
         if len(constant_level_nos) == idx.nlevels:
             # Every level is constant (single-row/column table): leave the
             # tick labels alone but still expose the values for the axis.
-            return None, constant_values
+            return None, constant_pairs
 
         remaining = idx.droplevel(constant_level_nos)
         if isinstance(remaining, pd.MultiIndex):
@@ -2072,7 +2159,7 @@ class SignalReturnRelations:
             ]
         else:
             display = [str(v) for v in remaining.tolist()]
-        return display, constant_values
+        return display, constant_pairs
 
     def set_df_labels(self, rows_dict: Dict, rows: List[str], columns: List[str]):
         """

--- a/macrosynergy/signal/signal_return_relations.py
+++ b/macrosynergy/signal/signal_return_relations.py
@@ -1594,10 +1594,18 @@ class SignalReturnRelations:
         xlabel : str, optional
             Label drawn beneath the heatmap columns, useful for naming
             the target return (e.g. ``"Forward return (target)"``).
-            Default is None.
+            Default is None, in which case any column-index levels whose
+            values are constant across the table are auto-collapsed into
+            this label (joined by ``" · "``).
         ylabel : str, optional
             Label drawn beside the heatmap rows, useful for naming the
-            feature (e.g. ``"Factor (feature)"``). Default is None.
+            feature (e.g. ``"Factor (feature)"``). Default is None, in
+            which case any row-index levels whose values are constant
+            across the table are auto-collapsed into this label (joined
+            by ``" · "``). For instance, a table whose rows iterate over
+            one signal, one aggregation, and several frequencies will
+            display only the frequencies as y-tick labels and place
+            ``"<signal> · <aggregation>"`` on the y-axis label.
         footnote : str, optional
             Free-text caption rendered below the heatmap. Useful for
             recording the significance test, panel scope, or annotation
@@ -1760,6 +1768,31 @@ class SignalReturnRelations:
             if df_psig is not None and significance_threshold is not None:
                 highlight_mask = df_psig > float(significance_threshold)
 
+            # Collapse row/column index levels whose values are constant so
+            # they don't clutter the tick labels. The collapsed values are
+            # promoted to the corresponding axis label when the caller did
+            # not provide one. ``df_result`` itself is left untouched.
+            display_yticks, constant_y = self._collapse_constant_levels(
+                df_result.index
+            )
+            display_xticks, constant_x = self._collapse_constant_levels(
+                df_result.columns
+            )
+
+            yticklabels_to_pass = (
+                row_names if row_names is not None else display_yticks
+            )
+            xticklabels_to_pass = (
+                column_names if column_names is not None else display_xticks
+            )
+
+            ylabel_to_pass = ylabel
+            if ylabel_to_pass is None and constant_y:
+                ylabel_to_pass = " · ".join(constant_y)
+            xlabel_to_pass = xlabel
+            if xlabel_to_pass is None and constant_x:
+                xlabel_to_pass = " · ".join(constant_x)
+
             msv.view_table(
                 df_result,
                 title=title,
@@ -1769,10 +1802,10 @@ class SignalReturnRelations:
                 figsize=figsize,
                 fmt=heatmap_fmt,
                 annot=heatmap_annot,
-                xlabel=xlabel,
-                ylabel=ylabel,
-                xticklabels=column_names,
-                yticklabels=row_names,
+                xlabel=xlabel_to_pass,
+                ylabel=ylabel_to_pass,
+                xticklabels=xticklabels_to_pass,
+                yticklabels=yticklabels_to_pass,
                 highlight_mask=highlight_mask,
                 footnote=footnote,
                 footnote_fontsize=footnote_fontsize,
@@ -1988,6 +2021,58 @@ class SignalReturnRelations:
                 else:
                     annot.loc[row, col] = f"{stat_str}\n({pval_str})"
         return annot
+
+    def _collapse_constant_levels(
+        self, idx: pd.Index
+    ) -> Tuple[Optional[List[str]], List[str]]:
+        """
+        Strip levels of a MultiIndex whose values are constant across the
+        index and surface those values for axis-label use.
+
+        Parameters
+        ----------
+        idx : pd.Index
+            Row or column index of the assembled statistic table. May be a
+            plain :class:`~pandas.Index` or a :class:`~pandas.MultiIndex`.
+
+        Returns
+        -------
+        Tuple[Optional[List[str]], List[str]]
+            ``(display_labels, constant_values)``.
+            ``display_labels`` is a list of tick labels with constant levels
+            removed, joined by ``" · "`` when more than one level survives.
+            It is ``None`` when no collapse applies (plain ``Index``, single
+            level, no constant levels, or all levels constant — in which
+            case the existing tick labels are kept). ``constant_values`` is
+            the ordered list of the collapsed level values, suitable for
+            building an auto axis label.
+        """
+        if not isinstance(idx, pd.MultiIndex) or idx.nlevels < 2:
+            return None, []
+
+        constant_level_nos: List[int] = []
+        constant_values: List[str] = []
+        for level_no in range(idx.nlevels):
+            uniq = idx.get_level_values(level_no).unique()
+            if len(uniq) == 1:
+                constant_level_nos.append(level_no)
+                constant_values.append(str(uniq[0]))
+
+        if not constant_level_nos:
+            return None, []
+        if len(constant_level_nos) == idx.nlevels:
+            # Every level is constant (single-row/column table): leave the
+            # tick labels alone but still expose the values for the axis.
+            return None, constant_values
+
+        remaining = idx.droplevel(constant_level_nos)
+        if isinstance(remaining, pd.MultiIndex):
+            display = [
+                " · ".join(str(part) for part in tup) for tup in remaining.tolist()
+            ]
+        else:
+            display = [str(v) for v in remaining.tolist()]
+        return display, constant_values
 
     def set_df_labels(self, rows_dict: Dict, rows: List[str], columns: List[str]):
         """

--- a/tests/unit/signal/test_signal_return_relations.py
+++ b/tests/unit/signal/test_signal_return_relations.py
@@ -1218,7 +1218,7 @@ class TestAll(unittest.TestCase):
             # Single signal + single aggregation, multiple frequencies:
             # both ``xcat`` and ``agg_sigs`` are constant across the rows,
             # so they should collapse out of the tick labels and into the
-            # auto y-label.
+            # auto y-label when the caller opts in.
             sr = SignalReturnRelations(
                 df=self.dfd,
                 rets="XR",
@@ -1235,6 +1235,7 @@ class TestAll(unittest.TestCase):
                     rows=["xcat", "agg_sigs", "freq"],
                     columns=["ret"],
                     show_heatmap=True,
+                    collapse_constant_levels=True,
                 )
                 mock_view_table.assert_called_once()
                 _, call_kwargs = mock_view_table.call_args
@@ -1248,6 +1249,21 @@ class TestAll(unittest.TestCase):
                     call_kwargs.get("ylabel"), "CRY · last"
                 )
 
+            # Default (collapse_constant_levels=False): byte-identical
+            # to the historical rendering — no auto y-label, no tick
+            # collapse passed to ``view_table``.
+            with patch("macrosynergy.visuals.view_table") as mock_view_table:
+                sr.single_statistic_table(
+                    stat="kendall",
+                    rows=["xcat", "agg_sigs", "freq"],
+                    columns=["ret"],
+                    show_heatmap=True,
+                )
+                mock_view_table.assert_called_once()
+                _, call_kwargs = mock_view_table.call_args
+                self.assertIsNone(call_kwargs.get("ylabel"))
+                self.assertIsNone(call_kwargs.get("yticklabels"))
+
             # Explicit ylabel/yticklabels must be respected even when a
             # collapse would otherwise have applied.
             with patch("macrosynergy.visuals.view_table") as mock_view_table:
@@ -1256,6 +1272,7 @@ class TestAll(unittest.TestCase):
                     rows=["xcat", "agg_sigs", "freq"],
                     columns=["ret"],
                     show_heatmap=True,
+                    collapse_constant_levels=True,
                     ylabel="Custom y-label",
                     row_names=["row1", "row2"],
                 )
@@ -1287,6 +1304,7 @@ class TestAll(unittest.TestCase):
                     rows=["xcat", "agg_sigs", "freq"],
                     columns=["ret"],
                     show_heatmap=True,
+                    collapse_constant_levels=True,
                 )
                 mock_view_table.assert_called_once()
                 _, call_kwargs = mock_view_table.call_args
@@ -1313,6 +1331,7 @@ class TestAll(unittest.TestCase):
                     rows=["xcat", "agg_sigs", "freq"],
                     columns=["ret"],
                     show_heatmap=True,
+                    collapse_constant_levels=True,
                 )
                 mock_view_table.assert_called_once()
                 _, call_kwargs = mock_view_table.call_args
@@ -1325,6 +1344,7 @@ class TestAll(unittest.TestCase):
                 stat="kendall",
                 rows=["xcat", "agg_sigs", "freq"],
                 columns=["ret"],
+                collapse_constant_levels=True,
             )
             self.assertIsInstance(df_returned.index, pd.MultiIndex)
             self.assertEqual(df_returned.index.nlevels, 3)
@@ -1401,6 +1421,7 @@ class TestAll(unittest.TestCase):
                     rows=["xcat", "agg_sigs", "freq"],
                     columns=["ret"],
                     show_heatmap=True,
+                    collapse_constant_levels=True,
                     axis_label_levels=["xcat"],
                 )
                 mock_view_table.assert_called_once()
@@ -1416,6 +1437,7 @@ class TestAll(unittest.TestCase):
                     rows=["xcat", "agg_sigs", "freq"],
                     columns=["ret"],
                     show_heatmap=True,
+                    collapse_constant_levels=True,
                     axis_label_levels=[],
                 )
                 mock_view_table.assert_called_once()
@@ -1430,7 +1452,18 @@ class TestAll(unittest.TestCase):
                     rows=["xcat", "agg_sigs", "freq"],
                     columns=["ret"],
                     show_heatmap=True,
+                    collapse_constant_levels=True,
                     axis_label_levels=["not_a_level"],
+                )
+
+            # axis_label_levels without the collapse gate is rejected.
+            with self.assertRaises(ValueError):
+                sr.single_statistic_table(
+                    stat="kendall",
+                    rows=["xcat", "agg_sigs", "freq"],
+                    columns=["ret"],
+                    show_heatmap=True,
+                    axis_label_levels=["xcat"],
                 )
 
         plt.close("all")
@@ -1467,6 +1500,7 @@ class TestAll(unittest.TestCase):
                     columns=["ret"],
                     show_heatmap=True,
                     xcat_labels=xcat_labels,
+                    collapse_constant_levels=True,
                     axis_label_levels=["xcat"],
                 )
                 mock_view_table.assert_called_once()

--- a/tests/unit/signal/test_signal_return_relations.py
+++ b/tests/unit/signal/test_signal_return_relations.py
@@ -1208,6 +1208,172 @@ class TestAll(unittest.TestCase):
         plt.close("all")
         matplotlib.use(self.mpl_backend)
 
+    def test_single_statistic_table_collapse_constant_levels(self):
+        self.mpl_backend: str = matplotlib.get_backend()
+        matplotlib.use("Agg")
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+
+            # Single signal + single aggregation, multiple frequencies:
+            # both ``xcat`` and ``agg_sigs`` are constant across the rows,
+            # so they should collapse out of the tick labels and into the
+            # auto y-label.
+            sr = SignalReturnRelations(
+                df=self.dfd,
+                rets="XR",
+                sigs="CRY",
+                freqs=["M", "Q"],
+                agg_sigs="last",
+                blacklist=self.blacklist,
+                slip=1,
+            )
+
+            with patch("macrosynergy.visuals.view_table") as mock_view_table:
+                sr.single_statistic_table(
+                    stat="kendall",
+                    rows=["xcat", "agg_sigs", "freq"],
+                    columns=["ret"],
+                    show_heatmap=True,
+                )
+                mock_view_table.assert_called_once()
+                _, call_kwargs = mock_view_table.call_args
+
+                # Constant xcat/agg_sigs collapse into the y-label,
+                # only the varying frequency remains on the y-axis.
+                self.assertEqual(
+                    call_kwargs.get("yticklabels"), ["M", "Q"]
+                )
+                self.assertEqual(
+                    call_kwargs.get("ylabel"), "CRY · last"
+                )
+
+            # Explicit ylabel/yticklabels must be respected even when a
+            # collapse would otherwise have applied.
+            with patch("macrosynergy.visuals.view_table") as mock_view_table:
+                sr.single_statistic_table(
+                    stat="kendall",
+                    rows=["xcat", "agg_sigs", "freq"],
+                    columns=["ret"],
+                    show_heatmap=True,
+                    ylabel="Custom y-label",
+                    row_names=["row1", "row2"],
+                )
+                mock_view_table.assert_called_once()
+                _, call_kwargs = mock_view_table.call_args
+                self.assertEqual(
+                    call_kwargs.get("yticklabels"), ["row1", "row2"]
+                )
+                self.assertEqual(
+                    call_kwargs.get("ylabel"), "Custom y-label"
+                )
+
+            # Multiple signals: xcat is no longer constant, so only the
+            # still-constant ``agg_sigs`` level collapses. The remaining
+            # ``xcat``/``freq`` pair survives in the tick labels.
+            sr2 = SignalReturnRelations(
+                df=self.dfd,
+                rets="XR",
+                sigs=["CRY", "GROWTH"],
+                freqs=["M", "Q"],
+                agg_sigs="last",
+                blacklist=self.blacklist,
+                slip=1,
+            )
+
+            with patch("macrosynergy.visuals.view_table") as mock_view_table:
+                sr2.single_statistic_table(
+                    stat="kendall",
+                    rows=["xcat", "agg_sigs", "freq"],
+                    columns=["ret"],
+                    show_heatmap=True,
+                )
+                mock_view_table.assert_called_once()
+                _, call_kwargs = mock_view_table.call_args
+                self.assertEqual(call_kwargs.get("ylabel"), "last")
+                self.assertEqual(
+                    sorted(call_kwargs.get("yticklabels")),
+                    sorted(["CRY · M", "CRY · Q", "GROWTH · M", "GROWTH · Q"]),
+                )
+
+            # All row levels varying: nothing collapses and the renderer
+            # falls back to the DataFrame's own MultiIndex tick labels.
+            sr3 = SignalReturnRelations(
+                df=self.dfd,
+                rets="XR",
+                sigs=["CRY", "GROWTH"],
+                freqs=["M", "Q"],
+                agg_sigs=["last", "mean"],
+                blacklist=self.blacklist,
+                slip=1,
+            )
+            with patch("macrosynergy.visuals.view_table") as mock_view_table:
+                sr3.single_statistic_table(
+                    stat="kendall",
+                    rows=["xcat", "agg_sigs", "freq"],
+                    columns=["ret"],
+                    show_heatmap=True,
+                )
+                mock_view_table.assert_called_once()
+                _, call_kwargs = mock_view_table.call_args
+                self.assertIsNone(call_kwargs.get("ylabel"))
+                self.assertIsNone(call_kwargs.get("yticklabels"))
+
+            # The returned DataFrame keeps its original MultiIndex — the
+            # collapse is display-only.
+            df_returned = sr.single_statistic_table(
+                stat="kendall",
+                rows=["xcat", "agg_sigs", "freq"],
+                columns=["ret"],
+            )
+            self.assertIsInstance(df_returned.index, pd.MultiIndex)
+            self.assertEqual(df_returned.index.nlevels, 3)
+
+        plt.close("all")
+        matplotlib.use(self.mpl_backend)
+
+    def test_collapse_constant_levels_helper(self):
+        sr = SignalReturnRelations(
+            df=self.dfd,
+            rets="XR",
+            sigs="CRY",
+            freqs="Q",
+            blacklist=self.blacklist,
+            slip=1,
+        )
+
+        # Plain index: no collapse.
+        plain = pd.Index(["a", "b", "c"])
+        display, constant = sr._collapse_constant_levels(plain)
+        self.assertIsNone(display)
+        self.assertEqual(constant, [])
+
+        # Mixed constant / varying levels: constant levels collapse out.
+        mi = pd.MultiIndex.from_tuples(
+            [("X", "last", "M"), ("X", "last", "Q")],
+            names=["Signal", "Aggregation", "Frequency"],
+        )
+        display, constant = sr._collapse_constant_levels(mi)
+        self.assertEqual(display, ["M", "Q"])
+        self.assertEqual(constant, ["X", "last"])
+
+        # No constant levels: nothing collapses.
+        mi2 = pd.MultiIndex.from_tuples(
+            [("X", "M"), ("Y", "Q")], names=["Signal", "Frequency"]
+        )
+        display, constant = sr._collapse_constant_levels(mi2)
+        self.assertIsNone(display)
+        self.assertEqual(constant, [])
+
+        # Every level constant: tick labels left alone, but the
+        # constant values are still surfaced for the axis label.
+        mi3 = pd.MultiIndex.from_tuples(
+            [("X", "M")], names=["Signal", "Frequency"]
+        )
+        display, constant = sr._collapse_constant_levels(mi3)
+        self.assertIsNone(display)
+        self.assertEqual(constant, ["X", "M"])
+
     def test_plot_single_statistic_heatmap(self):
         self.mpl_backend: str = matplotlib.get_backend()
         matplotlib.use("Agg")

--- a/tests/unit/signal/test_signal_return_relations.py
+++ b/tests/unit/signal/test_signal_return_relations.py
@@ -1349,13 +1349,15 @@ class TestAll(unittest.TestCase):
         self.assertEqual(constant, [])
 
         # Mixed constant / varying levels: constant levels collapse out.
+        # The helper now tags each constant value with its level name so
+        # the caller can filter by axis_label_levels.
         mi = pd.MultiIndex.from_tuples(
             [("X", "last", "M"), ("X", "last", "Q")],
             names=["Signal", "Aggregation", "Frequency"],
         )
         display, constant = sr._collapse_constant_levels(mi)
         self.assertEqual(display, ["M", "Q"])
-        self.assertEqual(constant, ["X", "last"])
+        self.assertEqual(constant, [("Signal", "X"), ("Aggregation", "last")])
 
         # No constant levels: nothing collapses.
         mi2 = pd.MultiIndex.from_tuples(
@@ -1372,7 +1374,144 @@ class TestAll(unittest.TestCase):
         )
         display, constant = sr._collapse_constant_levels(mi3)
         self.assertIsNone(display)
-        self.assertEqual(constant, ["X", "M"])
+        self.assertEqual(constant, [("Signal", "X"), ("Frequency", "M")])
+
+    def test_single_statistic_table_axis_label_levels(self):
+        self.mpl_backend: str = matplotlib.get_backend()
+        matplotlib.use("Agg")
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+
+            sr = SignalReturnRelations(
+                df=self.dfd,
+                rets="XR",
+                sigs="CRY",
+                freqs=["M", "Q"],
+                agg_sigs="last",
+                blacklist=self.blacklist,
+                slip=1,
+            )
+
+            # axis_label_levels=["xcat"] keeps the y-tick collapse but
+            # drops the constant agg_sigs ("last") from the auto y-label.
+            with patch("macrosynergy.visuals.view_table") as mock_view_table:
+                sr.single_statistic_table(
+                    stat="kendall",
+                    rows=["xcat", "agg_sigs", "freq"],
+                    columns=["ret"],
+                    show_heatmap=True,
+                    axis_label_levels=["xcat"],
+                )
+                mock_view_table.assert_called_once()
+                _, call_kwargs = mock_view_table.call_args
+                self.assertEqual(call_kwargs.get("yticklabels"), ["M", "Q"])
+                self.assertEqual(call_kwargs.get("ylabel"), "CRY")
+
+            # Empty list suppresses the auto label entirely while
+            # leaving the tick collapse intact.
+            with patch("macrosynergy.visuals.view_table") as mock_view_table:
+                sr.single_statistic_table(
+                    stat="kendall",
+                    rows=["xcat", "agg_sigs", "freq"],
+                    columns=["ret"],
+                    show_heatmap=True,
+                    axis_label_levels=[],
+                )
+                mock_view_table.assert_called_once()
+                _, call_kwargs = mock_view_table.call_args
+                self.assertEqual(call_kwargs.get("yticklabels"), ["M", "Q"])
+                self.assertIsNone(call_kwargs.get("ylabel"))
+
+            # Invalid level keys are rejected.
+            with self.assertRaises(ValueError):
+                sr.single_statistic_table(
+                    stat="kendall",
+                    rows=["xcat", "agg_sigs", "freq"],
+                    columns=["ret"],
+                    show_heatmap=True,
+                    axis_label_levels=["not_a_level"],
+                )
+
+        plt.close("all")
+        matplotlib.use(self.mpl_backend)
+
+    def test_single_statistic_table_xcat_labels(self):
+        self.mpl_backend: str = matplotlib.get_backend()
+        matplotlib.use("Agg")
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+
+            sr = SignalReturnRelations(
+                df=self.dfd,
+                rets=["XR", "GROWTH"],
+                sigs="CRY",
+                freqs=["M", "Q"],
+                agg_sigs="last",
+                blacklist=self.blacklist,
+                slip=1,
+            )
+
+            # Unified rename dict applied to both signals and returns;
+            # renamed values flow through to the auto y-label.
+            xcat_labels = {
+                "CRY": "Carry score",
+                "XR": "Spot return",
+                "GROWTH": "Growth score",
+            }
+            with patch("macrosynergy.visuals.view_table") as mock_view_table:
+                sr.single_statistic_table(
+                    stat="kendall",
+                    rows=["xcat", "agg_sigs", "freq"],
+                    columns=["ret"],
+                    show_heatmap=True,
+                    xcat_labels=xcat_labels,
+                    axis_label_levels=["xcat"],
+                )
+                mock_view_table.assert_called_once()
+                call_args, call_kwargs = mock_view_table.call_args
+                df_passed = call_args[0]
+                # Signal rename propagates to the y-label.
+                self.assertEqual(call_kwargs.get("ylabel"), "Carry score")
+                # Return rename appears on the DataFrame columns (a plain
+                # Index with two entries, so view_table picks them up
+                # directly when xticklabels is left at None).
+                self.assertEqual(
+                    sorted(df_passed.columns.tolist()),
+                    sorted(["Spot return", "Growth score"]),
+                )
+
+            # Partial dict: unlisted xcats are kept verbatim, not dropped.
+            with patch("macrosynergy.visuals.view_table") as mock_view_table:
+                sr.single_statistic_table(
+                    stat="kendall",
+                    rows=["xcat", "agg_sigs", "freq"],
+                    columns=["ret"],
+                    show_heatmap=True,
+                    xcat_labels={"CRY": "Carry score"},
+                )
+                mock_view_table.assert_called_once()
+                call_args, _ = mock_view_table.call_args
+                df_passed = call_args[0]
+                self.assertEqual(
+                    sorted(df_passed.columns.tolist()),
+                    sorted(["XR", "GROWTH"]),
+                )
+
+            # Combining xcat_labels with the legacy kwargs is rejected.
+            with self.assertRaises(ValueError):
+                sr.single_statistic_table(
+                    stat="kendall",
+                    rows=["xcat", "agg_sigs", "freq"],
+                    columns=["ret"],
+                    show_heatmap=True,
+                    xcat_labels={"CRY": "Carry score"},
+                    signal_name_dict={"CRY": "Carry"},
+                )
+
+        plt.close("all")
+        matplotlib.use(self.mpl_backend)
 
     def test_plot_single_statistic_heatmap(self):
         self.mpl_backend: str = matplotlib.get_backend()


### PR DESCRIPTION
## Summary

Three opt-in extensions to `SignalReturnRelations.single_statistic_table` for heatmap rendering. **Default behaviour is byte-identical to before this PR** — every change is gated behind a new kwarg or fires only when the caller leaves an existing kwarg at `None`. The returned DataFrame is unchanged in every case.

- **`collapse_constant_levels: bool = False`** — when True, row/column index levels whose values are constant across the table are stripped from the tick labels and auto-promoted into the corresponding axis label (joined by `" · "`) when the caller did not pass `xlabel`/`ylabel` (or `row_names`/`column_names`). A table that iterates over one signal, one aggregation, and several frequencies renders only the frequencies as y-ticks and places `"<signal> · <aggregation>"` on the y-axis label. Default `False` preserves the historical rendering (raw MultiIndex tuples as tick labels).
- **`xcat_labels: Optional[Dict[str, str]] = None`** — single rename dictionary covering both signal and return xcats. Internally split by membership in `self.sigs` / `self.rets` and routed through the existing `signal_name_dict` / `return_name_dict` machinery; unlisted xcats are kept verbatim so callers can't accidentally drop entries. Mutually exclusive with the legacy two dicts (raises if both supplied). Renamed values flow through to the auto axis label when `collapse_constant_levels=True`.
- **`axis_label_levels: Optional[List[str]] = None`** — list of level keys (`"xcat"`, `"ret"`, `"freq"`, `"agg_sigs"`) eligible for promotion into the auto axis label. Requires `collapse_constant_levels=True` (raises `ValueError` otherwise). Default `None` promotes every collapsed level. Passing `axis_label_levels=["xcat"]` drops aggregation/frequency suffixes from the auto label without putting them back on the ticks.

### Before / after (opt-in case)

Same call, same data — caller opts in to the new kwargs:

**Before** — caller passes `ylabel="Factor (feature) · aggregation · frequency"` because the y-tick labels would otherwise be opaque MultiIndex tuples like `("PFMONC_ZN", "last", "M")`.

**After** — drop the `ylabel` override; pass `collapse_constant_levels=True, axis_label_levels=["xcat"]`. Y-ticks become `M` / `Q`; y-axis label becomes `PFMONC_ZN` (or whatever the user passes via `xcat_labels`).

### Default-behaviour invariant

A reviewer flagged that the original version of this PR changed default rendering when callers had constant-valued levels and no explicit `xlabel`/`ylabel`. The `collapse_constant_levels=False` gate now removes that footgun: callers who don't touch the new kwargs get the same `view_table` inputs they did before.

## Test plan

- [x] `pytest tests/unit/signal/test_signal_return_relations.py` — all 20 tests pass (4 new, 1 updated). Includes an explicit assertion that the default path produces no auto y-label / no tick collapse, plus a `ValueError` assertion when `axis_label_levels` is passed without the gate.
- [x] Heatmaps re-rendered end-to-end via the Monetary Conditions Power Factor academy notebook; 20/20 code cells run cleanly with the new kwargs opted in.
- [x] Backward compatibility: callers who pass `xlabel`/`ylabel` explicitly continue to see those exact strings (auto-label only fires when the caller leaves the kwarg `None`); callers who omit all new kwargs see byte-identical rendering inputs to pre-PR.
- [ ] Reviewer sanity-check on docstring wording, the `xcat_labels` / legacy-dict mutual-exclusion behaviour, and the `axis_label_levels` requires-gate validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)