### PR TITLE
Bugfix: mismatched labels in timeline plots

### DIFF
--- a/macrosynergy/visuals/timelines.py
+++ b/macrosynergy/visuals/timelines.py
@@ -201,11 +201,8 @@ def timelines(
     )
 
     if cumsum:
-        df[val] = (
-            df.sort_values(["cid", "xcat", "real_date"])[["cid", "xcat", val]]
-            .groupby(["cid", "xcat"])
-            .cumsum()
-        )
+        df = df.sort_values(["cid", "xcat", "real_date"]).reset_index(drop=True)
+        df[val] = df.groupby(["cid", "xcat"], observed=True)[val].cumsum()
 
     cross_mean_series: Optional[str] = f"mean_{xcats[0]}" if cs_mean else None
     if cs_mean:


### PR DESCRIPTION
A reproducible example of the bug:

```
>>> import pandas as pd
>>> 
>>> # Two cross-sections built separately, then concatenated WITHOUT ignore_index.
>>> usd = pd.DataFrame({
...     "cid": "USD", "xcat": "XR",
...     "real_date": pd.date_range("2020-01-01", periods=4, freq="D"),
...     "value": [1.0, 1.0, 1.0, 1.0],     # cumsum should be 1, 2, 3, 4
... })
>>> eur = pd.DataFrame({
...     "cid": "EUR", "xcat": "XR",
...     "real_date": pd.date_range("2020-01-01", periods=4, freq="D"),
...     "value": [10.0, 10.0, 10.0, 10.0], # cumsum should be 10, 20, 30, 40
... })
>>> df = pd.concat([usd, eur])             # <-- no ignore_index=True
>>> 
>>> val = "value"
>>> df[val] = (
...     df.sort_values(["cid", "xcat", "real_date"])[["cid", "xcat", val]]
...       .groupby(["cid", "xcat"])
...       .cumsum()
... )
>>> print(df)
   cid xcat  real_date  value
0  USD   XR 2020-01-01   10.0
1  USD   XR 2020-01-02   20.0
2  USD   XR 2020-01-03   30.0
3  USD   XR 2020-01-04   40.0
0  EUR   XR 2020-01-01    1.0
1  EUR   XR 2020-01-02    2.0
2  EUR   XR 2020-01-03    3.0
3  EUR   XR 2020-01-04    4.0
>>> 
```
