### PR TITLE
Feature: edge/API coverage for QDF & panel hot-path helpers [2/4 split of #2695]

### DIFF
--- a/tests/unit/management/test_qdf.py
+++ b/tests/unit/management/test_qdf.py
@@ -1,10 +1,14 @@
+import inspect
 import unittest
+import unittest as _unittest
 import numpy as np
 import pandas as pd
+import pandas as _pd
 import random
 from typing import List
 import warnings
 from macrosynergy.management.types import QuantamentalDataFrame
+from macrosynergy.management.types import QuantamentalDataFrame as _QDF
 from macrosynergy.compat import PD_2_0_OR_LATER
 from macrosynergy.management.constants import JPMAQS_METRICS
 from macrosynergy.management.utils import (
@@ -12,6 +16,7 @@ from macrosynergy.management.utils import (
     get_xcat,
     qdf_to_ticker_df,
 )
+from macrosynergy.management.utils import reduce_df as _reduce_df
 from macrosynergy.management.types.qdf.methods import (
     get_col_sort_order,
     change_column_format,
@@ -32,6 +37,9 @@ from macrosynergy.management.types.qdf.methods import (
     qdf_from_timeseries,
     create_empty_categorical_qdf,
     concat_qdfs,
+)
+from macrosynergy.management.types.qdf.methods import (
+    _get_tickers_series as _gts,
 )
 
 
@@ -1905,6 +1913,91 @@ class TestQDFInitializationMethods(unittest.TestCase):
         expc_df = qdf_to_string_index(expc_df)
 
         self.assertTrue(qdf.equals(expc_df))
+
+
+class TestGetTickersSeriesEdge(_unittest.TestCase):
+    def _qdf(self, categorical):
+        df = _pd.DataFrame({
+            "cid": ["AUD", "AUD", "GBP"],
+            "xcat": ["XR", "INFL", "XR"],
+            "real_date": _pd.to_datetime(["2020-01-01", "2020-01-02", "2020-01-01"]),
+            "value": [1.0, 2.0, 3.0],
+        })
+        return _QDF(df, categorical=categorical)
+
+    def test_object_branch_returns_series(self):
+        out = _gts(self._qdf(False))
+        self.assertEqual(list(out), ["AUD_XR", "AUD_INFL", "GBP_XR"])
+
+    def test_categorical_branch_returns_ordered_categorical(self):
+        out = _gts(self._qdf(True))
+        self.assertTrue(isinstance(out, _pd.Categorical))
+        self.assertTrue(out.ordered)
+        self.assertEqual(list(out), ["AUD_XR", "AUD_INFL", "GBP_XR"])
+
+    def test_single_row(self):
+        df = _pd.DataFrame({"cid": ["AUD"], "xcat": ["XR"],
+                            "real_date": _pd.to_datetime(["2020-01-01"]), "value": [1.0]})
+        out = _gts(_QDF(df, categorical=True))
+        self.assertEqual(list(out), ["AUD_XR"])
+
+    def test_missing_column_raises(self):
+        with self.assertRaises(ValueError):
+            _gts(self._qdf(True), cid_column="nope")
+
+    def test_signature_unchanged(self):
+        sig = inspect.signature(_gts)
+        self.assertEqual(list(sig.parameters), ["df", "cid_column", "xcat_column"])
+        self.assertEqual(sig.parameters["cid_column"].default, "cid")
+        self.assertEqual(sig.parameters["xcat_column"].default, "xcat")
+
+
+class TestAddTickerColumnAPI(_unittest.TestCase):
+    def test_method_signature_unchanged(self):
+        sig = inspect.signature(_QDF.add_ticker_column)
+        self.assertEqual(list(sig.parameters), ["self"])
+
+    def test_reduce_df_by_ticker_signature_unchanged(self):
+        sig = inspect.signature(_QDF.reduce_df_by_ticker)
+        self.assertEqual(
+            list(sig.parameters), ["self", "tickers", "start", "end", "blacklist"]
+        )
+
+
+class TestReduceDfEdgeAPI(_unittest.TestCase):
+    def _qdf(self):
+        return _pd.DataFrame({
+            "cid": ["AUD", "AUD", "GBP", "GBP"],
+            "xcat": ["XR", "INFL", "XR", "INFL"],
+            "real_date": _pd.to_datetime(["2020-01-01"] * 4),
+            "value": [1.0, 2.0, 3.0, 4.0],
+        })
+
+    def test_filter_by_cids(self):
+        out = _reduce_df(self._qdf(), cids=["AUD"])
+        self.assertEqual(set(out["cid"].unique()), {"AUD"})
+
+    def test_filter_by_xcats_string(self):
+        out = _reduce_df(self._qdf(), xcats="XR")
+        self.assertEqual(set(out["xcat"].unique()), {"XR"})
+
+    def test_out_all_returns_tuple(self):
+        out, xcats, cids = _reduce_df(self._qdf(), out_all=True)
+        self.assertIsInstance(out, _pd.DataFrame)
+        self.assertEqual(sorted(xcats), ["INFL", "XR"])
+
+    def test_non_qdf_raises(self):
+        with self.assertRaises(TypeError):
+            _reduce_df([1, 2, 3])
+
+    def test_signature_unchanged(self):
+        sig = inspect.signature(_reduce_df)
+        self.assertEqual(
+            list(sig.parameters),
+            ["df", "xcats", "cids", "start", "end", "blacklist", "out_all", "intersect"],
+        )
+        self.assertIs(sig.parameters["out_all"].default, False)
+        self.assertIs(sig.parameters["intersect"].default, False)
 
 
 if __name__ == "__main__":

--- a/tests/unit/management/test_update_df.py
+++ b/tests/unit/management/test_update_df.py
@@ -11,6 +11,7 @@ from macrosynergy.management.utils import (
 )
 from macrosynergy.panel.make_relative_value import make_relative_value
 from typing import Union, List, Dict, Tuple, Optional
+import inspect as _inspect
 
 
 class TestAll(unittest.TestCase):
@@ -454,6 +455,55 @@ class TestAll(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             update_tickers(df=self.dfd, df_add=1)
+
+
+class TestUpdateDfEdge(unittest.TestCase):
+    def setUp(self):
+        self.df = pd.DataFrame({
+            "cid": ["AUD", "AUD", "GBP"],
+            "xcat": ["XR", "INFL", "XR"],
+            "real_date": pd.to_datetime(["2020-01-01", "2020-01-02", "2020-01-01"]),
+            "value": [1.0, 2.0, 3.0],
+        })
+
+    def test_empty_base_returns_add(self):
+        empty = self.df.iloc[0:0].copy()
+        out = update_df(empty, self.df)
+        self.assertEqual(len(out), len(self.df))
+
+    def test_empty_add_returns_base(self):
+        empty = self.df.iloc[0:0].copy()
+        out = update_df(self.df, empty)
+        self.assertEqual(len(out), len(self.df))
+
+    def test_last_wins_on_overlap(self):
+        upd = self.df.copy()
+        upd["value"] = [10.0, 20.0, 30.0]
+        out = update_df(self.df, upd)
+        merged = out.set_index(["cid", "xcat", "real_date"])["value"]
+        self.assertEqual(merged.loc[("AUD", "XR", pd.Timestamp("2020-01-01"))], 10.0)
+
+    def test_non_df_raises_attributeerror(self):
+        # A list has no .columns; current update_df accesses df.columns before its
+        # isinstance guard, so a non-DataFrame raises AttributeError (pinning current behaviour).
+        with self.assertRaises(AttributeError):
+            update_df([1, 2, 3], self.df)
+
+    def test_non_qdf_dataframe_raises_typeerror(self):
+        # A plain DataFrame has .columns (survives that access) but is not a
+        # QuantamentalDataFrame, so the isinstance guard fires the documented TypeError.
+        bad_df = pd.DataFrame({"a": [1], "b": [2]})
+        with self.assertRaises(TypeError):
+            update_df(bad_df, self.df)
+
+    def test_update_df_signature_unchanged(self):
+        sig = _inspect.signature(update_df)
+        self.assertEqual(list(sig.parameters), ["df", "df_add", "xcat_replace"])
+        self.assertEqual(sig.parameters["xcat_replace"].default, False)
+
+    def test_update_tickers_signature_unchanged(self):
+        sig = _inspect.signature(update_tickers)
+        self.assertEqual(list(sig.parameters), ["df", "df_add"])
 
 
 if __name__ == "__main__":

--- a/tests/unit/management/test_utils.py
+++ b/tests/unit/management/test_utils.py
@@ -1,4 +1,6 @@
+import inspect as _inspect_st
 import unittest
+import unittest as _ut_st
 import pandas as pd
 import warnings
 import datetime
@@ -34,6 +36,7 @@ from macrosynergy.management.utils import (
     Timer,
     rotate_cid_xcat,
 )
+from macrosynergy.management.utils.core import split_ticker as _split_ticker
 from macrosynergy.management.utils.df_utils import _long_to_wide, _wide_to_long
 from macrosynergy.management.constants import FREQUENCY_MAP
 from macrosynergy.management.utils.math import expanding_mean_with_nan
@@ -1970,6 +1973,44 @@ class TestRotateCidXcat(unittest.TestCase):
         restored = rotate_cid_xcat(rotated, "to_cids", template, "EQXR_NSA")
         self.assertEqual(set(restored["cid"].unique()), set(cids))
         self.assertTrue((restored["xcat"] == "EQXR_NSA").all())
+
+
+class TestSplitTickerDirect(_ut_st.TestCase):
+    def test_scalar_cid_and_xcat(self):
+        self.assertEqual(_split_ticker("AUD_XR_NSA", "cid"), "AUD")
+        self.assertEqual(_split_ticker("AUD_XR_NSA", "xcat"), "XR_NSA")
+
+    def test_iterable_returns_list(self):
+        self.assertEqual(
+            _split_ticker(["AUD_XR", "GBP_INFL"], "cid"), ["AUD", "GBP"]
+        )
+
+    def test_mode_normalised(self):
+        self.assertEqual(_split_ticker("AUD_XR", " CID "), "AUD")
+
+    def test_bad_mode_raises_valueerror(self):
+        with self.assertRaises(ValueError):
+            _split_ticker("AUD_XR", "nope")
+
+    def test_non_string_mode_raises_typeerror(self):
+        with self.assertRaises(TypeError):
+            _split_ticker("AUD_XR", 5)
+
+    def test_no_underscore_raises_valueerror(self):
+        with self.assertRaises(ValueError):
+            _split_ticker("AUDXR", "cid")
+
+    def test_empty_iterable_raises_valueerror(self):
+        with self.assertRaises(ValueError):
+            _split_ticker([], "cid")
+
+    def test_non_string_ticker_raises_typeerror(self):
+        with self.assertRaises(TypeError):
+            _split_ticker(5, "cid")
+
+    def test_signature_unchanged(self):
+        sig = _inspect_st.signature(_split_ticker)
+        self.assertEqual(list(sig.parameters), ["ticker", "mode"])
 
 
 if __name__ == "__main__":

--- a/tests/unit/signal/test_signal_return_relations.py
+++ b/tests/unit/signal/test_signal_return_relations.py
@@ -1,5 +1,7 @@
+import inspect
 import unittest
 from macrosynergy.signal.signal_return_relations import SignalReturnRelations
+from macrosynergy.management.utils import categories_df
 
 from tests.simulate import make_qdf
 from sklearn.metrics import accuracy_score
@@ -1742,6 +1744,84 @@ class TestAll(unittest.TestCase):
 
         plt.close("all")
         matplotlib.use(self.mpl_backend)
+
+
+def _cid_codes(n: int) -> List[str]:
+    # 3-char uppercase codes with no underscore (valid cid). AAA, AAB, ...
+    codes = []
+    i = 0
+    while len(codes) < n:
+        a, b, c = i // 676, (i // 26) % 26, i % 26
+        codes.append(chr(65 + a % 26) + chr(65 + b) + chr(65 + c))
+        i += 1
+    return codes
+
+
+def srr_panel(
+    n_cids: int, n_dates: int, n_signals: int, n_returns: int, *, seed: int = 42
+) -> pd.DataFrame:
+    """Deterministic QDF with `n_signals` signal xcats (SIGn) and `n_returns` return xcats (XRn).
+
+    Self-contained copy of the helper in tests/perf/data.py so this unit test does not
+    depend on the (opt-in) tests/perf package.
+    """
+    cids = _cid_codes(n_cids)
+    cal = int(n_dates * 7 / 5) + 10
+    latest = (pd.Timestamp("2000-01-01") + pd.Timedelta(days=cal)).strftime("%Y-%m-%d")
+    sig_xcats = [f"SIG{i:02d}" for i in range(n_signals)]
+    ret_xcats = [f"XR{i:02d}" for i in range(n_returns)]
+    xcats = sig_xcats + ret_xcats
+
+    df_cids = pd.DataFrame(
+        index=cids, columns=["earliest", "latest", "mean_add", "sd_mult"]
+    )
+    for cid in cids:
+        df_cids.loc[cid] = ["2000-01-01", latest, 0.0, 1.0]
+    df_xcats = pd.DataFrame(
+        index=xcats,
+        columns=["earliest", "latest", "mean_add", "sd_mult", "ar_coef", "back_coef"],
+    )
+    for xc in xcats:
+        df_xcats.loc[xc] = ["2000-01-01", latest, 0.0, 1.0, 0.3, 0.4]
+    df = make_qdf(df_cids, df_xcats, back_ar=0.5, seed=seed)
+    return df[["cid", "xcat", "real_date", "value"]].reset_index(drop=True)
+
+
+class TestMapPvalDirect(unittest.TestCase):
+    """Direct exercising of map_pval and an API signature tripwire."""
+
+    def test_map_pval_returns_float_in_unit_interval(self):
+        df = srr_panel(n_cids=4, n_dates=400, n_signals=1, n_returns=1)
+        cids = sorted(df["cid"].unique())
+        wide = categories_df(
+            df,
+            xcats=["SIG00", "XR00"],
+            cids=cids,
+            val="value",
+            freq="M",
+            lag=1,
+            fwin=1,
+            xcat_aggs=["last", "sum"],
+        ).dropna()
+        srr = SignalReturnRelations(
+            df,
+            rets=["XR00"],
+            sigs=["SIG00"],
+            cids=cids,
+            freqs=["M"],
+            ms_panel_test=True,
+        )
+        ret_vals = wide["XR00"]
+        sig_vals = wide["SIG00"]
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            p = srr.map_pval(ret_vals, sig_vals)
+        self.assertIsInstance(p, float)
+        self.assertTrue(0.0 <= p <= 1.0, f"p-value {p} not in [0, 1]")
+
+    def test_map_pval_signature_unchanged(self):
+        sig = inspect.signature(SignalReturnRelations.map_pval)
+        self.assertEqual(list(sig.parameters), ["self", "ret_vals", "sig_vals"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

**Part 2 of 4** splitting #2695 (kept open for reference on `feature/performance`). This PR extends the existing unit suites with edge-case, boundary and API-signature ("tripwire") tests for the QDF/panel helpers that are optimized in the companion perf PR — so that work is comprehensively covered by fast, deterministic unit tests.

All tests **characterize current behaviour and pass on `develop` unchanged** (verified: `195 passed`). They stay green after the perf changes land because the optimization is byte-identical.

## What's here

- **`test_qdf.py`** — `_get_tickers_series` object/categorical branches, single-row, missing-column error, signature guard; `add_ticker_column` / `reduce_df_by_ticker` signature guards; `reduce_df` filter / `out_all` / non-QDF / signature guards
- **`test_update_df.py`** — `update_df` empty-base / empty-add, last-wins on overlap, non-DataFrame vs non-QDF error contract, `update_df` / `update_tickers` signatures
- **`test_utils.py`** — `split_ticker` scalar / iterable / mode-normalisation / error paths and signature guard
- **`test_signal_return_relations.py`** — direct `map_pval` exercise (float in `[0, 1]`) + a `map_pval` signature tripwire

## Notes for reviewers

- The `srr_panel` builder is **inlined locally** in the signal test so this PR has **no dependency** on the (opt-in) `tests/perf` package from #2699 — each split PR stands alone against `develop`.
- No production code changes here.

cc @lsimonsen @Magnus167

🤖 Generated with [Claude Code](https://claude.com/claude-code)