### PR TITLE
Bugfix: Basket accepts categorical QuantamentalDataFrame input [3/4 split of #2695]

### DIFF
--- a/macrosynergy/panel/basket.py
+++ b/macrosynergy/panel/basket.py
@@ -499,7 +499,7 @@ class Basket(object):
         # Remove leading NA rows.
 
         fvi = max(dfw_wgs.first_valid_index(), self.dfw_ret.first_valid_index())
-        dfw_wgs = dfw_wgs[fvi:]
+        dfw_wgs = dfw_wgs.loc[fvi:]
 
         # Impose cap on cross-section weights.
 

--- a/tests/unit/panel/test_basket_performance.py
+++ b/tests/unit/panel/test_basket_performance.py
@@ -6,6 +6,7 @@ import sys
 from tests.simulate import dataframe_basket, construct_df, simulate_ar, make_qdf
 from macrosynergy.panel.basket import Basket
 from macrosynergy.management.utils import reduce_df, reduce_df_by_ticker
+from macrosynergy.management.types import QuantamentalDataFrame
 import random
 from macrosynergy.panel.historic_vol import flat_std
 from itertools import chain
@@ -780,6 +781,114 @@ class TestAll(unittest.TestCase):
         weight_equal_dates = list(set(weight_equal["real_date"]))
 
         self.assertTrue(basket_equal_dates == weight_equal_dates)
+
+    def test_categorical_qdf_parity(self):
+        """
+        Regression test: Basket must accept a categorical
+        QuantamentalDataFrame and produce output identical to the
+        object-dtype run.
+
+        Before the basket.py fix (dfw_wgs[fvi:] -> dfw_wgs.loc[fvi:])
+        this test raises InvalidIndexError because pandas probes
+        `fvi in columns` when the columns are a CategoricalIndex.
+        """
+        dfd_obj = self.dfd
+        dfd_cat = QuantamentalDataFrame(dfd_obj.copy(), categorical=True)
+
+        contracts = self.contracts
+        black = self.black
+
+        # Object-dtype basket run.
+        basket_obj = Basket(
+            df=dfd_obj,
+            contracts=contracts,
+            ret="XR_NSA",
+            cry=["CRY_NSA", "CRR_NSA"],
+            blacklist=black,
+        )
+        basket_obj.make_basket(
+            weight_meth="equal", max_weight=0.45, basket_name="GLB_EQUAL"
+        )
+        basket_obj.make_basket(
+            weight_meth="invsd",
+            lback_meth="ma",
+            lback_periods=21,
+            max_weight=0.55,
+            remove_zeros=True,
+            basket_name="GLB_INVERSE",
+        )
+
+        # Categorical QuantamentalDataFrame basket run.
+        # Raised InvalidIndexError before the fix at make_weights line 502.
+        basket_cat = Basket(
+            df=dfd_cat,
+            contracts=contracts,
+            ret="XR_NSA",
+            cry=["CRY_NSA", "CRR_NSA"],
+            blacklist=black,
+        )
+        basket_cat.make_basket(
+            weight_meth="equal", max_weight=0.45, basket_name="GLB_EQUAL"
+        )
+        basket_cat.make_basket(
+            weight_meth="invsd",
+            lback_meth="ma",
+            lback_periods=21,
+            max_weight=0.55,
+            remove_zeros=True,
+            basket_name="GLB_INVERSE",
+        )
+
+        def _normalize_and_sort(df):
+            # Convert categorical string columns to object so sort order
+            # is deterministic regardless of the dtype of the input QDF.
+            df = df.copy()
+            for col in ["cid", "xcat"]:
+                df[col] = df[col].astype(str)
+            return (
+                df.sort_values(["cid", "xcat", "real_date"])
+                .reset_index(drop=True)
+            )
+
+        # return_basket outputs must be value-identical.
+        for bname in ["GLB_EQUAL", "GLB_INVERSE"]:
+            rb_obj = _normalize_and_sort(
+                basket_obj.return_basket(basket_names=bname)
+            )
+            rb_cat = _normalize_and_sort(
+                basket_cat.return_basket(basket_names=bname)
+            )
+            self.assertEqual(
+                rb_obj.shape,
+                rb_cat.shape,
+                f"Shape mismatch for basket '{bname}'",
+            )
+            np.testing.assert_array_almost_equal(
+                rb_obj["value"].to_numpy(),
+                rb_cat["value"].to_numpy(),
+                decimal=10,
+                err_msg=f"Value mismatch for basket '{bname}'",
+            )
+
+        # return_weights outputs must be value-identical.
+        for bname in ["GLB_EQUAL", "GLB_INVERSE"]:
+            rw_obj = _normalize_and_sort(
+                basket_obj.return_weights(basket_names=bname)
+            )
+            rw_cat = _normalize_and_sort(
+                basket_cat.return_weights(basket_names=bname)
+            )
+            self.assertEqual(
+                rw_obj.shape,
+                rw_cat.shape,
+                f"Weight shape mismatch for basket '{bname}'",
+            )
+            np.testing.assert_array_almost_equal(
+                rw_obj["value"].to_numpy(),
+                rw_cat["value"].to_numpy(),
+                decimal=10,
+                err_msg=f"Weight value mismatch for basket '{bname}'",
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

**Part 3 of 4** splitting #2695 (kept open for reference on `feature/performance`). A standalone, minimal bug fix.

## The bug

`Basket.make_weights` trimmed leading all-NA rows with `dfw_wgs[fvi:]`, where `fvi` is a `real_date` **label** (a `Timestamp`). On the wide weight frame built from a **categorical** `QuantamentalDataFrame`, that index no longer supports positional `__getitem__` slicing with a label, so pandas raises:

```
pandas.errors.InvalidIndexError: slice(Timestamp('2010-12-01 00:00:00'), None, None)
```

…and `Basket` cannot be constructed from categorical QDF input. Object-dtype QDFs happened to work only because `frame[ts:]` on a `DatetimeIndex` is already label-based.

## The fix

```diff
-        dfw_wgs = dfw_wgs[fvi:]
+        dfw_wgs = dfw_wgs.loc[fvi:]
```

Explicit label-based slicing. **Byte-identical** for the object-dtype path (same rows), and it makes the categorical path work.

## Test (proves the bug)

Adds `tests/unit/panel/test_basket_performance.py`. Verified:
- **On `develop` (old code):** `test_categorical_qdf_parity` **fails** with the `InvalidIndexError` above (1 failed, 11 passed).
- **With the fix:** all **12 passed**; object- vs categorical-input Baskets agree.
- No regressions in `Basket`-dependent suites (`test_contract_signals`, `test_target_positions`): 29 passed.

cc @lsimonsen @Magnus167

🤖 Generated with [Claude Code](https://claude.com/claude-code)