### PR TITLE
Bugfix: harden corr_prob_calc panel-test p-value and fix PosRatio map_pval

### DIFF
--- a/macrosynergy/panel/category_relations.py
+++ b/macrosynergy/panel/category_relations.py
@@ -416,8 +416,24 @@ class CategoryRelations(object):
                 X = sm.add_constant(X)
                 y = df_i.loc[:, self.xcats[1]]
                 groups = df_i.reset_index().real_date
-                re = sm.MixedLM(y, X, groups).fit(reml=False)  # random effects est
-                pval = float(re.summary().tables[1].iloc[1, 3])
+                try:
+                    re = sm.MixedLM(y, X, groups).fit(reml=False)  # random effects est
+                    # Slope p-value read from the results object directly: full
+                    # precision, independent of the rendered summary-table layout.
+                    # A non-estimable coefficient yields NaN (rendered as "" in the
+                    # summary table, where float("") would raise).
+                    pval = float(np.asarray(re.pvalues)[1])
+                except np.linalg.LinAlgError:
+                    warnings.warn(
+                        "Singular matrix encountered, so the panel-test p-value "
+                        "could not be calculated."
+                    )
+                    pval = np.nan
+                if np.isnan(pval):
+                    warnings.warn(
+                        "Panel-test p-value could not be calculated, since there "
+                        "weren't enough datapoints."
+                    )
             row = [np.round(coeff, 3), np.round(1 - pval, 3)]
             cpl.append(row)
         return cpl

--- a/macrosynergy/signal/signal_return_relations.py
+++ b/macrosynergy/signal/signal_return_relations.py
@@ -1090,9 +1090,18 @@ class SignalReturnRelations:
             # Positive correlation with error prob < 50%.
             df_out.loc["PosRatio", below50s] = pos_pvals
             if self.ms_panel_test:
-                map_pval_bool = df_out.loc[css, "map_pval"] < 0.5
-                pos_map_pval = np.mean(np.array(map_pval_bool) * np.nan)
-                df_out.loc["PosRatio", "map_pval"] = pos_map_pval
+                # Positive pearson correlation with panel-test error prob < 50%,
+                # mirroring the pearson_pval/kendall_pval treatment above. The panel
+                # test needs multiple cross-sections, so per-cid segments carry NaN;
+                # the ratio is computed over the segments where the test exists
+                # (yearly segments), and stays NaN where it is undefined (cid segments).
+                map_sig = (df_out.loc[css, "map_pval"] < 0.5) & (
+                    df_out.loc[css, "pearson"] > 0
+                )
+                valid = df_out.loc[css, "map_pval"].notna()
+                df_out.loc["PosRatio", "map_pval"] = (
+                    map_sig[valid].mean() if valid.any() else np.nan
+                )
 
         return df_out.astype("float")
 

--- a/tests/unit/panel/test_category_relations.py
+++ b/tests/unit/panel/test_category_relations.py
@@ -884,6 +884,37 @@ class TestAll(unittest.TestCase):
         except:
             self.fail("CategoryRelations failed when using seperator=2012")
 
+    def test_corr_prob_calc_map_degenerate(self):
+        # A degenerate (perfectly collinear) panel must warn and return a NaN
+        # probability instead of raising from the panel-test fit.
+        n = 6
+        dates = pd.bdate_range("2020-01-01", periods=n)
+        rows = []
+        for cid in ["AAA", "BBB"]:
+            for date, value in zip(dates, np.linspace(1.0, 2.0, n)):
+                rows.append(
+                    {"cid": cid, "xcat": "FF", "real_date": date, "value": value}
+                )
+                rows.append(
+                    {"cid": cid, "xcat": "TT", "real_date": date, "value": value}
+                )
+        degenerate = pd.DataFrame(rows)
+
+        cr = CategoryRelations(
+            degenerate,
+            xcats=["FF", "TT"],
+            cids=["AAA", "BBB"],
+            freq="D",
+            lag=0,
+            xcat_aggs=["last", "last"],
+        )
+
+        with self.assertWarns(UserWarning):
+            out = cr.corr_prob_calc(cr.df, prob_est="map")
+
+        self.assertEqual(len(out), 1)
+        self.assertTrue(np.isnan(out[0][1]))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/signal/test_signal_return_relations.py
+++ b/tests/unit/signal/test_signal_return_relations.py
@@ -1745,6 +1745,39 @@ class TestAll(unittest.TestCase):
         plt.close("all")
         matplotlib.use(self.mpl_backend)
 
+    def test_output_table_posratio_map_pval(self):
+        # PosRatio for map_pval: a real ratio over the segments where the panel
+        # test exists (years), NaN where it is undefined (single cross-sections).
+        sr = SignalReturnRelations(
+            self.dfd, rets="XR", sigs="CRY", freqs="M", ms_panel_test=True
+        )
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            ytbl = sr.single_relation_table(table_type="years")
+            ctbl = sr.single_relation_table(table_type="cross_section")
+
+        segments = [
+            i
+            for i in ytbl.index
+            if i not in ("Mean", "PosRatio") and "=>" not in str(i)
+        ]
+        map_vals = ytbl.loc[segments, "map_pval"]
+        valid = map_vals.notna()
+        self.assertTrue(valid.any())
+
+        expected = float(
+            ((map_vals < 0.5) & (ytbl.loc[segments, "pearson"] > 0))[valid].mean()
+        )
+        pos_ratio = ytbl.loc["PosRatio", "map_pval"]
+        self.assertFalse(np.isnan(pos_ratio))
+        # single_relation_table rounds the returned table, so compare within
+        # display precision.
+        self.assertAlmostEqual(float(pos_ratio), expected, places=4)
+
+        # Per-cid segments cannot host a panel test: the ratio stays undefined.
+        self.assertTrue(np.isnan(ctbl.loc["PosRatio", "map_pval"]))
+
 
 import statsmodels.api as sm
 from macrosynergy.learning.random_effects import RandomEffects


### PR DESCRIPTION
Two hardening fixes in the MAP panel-test code path, on functions the recent map_pval refactor (6fe7a573) did not touch.

**1. `CategoryRelations.corr_prob_calc` — read the p-value from the results object, with guards.** `corr_prob_calc` still fits `sm.MixedLM` and extracts the slope p-value with `re.summary().tables[1].iloc[1, 3]` — a rendered string, rounded to three decimals and dependent on the table layout — with no error handling. On a singular/collinear panel the fit raises an uncaught `LinAlgError`, and a non-estimable coefficient makes `float("")` raise `ValueError`, both propagating out of `reg_scatter`. This reads `re.pvalues` directly (full precision, layout-independent) and guards the degenerate cases so they warn and return `NaN` — the same treatment `SignalReturnRelations.map_pval` already has. (Migrating `corr_prob_calc` to the `RandomEffects` estimator, as `map_pval` was just refactored to do, would be a natural follow-up; this PR keeps the change minimal.)

**2. `SignalReturnRelations` — `PosRatio` for `map_pval` was always `NaN`.** In `__output_table__` the PosRatio row for `map_pval` computed `np.mean(np.array(map_pval_bool) * np.nan)` — multiplying by `np.nan`, so the result was unconditionally `NaN`. It now mirrors the `pearson_pval`/`kendall_pval` rows: the share of segments (where the panel test is defined) with error probability < 0.5 and positive correlation, staying `NaN` for single-cross-section segments.

**Tests.** Adds a regression test for each. Rebased onto current `develop`; the earlier `map_pval` p-value/guard changes were dropped as they're already covered by the recent refactor.
