### PR TITLE
test(perf): in-repo performance-testing framework (tests/perf) [1/4 split of #2695]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,3 +195,9 @@ coverage.xml
 # Visual studio
 .trunk/
 launch.json
+
+# perf framework: machine-specific result artifacts and large golden blobs
+tests/perf/results/*
+!tests/perf/results/.gitkeep
+tests/perf/golden/*.parquet
+!tests/perf/golden/index.json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ test = [
   "pytest-xdist>=3.3.1",
   "flake8>=4.0.1",
   "parameterized>=0.9.0",
+  "pytest-benchmark>=4.0",
   "linearmodels>=4.28",
 ]
 excel = ["openpyxl>=3.0.10"]
@@ -105,6 +106,7 @@ all = [
   "pytest-cov>3.0.0",
   "coverage>=6.0.0",
   "pytest-xdist>=3.3.1",
+  "pytest-benchmark>=4.0",
   "flake8>=4.0.1",
   "parameterized>=0.9.0",
   "pydata-sphinx-theme==0.14.4",
@@ -153,7 +155,8 @@ exclude = '''
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "-rEf -rP -n auto --durations=10 --cov=macrosynergy --verbose"
+addopts = "-rEf -rP -n auto --durations=10 --cov=macrosynergy --verbose -m 'not perf'"
+markers = ["perf: performance benchmark (deselected by default; run with -m perf)"]
 # testpaths = ['./tests/']
 
 [tool.coverage]

--- a/tests/perf/README.md
+++ b/tests/perf/README.md
@@ -1,0 +1,51 @@
+# Performance + parity testing framework
+
+Complements the main `tests/` suite for the T1–T5 optimization targets
+(see `prompts/TARGETS.md`, `prompts/QUEUE.md`, and the design spec in
+`docs/superpowers/specs/2026-06-30-macrosynergy-perf-framework-design.md`).
+
+## Two halves
+
+- **Parity / edge / API guards** — `tests/perf/test_parity_*.py` and additions in
+  `tests/unit/...`. Run in the **default** `pytest` gate. They must pass on every
+  `perf/<slug>` branch (encode current behaviour as the contract).
+- **Benchmarks** — `tests/perf/test_perf_*.py`, marked `@pytest.mark.perf`,
+  **deselected by default**. Measure speed (pytest-benchmark) and memory (`mem.py`).
+
+## Run the default gate (includes parity, excludes benchmarks)
+
+    pytest            # addopts already applies -m 'not perf'
+
+## Run the benchmarks
+
+Disable xdist and coverage (they skew/slow benchmarks):
+
+    pytest tests/perf -m perf --benchmark-only -n0 --no-cov \
+        --benchmark-json=tests/perf/results/bench_$(hostname).json
+
+Enable opt-in RSS memory sampling:
+
+    MACROSYN_PERF_RSS=1 pytest tests/perf -m perf -n0 --no-cov
+
+## Scale tiers
+
+`tests/perf/data.py::SCALE_TIERS` — `tiny` (~3k rows, parity/CI), `small` (~100k),
+`medium` (~1M), `large` (~6M, local deep-dive). Benchmarks default to `small`+`medium`.
+
+## Record before/after for QUEUE.md
+
+1. On clean `feature/performance`, capture a per-machine baseline:
+   `pytest tests/perf -m perf --benchmark-only -n0 --no-cov --benchmark-json=tests/perf/results/baseline_<host>.json`
+2. On the `perf/<slug>` branch, repeat into `results/<slug>_<host>.json`.
+3. `python tests/perf/record.py results/baseline_<host>.json results/<slug>_<host>.json`
+   → paste the markdown into the QUEUE item's before/after. The recorder prints a
+   `⚠ cross-machine — advisory only` banner if the two runs are from different hardware/OS.
+
+## Regenerate parity goldens (deliberate only)
+
+    python tests/perf/capture_parity.py --update   # then commit golden/index.json
+
+## Environment fingerprint
+
+Every benchmark JSON carries `machine_info.macrosynergy_env` (CPU/chip/RAM/OS/lib
+versions/git SHA/CI label) so results are never silently compared across machines.

--- a/tests/perf/__init__.py
+++ b/tests/perf/__init__.py
@@ -1,0 +1,4 @@
+"""In-repo performance + parity testing framework for the T1-T5 optimization targets.
+
+See docs/superpowers/specs/2026-06-30-macrosynergy-perf-framework-design.md.
+"""

--- a/tests/perf/capture_parity.py
+++ b/tests/perf/capture_parity.py
@@ -1,0 +1,70 @@
+"""Regenerate golden output snapshots from CURRENT package code.
+
+Run once on clean feature/performance (and deliberately with --update to refresh):
+    python tests/perf/capture_parity.py --update
+Each perf/<slug> branch re-runs the default gate, whose test_parity_*.py assert against these.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+
+# Allow running as a bare script (`python tests/perf/capture_parity.py`): ensure the
+# repo root is importable so `tests.perf.*` resolves without PYTHONPATH being set.
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+import pandas as pd  # noqa: E402
+
+from macrosynergy.management.utils import update_df, reduce_df, ticker_df_to_qdf  # noqa: E402
+from tests.perf.data import qdf_for_tier, wide_ticker_frame  # noqa: E402
+from tests.perf.parity import GOLDEN_DIR, save_golden  # noqa: E402
+
+
+def _build_goldens() -> dict:
+    """Return {name: (kind, DataFrame)} computed on current code at tiny scale."""
+    out = {}
+
+    # T3 reduce_df — input WITH exact full-row duplicates so the terminal drop_duplicates actually fires.
+    clean = qdf_for_tier("tiny")
+    dupd = pd.concat([clean, clean.iloc[:100]], ignore_index=True)
+    out["reduce_df_dedup_tiny"] = ("qdf", pd.DataFrame(reduce_df(dupd)))
+
+    # T1 update_df — df_add overlaps half the base keys with bumped values, so last-wins dedup fires.
+    base = qdf_for_tier("tiny")
+    overlap = base.iloc[: len(base) // 2].copy()
+    overlap["value"] = overlap["value"] + 100.0
+    out["update_df_lastwins_tiny"] = ("qdf", pd.DataFrame(update_df(base, overlap)))
+
+    # T2 ticker_df_to_qdf
+    out["ticker_df_to_qdf_tiny"] = ("qdf", pd.DataFrame(ticker_df_to_qdf(wide_ticker_frame(12, 60))))
+
+    return out
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--update", action="store_true", help="overwrite existing goldens")
+    args = parser.parse_args(argv)
+
+    index_path = GOLDEN_DIR / "index.json"
+    if index_path.exists() and not args.update:
+        print(f"Goldens already exist at {index_path}; pass --update to regenerate.")
+        return 1
+
+    index = {}
+    for name, (kind, df) in _build_goldens().items():
+        h = save_golden(name, df)
+        index[name] = {"kind": kind, "hash": h}
+        print(f"  captured {name}: {kind} sha256={h[:12]}…")
+
+    GOLDEN_DIR.mkdir(parents=True, exist_ok=True)
+    index_path.write_text(json.dumps(index, indent=2, sort_keys=True) + "\n")
+    print(f"Wrote {index_path} ({len(index)} goldens).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/perf/conftest.py
+++ b/tests/perf/conftest.py
@@ -1,0 +1,15 @@
+"""Perf-suite fixtures and the pytest-benchmark machine-info hook."""
+
+import pytest
+
+from tests.perf.env import environment_fingerprint
+
+
+@pytest.fixture(scope="session")
+def perf_env():
+    return environment_fingerprint()
+
+
+def pytest_benchmark_update_machine_info(config, machine_info):
+    # Stamp our richer fingerprint into pytest-benchmark's JSON for comparability.
+    machine_info["macrosynergy_env"] = environment_fingerprint()

--- a/tests/perf/data.py
+++ b/tests/perf/data.py
@@ -1,0 +1,137 @@
+"""Deterministic synthetic QuantamentalDataFrame builders at controlled scale.
+
+Built on macrosynergy.management.simulate.make_qdf (seeded, object-dtype) so benchmarks
+have a clear, reproducible target. Row count is approximate per tier; the seed pins values.
+"""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+import numpy as np
+import pandas as pd
+
+from macrosynergy.management.simulate import make_qdf
+from macrosynergy.management.types import QuantamentalDataFrame
+
+# Approximate total rows = n_cids * n_xcats * n_days (business days).
+SCALE_TIERS = {
+    "tiny": {"n_cids": 4, "n_xcats": 3, "n_days": 250},        # ~3k rows
+    "small": {"n_cids": 10, "n_xcats": 8, "n_days": 1300},     # ~104k rows
+    "medium": {"n_cids": 20, "n_xcats": 15, "n_days": 3500},   # ~1.05M rows
+    "large": {"n_cids": 40, "n_xcats": 30, "n_days": 5200},    # ~6.2M rows
+}
+
+
+def _cid_codes(n: int) -> List[str]:
+    # 3-char uppercase codes with no underscore (valid cid). AAA, AAB, ...
+    codes = []
+    i = 0
+    while len(codes) < n:
+        a, b, c = i // 676, (i // 26) % 26, i % 26
+        codes.append(chr(65 + a % 26) + chr(65 + b) + chr(65 + c))
+        i += 1
+    return codes
+
+
+def _xcat_codes(n: int) -> List[str]:
+    return [f"XCAT{j:03d}" for j in range(n)]
+
+
+def _days_to_latest(n_days: int, earliest: str = "2000-01-01") -> str:
+    # n_days business days from `earliest`; pad calendar days by ~7/5.
+    cal = int(n_days * 7 / 5) + 10
+    return (pd.Timestamp(earliest) + pd.Timedelta(days=cal)).strftime("%Y-%m-%d")
+
+
+def make_perf_qdf(
+    n_cids: int, n_xcats: int, n_days: int, *, categorical: bool = False, seed: int = 42
+) -> pd.DataFrame:
+    """Object-dtype QDF (or categorical) with `cid, xcat, real_date, value` columns."""
+    cids = _cid_codes(n_cids)
+    xcats = _xcat_codes(n_xcats)
+    latest = _days_to_latest(n_days)
+
+    df_cids = pd.DataFrame(index=cids, columns=["earliest", "latest", "mean_add", "sd_mult"])
+    for k, cid in enumerate(cids):
+        df_cids.loc[cid] = ["2000-01-01", latest, 0.0, 1.0 + (k % 3) * 0.5]
+
+    df_xcats = pd.DataFrame(
+        index=xcats,
+        columns=["earliest", "latest", "mean_add", "sd_mult", "ar_coef", "back_coef"],
+    )
+    for j, xc in enumerate(xcats):
+        df_xcats.loc[xc] = ["2000-01-01", latest, 0.0, 1.0, 0.5, 0.0]
+
+    df = make_qdf(df_cids, df_xcats, back_ar=0.0, seed=seed)
+    df = df[["cid", "xcat", "real_date", "value"]].reset_index(drop=True)
+    if categorical:
+        return QuantamentalDataFrame(df, categorical=True)
+    return df
+
+
+def qdf_for_tier(tier: str, *, categorical: bool = False, seed: int = 42) -> pd.DataFrame:
+    cfg = SCALE_TIERS[tier]
+    return make_perf_qdf(
+        cfg["n_cids"], cfg["n_xcats"], cfg["n_days"], categorical=categorical, seed=seed
+    )
+
+
+def wide_ticker_frame(n_tickers: int, n_days: int, *, seed: int = 42) -> pd.DataFrame:
+    """Wide frame: DatetimeIndex rows, one `cid_xcat` column per ticker (for ticker_df_to_qdf)."""
+    rng = np.random.default_rng(seed)
+    n_cids = max(1, int(np.ceil(np.sqrt(n_tickers))))
+    cids = _cid_codes(n_cids)
+    cols = []
+    for cid in cids:
+        for j in range(n_cids):
+            if len(cols) >= n_tickers:
+                break
+            cols.append(f"{cid}_XCAT{j:03d}")
+    cols = cols[:n_tickers]
+    idx = pd.bdate_range("2000-01-01", periods=n_days, name="real_date")
+    data = rng.standard_normal((n_days, len(cols)))
+    return pd.DataFrame(data, index=idx, columns=cols)
+
+
+def update_df_pieces(
+    tier: str, n_pieces: int, *, categorical: bool = False, seed: int = 42
+) -> Tuple[pd.DataFrame, List[pd.DataFrame]]:
+    """A base QDF plus `n_pieces` non-empty row-slices to feed update_df in a growing loop.
+
+    Splitting by rows (not by xcat) guarantees every piece is non-empty for any
+    ``1 <= n_pieces <= len(full)``, so callers can request more pieces than there are
+    categories without silently producing empty slices.
+    """
+    full = qdf_for_tier(tier, categorical=categorical, seed=seed)
+    xcats = list(pd.unique(full["xcat"]))
+    base = full[full["xcat"].isin(xcats[: max(1, len(xcats) // 2)])].reset_index(drop=True)
+    pieces = [
+        full.iloc[idx].reset_index(drop=True)
+        for idx in np.array_split(np.arange(len(full)), n_pieces)
+        if len(idx) > 0
+    ]
+    return base, pieces
+
+
+def srr_panel(
+    n_cids: int, n_dates: int, n_signals: int, n_returns: int, *, seed: int = 42
+) -> pd.DataFrame:
+    """QDF with `n_signals` signal xcats (SIGn) and `n_returns` return xcats (XRn)."""
+    cids = _cid_codes(n_cids)
+    latest = _days_to_latest(n_dates)
+    sig_xcats = [f"SIG{i:02d}" for i in range(n_signals)]
+    ret_xcats = [f"XR{i:02d}" for i in range(n_returns)]
+    xcats = sig_xcats + ret_xcats
+
+    df_cids = pd.DataFrame(index=cids, columns=["earliest", "latest", "mean_add", "sd_mult"])
+    for cid in cids:
+        df_cids.loc[cid] = ["2000-01-01", latest, 0.0, 1.0]
+    df_xcats = pd.DataFrame(
+        index=xcats,
+        columns=["earliest", "latest", "mean_add", "sd_mult", "ar_coef", "back_coef"],
+    )
+    for xc in xcats:
+        df_xcats.loc[xc] = ["2000-01-01", latest, 0.0, 1.0, 0.3, 0.4]
+    df = make_qdf(df_cids, df_xcats, back_ar=0.5, seed=seed)
+    return df[["cid", "xcat", "real_date", "value"]].reset_index(drop=True)

--- a/tests/perf/env.py
+++ b/tests/perf/env.py
@@ -1,0 +1,107 @@
+"""Environment fingerprint so perf results are never silently compared across machines."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import platform
+import socket
+import subprocess
+from datetime import datetime, timezone
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
+from typing import Optional
+
+
+def _cpu_brand() -> str:
+    # py-cpuinfo ships with pytest-benchmark; use it when available for a real brand string.
+    try:
+        import cpuinfo  # type: ignore
+
+        info = cpuinfo.get_cpu_info()
+        return info.get("brand_raw") or info.get("brand") or platform.processor() or "unknown"
+    except Exception:
+        return platform.processor() or platform.machine() or "unknown"
+
+
+def _cpu_count_physical() -> Optional[int]:
+    try:
+        import psutil  # type: ignore
+
+        return psutil.cpu_count(logical=False)
+    except Exception:
+        return None
+
+
+def _ram_total_gib() -> Optional[float]:
+    try:
+        import psutil  # type: ignore
+
+        return round(psutil.virtual_memory().total / (1024 ** 3), 2)
+    except Exception:
+        return None
+
+
+def _git_sha() -> Optional[str]:
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if out.returncode != 0:
+            return None
+        return out.stdout.strip() or None
+    except Exception:
+        return None
+
+
+def _ci_label() -> Optional[str]:
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        return f"github-actions:{os.environ.get('RUNNER_NAME', 'unknown')}"
+    if os.environ.get("CI"):
+        return "ci:unknown"
+    return None
+
+
+def _lib_versions() -> dict:
+    out = {}
+    for pkg in ["numpy", "pandas", "statsmodels", "scipy", "pyarrow", "macrosynergy"]:
+        try:
+            out[pkg] = _pkg_version(pkg)
+        except PackageNotFoundError:
+            out[pkg] = "not-installed"
+    return out
+
+
+def environment_fingerprint() -> dict:
+    """Capture CPU/chip, RAM, OS, Python, library versions, git SHA, and CI context."""
+    return {
+        "cpu_brand": _cpu_brand(),
+        "cpu_arch": platform.machine(),
+        "cpu_count_logical": os.cpu_count() or 0,
+        "cpu_count_physical": _cpu_count_physical(),
+        "ram_total_gib": _ram_total_gib(),
+        "os_system": platform.system(),
+        "os_release": platform.release(),
+        "python_version": platform.python_version(),
+        "lib_versions": _lib_versions(),
+        "git_sha": _git_sha(),
+        "ci": _ci_label(),
+        "hostname": socket.gethostname(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+_IDENTITY_KEYS = ("cpu_brand", "cpu_count_logical", "cpu_arch", "os_system")
+
+
+def fingerprint_hash(fp: dict) -> str:
+    """8-char hash of the hardware/OS identity subset (excludes timestamp, lib versions, git)."""
+    identity = {k: fp.get(k) for k in _IDENTITY_KEYS}
+    blob = json.dumps(identity, sort_keys=True).encode()
+    return hashlib.sha256(blob).hexdigest()[:8]
+
+
+def comparable(fp_a: dict, fp_b: dict) -> bool:
+    """True iff two fingerprints describe the same hardware/OS (benchmarks are comparable)."""
+    return all(fp_a.get(k) == fp_b.get(k) for k in _IDENTITY_KEYS)

--- a/tests/perf/golden/index.json
+++ b/tests/perf/golden/index.json
@@ -1,0 +1,14 @@
+{
+  "reduce_df_dedup_tiny": {
+    "hash": "ae5b3df5aed938c248d016005d50d90add4f4215a31ee2827388cc83dadb1bda",
+    "kind": "qdf"
+  },
+  "ticker_df_to_qdf_tiny": {
+    "hash": "0b594f9420f1bdd2f6e28fa25044a4388d4b6dea277a3d8ff1a7ca7135417e9c",
+    "kind": "qdf"
+  },
+  "update_df_lastwins_tiny": {
+    "hash": "159ddefa90344bb50ab3e058e5329e79807baa5f6907d961ba24b81b0310c109",
+    "kind": "qdf"
+  }
+}

--- a/tests/perf/mem.py
+++ b/tests/perf/mem.py
@@ -1,0 +1,76 @@
+"""Memory measurement: tracemalloc peak (default, deterministic) + opt-in psutil RSS."""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+import tracemalloc
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Iterator, Optional
+
+_MIB = 1024 ** 2
+
+
+@dataclass
+class MemResult:
+    wall_s: float = 0.0
+    tracemalloc_peak_mib: Optional[float] = None
+    rss_peak_mib: Optional[float] = None
+
+
+def _rss_now_mib() -> Optional[float]:
+    try:
+        import psutil  # type: ignore
+
+        return psutil.Process(os.getpid()).memory_info().rss / _MIB
+    except Exception:
+        return None
+
+
+@contextmanager
+def measure(
+    *,
+    track_rss: Optional[bool] = None,
+    track_tracemalloc: bool = True,
+    rss_interval_s: float = 0.02,
+) -> Iterator[MemResult]:
+    if track_rss is None:
+        track_rss = os.environ.get("MACROSYN_PERF_RSS", "0") == "1"
+
+    result = MemResult()
+    stop = threading.Event()
+    peak_holder = {"rss": None}
+    baseline_rss = _rss_now_mib() if track_rss else None
+
+    def _sampler():
+        while not stop.is_set():
+            cur = _rss_now_mib()
+            if cur is not None:
+                prev = peak_holder["rss"]
+                peak_holder["rss"] = cur if prev is None else max(prev, cur)
+            time.sleep(rss_interval_s)
+
+    sampler = None
+    if track_rss and baseline_rss is not None:
+        sampler = threading.Thread(target=_sampler, daemon=True)
+        sampler.start()
+
+    if track_tracemalloc:
+        tracemalloc.start()
+
+    t0 = time.perf_counter()
+    try:
+        yield result
+    finally:
+        result.wall_s = time.perf_counter() - t0
+        if track_tracemalloc:
+            _, peak = tracemalloc.get_traced_memory()
+            tracemalloc.stop()
+            result.tracemalloc_peak_mib = peak / _MIB
+        if sampler is not None:
+            stop.set()
+            sampler.join(timeout=1.0)
+            if peak_holder["rss"] is not None and baseline_rss is not None:
+                result.rss_peak_mib = max(0.0, peak_holder["rss"] - baseline_rss)

--- a/tests/perf/parity.py
+++ b/tests/perf/parity.py
@@ -1,0 +1,54 @@
+"""Parity helpers: byte-identical comparison for QDFs, frames, and categoricals + golden I/O."""
+
+from __future__ import annotations
+
+import hashlib
+import pathlib
+
+import numpy as np
+import pandas as pd
+
+GOLDEN_DIR = pathlib.Path(__file__).parent / "golden"
+_SORT = ["cid", "xcat", "real_date"]
+
+
+def assert_frame_parity(actual: pd.DataFrame, expected: pd.DataFrame) -> None:
+    assert list(actual.columns) == list(expected.columns), (
+        f"columns differ: {list(actual.columns)} != {list(expected.columns)}"
+    )
+    assert actual.shape == expected.shape, f"shape {actual.shape} != {expected.shape}"
+    for col in expected.columns:
+        a, e = actual[col], expected[col]
+        assert str(a.dtype) == str(e.dtype), f"dtype for {col}: {a.dtype} != {e.dtype}"
+        if pd.api.types.is_numeric_dtype(e):
+            assert np.allclose(a.to_numpy(), e.to_numpy(), equal_nan=True), f"values differ in {col}"
+        else:
+            assert a.reset_index(drop=True).equals(e.reset_index(drop=True)), f"values differ in {col}"
+
+
+def assert_qdf_equal(actual: pd.DataFrame, expected: pd.DataFrame) -> None:
+    a = pd.DataFrame(actual).sort_values(_SORT).reset_index(drop=True)
+    e = pd.DataFrame(expected).sort_values(_SORT).reset_index(drop=True)
+    assert_frame_parity(a, e)
+
+
+def assert_categorical_equal(actual: pd.Categorical, expected: pd.Categorical) -> None:
+    assert list(actual.categories) == list(expected.categories), "category set/order differs"
+    assert actual.ordered == expected.ordered, "ordered flag differs"
+    assert np.array_equal(actual.codes, expected.codes), "codes differ"
+
+
+def save_golden(name: str, df: pd.DataFrame) -> str:
+    GOLDEN_DIR.mkdir(parents=True, exist_ok=True)
+    path = GOLDEN_DIR / f"{name}.parquet"
+    df.to_parquet(path)
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def load_golden(name: str) -> pd.DataFrame:
+    path = GOLDEN_DIR / f"{name}.parquet"
+    if not path.exists():
+        raise FileNotFoundError(
+            f"Golden not found: {path}. Run `python tests/perf/capture_parity.py --update` first."
+        )
+    return pd.read_parquet(path)

--- a/tests/perf/record.py
+++ b/tests/perf/record.py
@@ -1,0 +1,63 @@
+"""Diff two pytest-benchmark JSON files into a QUEUE-ready markdown table, with env guard."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+from tests.perf.env import comparable
+
+
+def load_benchmark(path: str) -> dict:
+    with open(path) as fh:
+        return json.load(fh)
+
+
+def extract_env(bench_json: dict) -> dict:
+    return bench_json.get("machine_info", {}).get("macrosynergy_env", {})
+
+
+def _index_by_name(bench_json: dict) -> dict:
+    return {b["name"]: b["stats"]["mean"] for b in bench_json.get("benchmarks", [])}
+
+
+def render_report(baseline: dict, branch: dict) -> str:
+    env_a, env_b = extract_env(baseline), extract_env(branch)
+    is_comparable = comparable(env_a, env_b)
+    lines = []
+    if not is_comparable:
+        lines.append("> ⚠ **cross-machine — advisory only** "
+                     f"(baseline `{env_a.get('cpu_brand')}` vs branch `{env_b.get('cpu_brand')}`)")
+        lines.append("")
+    base_idx, br_idx = _index_by_name(baseline), _index_by_name(branch)
+    if is_comparable:
+        lines.append("| benchmark | baseline (s) | branch (s) | change |")
+        lines.append("|---|--:|--:|--:|")
+    else:
+        lines.append("| benchmark | baseline (s) | branch (s) |")
+        lines.append("|---|--:|--:|")
+    for name in sorted(set(base_idx) | set(br_idx)):
+        b0, b1 = base_idx.get(name), br_idx.get(name)
+        b0s = f"{b0:.4f}" if b0 is not None else "—"
+        b1s = f"{b1:.4f}" if b1 is not None else "—"
+        if is_comparable and b0 is not None and b1 is not None and b0 != 0:
+            pct = (1 - b1 / b0) * 100
+            lines.append(f"| {name} | {b0s} | {b1s} | {pct:.0f}% |")
+        elif is_comparable:
+            lines.append(f"| {name} | {b0s} | {b1s} | — |")
+        else:
+            lines.append(f"| {name} | {b0s} | {b1s} |")
+    return "\n".join(lines)
+
+
+def main(argv=None) -> int:
+    argv = argv if argv is not None else sys.argv[1:]
+    if len(argv) != 2:
+        print("usage: python tests/perf/record.py <baseline.json> <branch.json>")
+        return 2
+    print(render_report(load_benchmark(argv[0]), load_benchmark(argv[1])))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/perf/test_conftest_hook.py
+++ b/tests/perf/test_conftest_hook.py
@@ -1,0 +1,3 @@
+def test_perf_env_fixture(perf_env):
+    assert "cpu_brand" in perf_env
+    assert "lib_versions" in perf_env

--- a/tests/perf/test_data.py
+++ b/tests/perf/test_data.py
@@ -1,0 +1,69 @@
+import pandas as pd
+
+from macrosynergy.management.types import QuantamentalDataFrame
+from tests.perf.data import (
+    SCALE_TIERS, make_perf_qdf, qdf_for_tier, wide_ticker_frame,
+    update_df_pieces, srr_panel,
+)
+
+
+def test_scale_tiers_defined():
+    assert set(SCALE_TIERS) == {"tiny", "small", "medium", "large"}
+    for tier in SCALE_TIERS.values():
+        assert {"n_cids", "n_xcats", "n_days"} <= set(tier)
+
+
+def test_make_perf_qdf_columns_and_dtype():
+    df = make_perf_qdf(3, 4, 50)
+    assert list(df.columns) == ["cid", "xcat", "real_date", "value"]
+    assert df["cid"].dtype == object  # object by default (notebook's slow case)
+    assert df["cid"].nunique() == 3 and df["xcat"].nunique() == 4
+
+
+def test_make_perf_qdf_is_deterministic():
+    a = make_perf_qdf(3, 4, 50, seed=7)
+    b = make_perf_qdf(3, 4, 50, seed=7)
+    pd.testing.assert_frame_equal(a, b)
+
+
+def test_make_perf_qdf_categorical_variant():
+    df = make_perf_qdf(3, 4, 50, categorical=True)
+    assert isinstance(df, QuantamentalDataFrame)
+    assert df["cid"].dtype.name == "category"
+
+
+def test_qdf_for_tier_tiny_is_small_enough():
+    df = qdf_for_tier("tiny")
+    assert len(df) < 50_000
+
+
+def test_wide_ticker_frame_shape():
+    w = wide_ticker_frame(n_tickers=10, n_days=30)
+    assert w.shape[1] == 10
+    assert all("_" in str(c) for c in w.columns)
+    assert isinstance(w.index, pd.DatetimeIndex)
+
+
+def test_update_df_pieces_returns_base_and_list():
+    base, pieces = update_df_pieces("tiny", n_pieces=4)
+    assert isinstance(base, pd.DataFrame) and len(pieces) == 4
+    assert all(set(["cid", "xcat", "real_date", "value"]) <= set(p.columns) for p in pieces)
+    assert all(len(p) > 0 for p in pieces)
+
+
+def test_update_df_pieces_more_pieces_than_xcats_are_nonempty():
+    base, pieces = update_df_pieces("tiny", n_pieces=10)  # tiny has 3 xcats
+    assert len(pieces) == 10
+    assert all(len(p) > 0 for p in pieces)
+
+
+def test_scale_tiers_row_count_ordering():
+    def _rows(t):
+        c = SCALE_TIERS[t]
+        return c["n_cids"] * c["n_xcats"] * c["n_days"]
+    assert _rows("tiny") < _rows("small") < _rows("medium") < _rows("large")
+
+
+def test_srr_panel_has_signal_and_return_xcats():
+    df = srr_panel(n_cids=4, n_dates=200, n_signals=2, n_returns=3)
+    assert df["xcat"].nunique() == 5

--- a/tests/perf/test_env.py
+++ b/tests/perf/test_env.py
@@ -1,0 +1,32 @@
+from tests.perf.env import environment_fingerprint, fingerprint_hash, comparable
+
+
+def test_fingerprint_has_required_keys():
+    fp = environment_fingerprint()
+    for key in [
+        "cpu_brand", "cpu_arch", "cpu_count_logical", "os_system",
+        "os_release", "python_version", "lib_versions", "hostname", "timestamp",
+    ]:
+        assert key in fp, f"missing key: {key}"
+    assert {"numpy", "pandas", "statsmodels", "scipy", "pyarrow", "macrosynergy"} <= set(
+        fp["lib_versions"]
+    )
+
+
+def test_fingerprint_hash_is_stable_and_short():
+    fp = environment_fingerprint()
+    h1 = fingerprint_hash(fp)
+    h2 = fingerprint_hash(environment_fingerprint())
+    assert h1 == h2  # same machine -> same hash
+    assert len(h1) == 8 and all(c in "0123456789abcdef" for c in h1)
+
+
+def test_comparable_true_for_same_machine():
+    assert comparable(environment_fingerprint(), environment_fingerprint())
+
+
+def test_comparable_false_when_cpu_differs():
+    a = environment_fingerprint()
+    b = dict(a)
+    b["cpu_brand"] = a["cpu_brand"] + " (other)"
+    assert not comparable(a, b)

--- a/tests/perf/test_mem.py
+++ b/tests/perf/test_mem.py
@@ -1,0 +1,22 @@
+import numpy as np
+from tests.perf.mem import measure, MemResult
+
+
+def test_measure_records_wall_and_tracemalloc():
+    with measure() as r:
+        _alloc = [0] * 1_000_000  # noqa: F841
+    assert isinstance(r, MemResult)
+    assert r.wall_s >= 0.0
+    assert r.tracemalloc_peak_mib is not None and r.tracemalloc_peak_mib > 0
+
+
+def test_measure_can_disable_tracemalloc():
+    with measure(track_tracemalloc=False) as r:
+        _ = np.zeros(1000)
+    assert r.tracemalloc_peak_mib is None
+
+
+def test_measure_rss_off_by_default():
+    with measure() as r:
+        pass
+    assert r.rss_peak_mib is None  # opt-in only

--- a/tests/perf/test_parity_helpers.py
+++ b/tests/perf/test_parity_helpers.py
@@ -1,0 +1,44 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from tests.perf.parity import (
+    assert_frame_parity, assert_qdf_equal, assert_categorical_equal,
+)
+
+
+def test_frame_parity_passes_for_equal_with_nan():
+    a = pd.DataFrame({"x": [1.0, np.nan], "s": ["p", "q"]})
+    b = a.copy()
+    assert_frame_parity(a, b)  # no raise
+
+
+def test_frame_parity_fails_on_value_diff():
+    a = pd.DataFrame({"x": [1.0, 2.0]})
+    b = pd.DataFrame({"x": [1.0, 2.5]})
+    with pytest.raises(AssertionError):
+        assert_frame_parity(a, b)
+
+
+def test_qdf_equal_ignores_row_order():
+    a = pd.DataFrame({"cid": ["A", "B"], "xcat": ["X", "Y"],
+                      "real_date": pd.to_datetime(["2020-01-01", "2020-01-02"]),
+                      "value": [1.0, 2.0]})
+    b = a.iloc[::-1].reset_index(drop=True)
+    assert_qdf_equal(a, b)
+
+
+def test_categorical_equal_detects_order_diff():
+    a = pd.Categorical(["x_a", "y_b"], categories=["x_a", "y_b"], ordered=True)
+    b = pd.Categorical(["x_a", "y_b"], categories=["y_b", "x_a"], ordered=True)
+    with pytest.raises(AssertionError):
+        assert_categorical_equal(a, b)
+
+
+def test_save_and_load_golden_roundtrip(tmp_path, monkeypatch):
+    import tests.perf.parity as parity
+    monkeypatch.setattr(parity, "GOLDEN_DIR", tmp_path)
+    df = pd.DataFrame({"a": [1, 2, 3]})
+    h = parity.save_golden("roundtrip", df)
+    assert isinstance(h, str) and len(h) == 64
+    pd.testing.assert_frame_equal(parity.load_golden("roundtrip"), df)

--- a/tests/perf/test_parity_qdf_ticker_series.py
+++ b/tests/perf/test_parity_qdf_ticker_series.py
@@ -1,0 +1,39 @@
+"""Output-parity guard for the T2c targets (runs in the default gate; not marked perf)."""
+
+import pandas as pd
+
+from macrosynergy.management.types import QuantamentalDataFrame
+from macrosynergy.management.types.qdf.methods import _get_tickers_series
+from tests.perf.data import qdf_for_tier
+from tests.perf.parity import assert_categorical_equal
+
+
+def test_get_tickers_series_categorical_contract():
+    qdf = qdf_for_tier("tiny", categorical=True)
+    series = _get_tickers_series(qdf)
+    # categories may be ordered by first appearance; rebuild the same way the function does
+    labels = [f"{c}_{x}" for c, x in zip(
+        qdf["cid"].cat.categories[qdf["cid"].cat.codes],
+        qdf["xcat"].cat.categories[qdf["xcat"].cat.codes],
+    )]
+    cats = pd.unique(pd.Series(labels))
+    expected = pd.Categorical(labels, categories=cats, ordered=True)
+    assert_categorical_equal(pd.Categorical(series), expected)
+
+
+def test_add_ticker_column_parity_object_vs_categorical():
+    obj = qdf_for_tier("tiny", categorical=False)
+    cat = QuantamentalDataFrame(obj.copy(), categorical=True)
+    out_cat = cat.add_ticker_column()
+    tickers_cat = [str(t) for t in out_cat["ticker"]]
+    tickers_obj = [f"{c}_{x}" for c, x in zip(obj["cid"], obj["xcat"])]
+    assert sorted(tickers_cat) == sorted(tickers_obj)
+
+
+def test_reduce_df_by_ticker_parity():
+    cat = qdf_for_tier("tiny", categorical=True)
+    tickers = sorted({f"{c}_{x}" for c, x in zip(
+        cat["cid"].astype(str), cat["xcat"].astype(str))})[:5]
+    out = cat.reduce_df_by_ticker(tickers=tickers)
+    got = sorted({f"{c}_{x}" for c, x in zip(out["cid"].astype(str), out["xcat"].astype(str))})
+    assert got == sorted(tickers)

--- a/tests/perf/test_parity_reduce_df.py
+++ b/tests/perf/test_parity_reduce_df.py
@@ -1,0 +1,23 @@
+"""Output-parity guard for T3 reduce_df (default gate)."""
+
+import pandas as pd
+
+from macrosynergy.management.utils import reduce_df
+from tests.perf.data import qdf_for_tier
+from tests.perf.parity import assert_qdf_equal, load_golden
+
+
+def test_reduce_df_dedup_matches_golden():
+    clean = qdf_for_tier("tiny")
+    dupd = pd.concat([clean, clean.iloc[:100]], ignore_index=True)
+    out = reduce_df(dupd)
+    # dedup must remove the 100 exact-duplicate rows
+    assert len(out) == len(clean)
+    assert_qdf_equal(pd.DataFrame(out), load_golden("reduce_df_dedup_tiny"))
+
+
+def test_reduce_df_no_spurious_row_drop_on_clean_panel():
+    qdf = qdf_for_tier("tiny")
+    out = reduce_df(qdf)
+    # clean panel has no full-row duplicates -> reduce_df must not drop rows
+    assert len(out) == len(qdf.drop_duplicates())

--- a/tests/perf/test_parity_ticker_split.py
+++ b/tests/perf/test_parity_ticker_split.py
@@ -1,0 +1,17 @@
+"""Output-parity guard for T2 split_ticker / ticker_df_to_qdf (default gate)."""
+
+import pandas as pd
+
+from macrosynergy.management.utils import ticker_df_to_qdf
+from tests.perf.data import wide_ticker_frame
+from tests.perf.parity import assert_qdf_equal, load_golden
+
+
+def test_ticker_df_to_qdf_matches_golden():
+    out = ticker_df_to_qdf(wide_ticker_frame(12, 60))
+    assert_qdf_equal(pd.DataFrame(out), load_golden("ticker_df_to_qdf_tiny"))
+
+
+def test_ticker_df_to_qdf_columns():
+    out = ticker_df_to_qdf(wide_ticker_frame(6, 20))
+    assert list(pd.DataFrame(out).columns) == ["real_date", "cid", "xcat", "value"]

--- a/tests/perf/test_parity_update_df.py
+++ b/tests/perf/test_parity_update_df.py
@@ -1,0 +1,32 @@
+"""Output-parity guard for T1 update_df (default gate)."""
+
+import pandas as pd
+
+from macrosynergy.management.utils import update_df
+from tests.perf.data import qdf_for_tier, update_df_pieces
+from tests.perf.parity import assert_qdf_equal, load_golden
+
+
+def test_update_df_lastwins_matches_golden():
+    base = qdf_for_tier("tiny")
+    overlap = base.iloc[: len(base) // 2].copy()
+    overlap["value"] = overlap["value"] + 100.0
+    out = update_df(base, overlap)
+    assert_qdf_equal(pd.DataFrame(out), load_golden("update_df_lastwins_tiny"))
+
+
+def test_update_df_invariants_last_wins_and_sorted():
+    base, pieces = update_df_pieces("tiny", n_pieces=2)
+    out = update_df(base, pieces[0])
+    # no duplicate (cid, xcat, real_date) keys
+    assert not pd.DataFrame(out).duplicated(subset=["real_date", "xcat", "cid"]).any()
+    # sorted ascending by cid, xcat, real_date (IDX_COLS_SORT_ORDER)
+    s = pd.DataFrame(out)[["cid", "xcat", "real_date"]].reset_index(drop=True)
+    assert s.equals(s.sort_values(["cid", "xcat", "real_date"]).reset_index(drop=True))
+
+
+def test_update_df_does_not_mutate_input():
+    base, pieces = update_df_pieces("tiny", n_pieces=2)
+    snapshot = base.copy(deep=True)
+    update_df(base, pieces[0])
+    pd.testing.assert_frame_equal(base, snapshot)

--- a/tests/perf/test_perf_qdf_ticker_series.py
+++ b/tests/perf/test_perf_qdf_ticker_series.py
@@ -1,0 +1,43 @@
+"""T2c benchmarks: _get_tickers_series / add_ticker_column / reduce_df_by_ticker.
+
+Run: pytest tests/perf/test_perf_qdf_ticker_series.py -m perf --benchmark-only -n0 --no-cov
+"""
+
+import json
+
+import pytest
+
+from macrosynergy.management.types import QuantamentalDataFrame
+from macrosynergy.management.types.qdf.methods import _get_tickers_series
+from tests.perf.data import qdf_for_tier
+from tests.perf.mem import measure
+
+TIERS = ["small", "medium"]
+
+
+@pytest.mark.perf
+@pytest.mark.parametrize("tier", TIERS)
+@pytest.mark.parametrize("categorical", [True, False], ids=["cat", "obj"])
+def test_bench_get_tickers_series(benchmark, tier, categorical):
+    qdf = qdf_for_tier(tier, categorical=categorical)
+    benchmark(_get_tickers_series, qdf)
+
+
+@pytest.mark.perf
+@pytest.mark.parametrize("tier", TIERS)
+def test_bench_add_ticker_column(benchmark, tier):
+    qdf = qdf_for_tier(tier, categorical=True)
+    benchmark(lambda d: QuantamentalDataFrame(d.copy(), categorical=True).add_ticker_column(), qdf)
+
+
+@pytest.mark.perf
+@pytest.mark.parametrize("tier", TIERS)
+def test_mem_get_tickers_series(tier, perf_env, tmp_path):
+    qdf = qdf_for_tier(tier, categorical=True)
+    with measure() as r:
+        _get_tickers_series(qdf)
+    out = {"target": "get_tickers_series", "tier": tier,
+           "wall_s": r.wall_s, "tracemalloc_peak_mib": r.tracemalloc_peak_mib,
+           "rss_peak_mib": r.rss_peak_mib, "env": perf_env}
+    (tmp_path / "mem.json").write_text(json.dumps(out))
+    assert r.wall_s >= 0

--- a/tests/perf/test_perf_reduce_df.py
+++ b/tests/perf/test_perf_reduce_df.py
@@ -1,0 +1,27 @@
+"""T3 benchmarks: reduce_df on object vs categorical QDFs.
+
+Run: pytest tests/perf/test_perf_reduce_df.py -m perf --benchmark-only -n0 --no-cov
+"""
+
+import pytest
+
+from macrosynergy.management.utils import reduce_df
+from tests.perf.data import qdf_for_tier
+
+TIERS = ["small", "medium"]
+
+
+@pytest.mark.perf
+@pytest.mark.parametrize("tier", TIERS)
+@pytest.mark.parametrize("categorical", [True, False], ids=["cat", "obj"])
+def test_bench_reduce_df_full(benchmark, tier, categorical):
+    qdf = qdf_for_tier(tier, categorical=categorical)
+    benchmark(reduce_df, qdf)
+
+
+@pytest.mark.perf
+@pytest.mark.parametrize("tier", TIERS)
+def test_bench_reduce_df_filtered(benchmark, tier):
+    qdf = qdf_for_tier(tier)
+    cids = sorted(qdf["cid"].unique())[:3]
+    benchmark(lambda d: reduce_df(d, cids=cids), qdf)

--- a/tests/perf/test_perf_srr_mixedlm.py
+++ b/tests/perf/test_perf_srr_mixedlm.py
@@ -1,0 +1,37 @@
+"""T4 benchmarks: SignalReturnRelations MixedLM panel test (the dominant SRR cost).
+
+Run: pytest tests/perf/test_perf_srr_mixedlm.py -m perf --benchmark-only -n0 --no-cov
+"""
+
+import pytest
+
+from macrosynergy.signal.signal_return_relations import SignalReturnRelations
+from tests.perf.data import srr_panel
+
+
+def _build_srr(n_signals, n_returns):
+    df = srr_panel(n_cids=6, n_dates=600, n_signals=n_signals, n_returns=n_returns)
+    return SignalReturnRelations(
+        df,
+        rets=[f"XR{i:02d}" for i in range(n_returns)],
+        sigs=[f"SIG{i:02d}" for i in range(n_signals)],
+        cids=sorted(df["cid"].unique()),
+        freqs=["M"],
+        ms_panel_test=True,
+    )
+
+
+@pytest.mark.perf
+@pytest.mark.parametrize("n_signals,n_returns", [(1, 1), (2, 3)])
+def test_bench_srr_single_statistic_table(benchmark, n_signals, n_returns):
+    # NOTE: benchmark the MixedLM panel-test path (map_pval), NOT stat="accuracy".
+    # accuracy never calls map_pval, so it measured a dead path (the Q5 trap); the
+    # per-fit MixedLM cost is what T4b optimizes. `type="panel"` is required for the
+    # map_pval branch (calculate_single_stat: stat=="map_pval" and self.ms_panel_test).
+    srr = _build_srr(n_signals, n_returns)
+    benchmark(
+        srr.single_statistic_table,
+        stat="map_pval",
+        type="panel",
+        show_heatmap=False,
+    )

--- a/tests/perf/test_perf_ticker_split.py
+++ b/tests/perf/test_perf_ticker_split.py
@@ -1,0 +1,37 @@
+"""T2 benchmarks: split_ticker / get_cid / get_xcat / ticker_df_to_qdf.
+
+Run: pytest tests/perf/test_perf_ticker_split.py -m perf --benchmark-only -n0 --no-cov
+"""
+
+import numpy as np
+import pytest
+
+from macrosynergy.management.utils import ticker_df_to_qdf
+from macrosynergy.management.utils.core import get_cid, get_xcat
+from tests.perf.data import wide_ticker_frame
+
+
+def _ticker_list(n_unique, repeats):
+    base = [f"C{i:03d}_XCAT{i % 10}" for i in range(n_unique)]
+    return list(np.repeat(base, repeats))
+
+
+@pytest.mark.perf
+@pytest.mark.parametrize("n_unique,repeats", [(2000, 50), (5000, 200)])
+def test_bench_get_cid_large_list(benchmark, n_unique, repeats):
+    tickers = _ticker_list(n_unique, repeats)
+    benchmark(get_cid, tickers)
+
+
+@pytest.mark.perf
+@pytest.mark.parametrize("n_unique,repeats", [(2000, 50), (5000, 200)])
+def test_bench_get_xcat_large_list(benchmark, n_unique, repeats):
+    tickers = _ticker_list(n_unique, repeats)
+    benchmark(get_xcat, tickers)
+
+
+@pytest.mark.perf
+@pytest.mark.parametrize("n_tickers,n_days", [(500, 1300), (2000, 2600)])
+def test_bench_ticker_df_to_qdf(benchmark, n_tickers, n_days):
+    wide = wide_ticker_frame(n_tickers, n_days)
+    benchmark(ticker_df_to_qdf, wide)

--- a/tests/perf/test_perf_update_df.py
+++ b/tests/perf/test_perf_update_df.py
@@ -1,0 +1,33 @@
+"""T1 benchmarks: update_df in a growing loop + single update_tickers.
+
+Run: pytest tests/perf/test_perf_update_df.py -m perf --benchmark-only -n0 --no-cov
+"""
+
+import pytest
+
+from macrosynergy.management.utils import update_df, update_tickers
+from tests.perf.data import update_df_pieces
+
+TIERS = ["small", "medium"]
+
+
+def _growing_loop(base, pieces):
+    acc = base
+    for p in pieces:
+        acc = update_df(acc, p)
+    return acc
+
+
+@pytest.mark.perf
+@pytest.mark.parametrize("tier", TIERS)
+@pytest.mark.parametrize("categorical", [True, False], ids=["cat", "obj"])
+def test_bench_update_df_growing_loop(benchmark, tier, categorical):
+    base, pieces = update_df_pieces(tier, n_pieces=5, categorical=categorical)
+    benchmark(_growing_loop, base, pieces)
+
+
+@pytest.mark.perf
+@pytest.mark.parametrize("tier", TIERS)
+def test_bench_update_tickers(benchmark, tier):
+    base, pieces = update_df_pieces(tier, n_pieces=2)
+    benchmark(update_tickers, base, pieces[0])

--- a/tests/perf/test_record.py
+++ b/tests/perf/test_record.py
@@ -1,0 +1,27 @@
+from tests.perf.record import render_report, extract_env
+
+
+def _bench(env, name="bench_x", mean=1.0):
+    return {
+        "machine_info": {"macrosynergy_env": env},
+        "benchmarks": [{"name": name, "stats": {"mean": mean, "min": mean, "max": mean}}],
+    }
+
+
+SAME = {"cpu_brand": "TestCPU", "cpu_count_logical": 8, "cpu_arch": "x86_64", "os_system": "Linux"}
+OTHER = {**SAME, "cpu_brand": "OtherCPU"}
+
+
+def test_extract_env():
+    assert extract_env(_bench(SAME)) == SAME
+
+
+def test_same_machine_shows_verdict():
+    report = render_report(_bench(SAME, mean=2.0), _bench(SAME, mean=1.0))
+    assert "advisory only" not in report
+    assert "50%" in report  # ~50% faster shown in the verdict column
+
+
+def test_cross_machine_shows_banner():
+    report = render_report(_bench(SAME, mean=2.0), _bench(OTHER, mean=1.0))
+    assert "advisory only" in report


### PR DESCRIPTION
## Summary

This is **part 1 of 4** splitting #2695 (kept open for reference on `feature/performance`) into self-contained PRs. It adds the in-repo **performance / parity testing framework** under `tests/perf/` — a standalone unit that stands on its own against `develop`.

The three companion PRs are:
1. **This PR** — the `tests/perf/` framework (+ `.gitignore`/`pyproject.toml`)
2. Enhanced unit tests (`tests/unit/`)
3. `Basket` categorical-QDF bug fix (`macrosynergy/panel/basket.py`) + its pinning test
4. The QDF/panel hot-path performance enhancements (`methods.py`, `core.py`, `df_utils.py`)

## What's here

- **Deterministic synthetic QDF builders** at controlled scale — `data.py`
- **Byte-identical parity helpers** + golden capture/load — `parity.py`, `capture_parity.py`
- **pytest-benchmark wiring**: a `perf` marker deselected by default, a machine-info fingerprint hook, memory probes, and a cross-machine benchmark recorder — `conftest.py`, `env.py`, `mem.py`, `record.py`
- **Parity guards + benchmarks** for the hot paths (ticker split, `reduce_df`, `update_df`, QDF ticker series) and the SRR MixedLM panel test

## Notes for reviewers

- Goldens (`.parquet`) are **not committed** — regenerate locally with `python tests/perf/capture_parity.py --update`; `golden/index.json` pins their hashes. Verified locally: freshly captured hashes match the committed index (i.e. current `develop` output is already byte-identical to the optimized branch).
- The `perf` marker is **deselected by default** (`-m 'not perf'`), so normal test runs are unaffected. Repo CI runs only `tests/unit/`, so this framework is opt-in and does not change CI time.
- Local verification: `36 passed` (parity + helpers), `28 passed` (benchmarks, `-m perf`).
- The SRR *source* optimization and internal planning docs from #2695 intentionally stay on `feature/performance`; only the SRR **benchmark** (which runs against the existing `map_pval`) is included here.

cc @lsimonsen @Magnus167

🤖 Generated with [Claude Code](https://claude.com/claude-code)