### PR TITLE
Bugfix: align signs/weights with requested cids in linear_composite

### DIFF
--- a/macrosynergy/panel/linear_composite.py
+++ b/macrosynergy/panel/linear_composite.py
@@ -611,13 +611,19 @@ def _check_df_for_missing_cid_data(
                 f"Available categories are {found_xcats}."
             )
 
-    if set(cids) - set(found_cids) != set():
-        for cid in set(cids) - set(found_cids):
-            # Cids has already been removed since it uses
+    missing_cids = set(cids) - set(found_cids)
+    if missing_cids:
+        for cid in sorted(missing_cids):
             warnings.warn(f"cid {cid} not found in `df`. It will be ignored.")
-            signs.pop(cids.index(cid))
-            if isinstance(weights, list):
-                weights.pop(cids.index(cid))
+        # Filter `signs`/`weights` together against the missing set so they stay
+        # positionally aligned with `found_cids` (the same idiom as `_check_args`).
+        # Popping by `cids.index(cid)` while `cids` is not shortened uses a stale
+        # index once more than one cid is missing, removing the wrong element.
+        signs = [signs[i] for i, cid in enumerate(cids) if cid not in missing_cids]
+        if isinstance(weights, list):
+            weights = [
+                weights[i] for i, cid in enumerate(cids) if cid not in missing_cids
+            ]
 
     ctr = 0
     for cidx in found_cids.copy():  # copy to allow modification of `cids`

--- a/tests/unit/panel/test_linear_composite.py
+++ b/tests/unit/panel/test_linear_composite.py
@@ -1050,6 +1050,53 @@ class TestAll(unittest.TestCase):
         # All values should be NaN with lag larger than data
         self.assertTrue(result_large_lag["value"].isna().all())
 
+    def test_linear_composite_cid_agg_missing_cids(self):
+        """
+        cid aggregation where several requested cids are removed by a blacklist:
+        the surviving cross-sections must keep their own signs and weights.
+        Regression test for the sign/weight misalignment in #2484.
+        """
+        cids: List[str] = ["AUD", "CAD", "CHF", "GBP", "NZD", "USD"]
+        xcat: str = "XR"
+
+        dfd: pd.DataFrame = make_test_df(
+            cids=cids, xcats=[xcat], start="2000-01-01", end="2000-03-31"
+        )
+        # A distinct constant per cross-section so the composite is predictable.
+        value_map: Dict[str, int] = {
+            "AUD": 1,
+            "CAD": 2,
+            "CHF": 3,
+            "GBP": 4,
+            "NZD": 5,
+            "USD": 6,
+        }
+        dfd["value"] = dfd["cid"].astype(str).map(value_map)
+
+        weights: List[float] = [1, 2, 3, 4, 5, 6]
+        signs: List[float] = [1, -1, 1, -1, 1, -1]
+
+        # Drop four cross-sections entirely; CAD and USD remain.
+        blacklist: Dict[str, List[str]] = {
+            cid: ["2000-01-01", "2000-03-31"] for cid in ["AUD", "CHF", "GBP", "NZD"]
+        }
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            rdf: pd.DataFrame = linear_composite(
+                df=dfd,
+                xcats=xcat,
+                cids=cids,
+                weights=weights,
+                signs=signs,
+                normalize_weights=False,
+                blacklist=blacklist,
+            )
+
+        # CAD: value 2, sign -1, weight 2 -> -4; USD: value 6, sign -1, weight 6 -> -36.
+        expected = 2 * (-1) * 2 + 6 * (-1) * 6
+        self.assertTrue(np.all(rdf["value"].values == expected))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
_check_df_for_missing_cid_data removed missing-cid entries with signs.pop(cids.index(cid)) while cids itself was never shortened, so once more than one cid was missing the index was stale and the wrong sign/weight was dropped (or pop raised IndexError). Because the loop iterates a set, the corruption was non-deterministic across runs.

Filter signs/weights together against the missing set, the same idiom _check_args already uses, keeping them aligned with found_cids. Adds a regression test with asymmetric signs/weights and several blacklisted cids.