### PR TITLE
Feature: optional robust covariance estimators for CategoryRelations.ols_table 

### DIFF
--- a/macrosynergy/panel/category_relations.py
+++ b/macrosynergy/panel/category_relations.py
@@ -970,28 +970,69 @@ class CategoryRelations(object):
         if show_plot:
             plt.show()
 
-    def ols_table(self, type="pool"):
+    def ols_table(self, type="pool", cov_type=None, cov_kwds=None):
         """
-        Print statsmodels regression summaries.
+        Print and return statsmodels regression summaries.
 
         Parameters
         ----------
         type : str
             type of linear regression summary to print. Default is 'pool'. Alternative
             is 're' for period-specific random effects.
+        cov_type : str
+            optional robust covariance estimator for the pooled regression, passed to
+            the statsmodels fit. Panel-aware defaults are provided for two estimators:
+            'cluster' clusters by cross-section, and 'hac-groupsum' / 'nw-groupsum'
+            (Driscoll-Kraay) use the real_date periods with a standard automatic lag
+            choice. Default is None, which keeps the classic (i.i.d.) standard errors.
+            Only available with type='pool'.
+        cov_kwds : dict
+            optional keyword arguments for the covariance estimator, overriding the
+            panel-aware defaults.
+
+        Returns
+        -------
+        The statsmodels results object of the fitted regression.
         """
 
         assert type in ["pool", "re"], "Type must be either 'pool' or 're'."
+        if cov_type is not None and type != "pool":
+            raise ValueError("`cov_type` is only available with type='pool'.")
 
-        x, y = self.df.dropna().iloc[:, 0], self.df.dropna().iloc[:, 1]
+        df_fit = self.df.dropna()
+        x, y = df_fit.iloc[:, 0], df_fit.iloc[:, 1]
         x_fit = sm.add_constant(x)
         groups = self.df.reset_index().real_date
         if type == "pool":
-            fit_results = sm.OLS(y, x_fit).fit()
+            if cov_type is None:
+                fit_results = sm.OLS(y, x_fit).fit()
+            else:
+                kwds = dict(cov_kwds) if cov_kwds else {}
+                fit_kwargs = {}
+                if cov_type == "cluster" and "groups" not in kwds:
+                    kwds["groups"] = df_fit.index.get_level_values("cid")
+                if cov_type in ("hac-groupsum", "nw-groupsum"):
+                    if "time" not in kwds:
+                        kwds["time"] = pd.factorize(
+                            df_fit.index.get_level_values("real_date")
+                        )[0]
+                    if "maxlags" not in kwds:
+                        n_periods = int(np.max(kwds["time"])) + 1
+                        kwds["maxlags"] = max(
+                            1, int(np.floor(4 * (n_periods / 100.0) ** (2.0 / 9.0)))
+                        )
+                    # Group-summed HAC estimators have no small-sample df
+                    # correction; t-based inference yields NaN p-values, so use
+                    # normal-based inference.
+                    fit_kwargs["use_t"] = False
+                fit_results = sm.OLS(y, x_fit).fit(
+                    cov_type=cov_type, cov_kwds=kwds, **fit_kwargs
+                )
         elif type == "re":
             fit_results = sm.MixedLM(y, x_fit, groups).fit(reml=False)
 
         print(fit_results.summary())
+        return fit_results
 
 
 if __name__ == "__main__":

--- a/tests/unit/panel/test_category_relations.py
+++ b/tests/unit/panel/test_category_relations.py
@@ -884,6 +884,90 @@ class TestAll(unittest.TestCase):
         except:
             self.fail("CategoryRelations failed when using seperator=2012")
 
+    def _quiet_ols_table(self, cr, **kwargs):
+        # ols_table prints the statsmodels summary; capture it to keep test
+        # output clean.
+        buffer = io.StringIO()
+        stdout = sys.stdout
+        sys.stdout = buffer
+        try:
+            return cr.ols_table(**kwargs)
+        finally:
+            sys.stdout = stdout
+
+    def test_ols_table_returns_results(self):
+        import statsmodels.api as sm
+
+        cr = CategoryRelations(
+            self.dfd,
+            xcats=["CRY", "XR"],
+            cids=self.cids,
+            freq="M",
+            lag=1,
+            xcat_aggs=["mean", "mean"],
+        )
+
+        res_pool = self._quiet_ols_table(cr)
+        res_re = self._quiet_ols_table(cr, type="re")
+        self.assertIsNotNone(res_pool)
+        self.assertIsNotNone(res_re)
+
+        df_fit = cr.df.dropna()
+        direct = sm.OLS(df_fit.iloc[:, 1], sm.add_constant(df_fit.iloc[:, 0])).fit()
+        self.assertTrue(
+            np.allclose(np.asarray(res_pool.params), np.asarray(direct.params))
+        )
+
+    def test_ols_table_cov_type(self):
+        import statsmodels.api as sm
+
+        cr = CategoryRelations(
+            self.dfd,
+            xcats=["CRY", "XR"],
+            cids=self.cids,
+            freq="M",
+            lag=1,
+            xcat_aggs=["mean", "mean"],
+        )
+
+        res_iid = self._quiet_ols_table(cr)
+        res_cluster = self._quiet_ols_table(cr, cov_type="cluster")
+        res_dk = self._quiet_ols_table(cr, cov_type="hac-groupsum")
+
+        # Robust estimators change the standard errors, never the coefficients.
+        for res in (res_cluster, res_dk):
+            self.assertTrue(
+                np.allclose(np.asarray(res.params), np.asarray(res_iid.params))
+            )
+            self.assertTrue(np.isfinite(np.asarray(res.bse)).all())
+            self.assertTrue(np.isfinite(np.asarray(res.pvalues)).all())
+        self.assertFalse(
+            np.allclose(np.asarray(res_cluster.bse), np.asarray(res_iid.bse))
+        )
+        self.assertFalse(np.allclose(np.asarray(res_dk.bse), np.asarray(res_iid.bse)))
+
+        # The cross-section clustering default matches a direct statsmodels fit.
+        df_fit = cr.df.dropna()
+        direct = sm.OLS(df_fit.iloc[:, 1], sm.add_constant(df_fit.iloc[:, 0])).fit(
+            cov_type="cluster",
+            cov_kwds={"groups": df_fit.index.get_level_values("cid")},
+        )
+        self.assertTrue(
+            np.allclose(np.asarray(res_cluster.bse), np.asarray(direct.bse))
+        )
+
+    def test_ols_table_cov_type_re_raises(self):
+        cr = CategoryRelations(
+            self.dfd,
+            xcats=["CRY", "XR"],
+            cids=self.cids,
+            freq="M",
+            lag=1,
+            xcat_aggs=["mean", "mean"],
+        )
+        with self.assertRaises(ValueError):
+            self._quiet_ols_table(cr, type="re", cov_type="cluster")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
optional robust standard errors in `ols_table`

Adds an opt-in `cov_type` (and `cov_kwds`) to `CategoryRelations.ols_table`, passed through to the statsmodels pooled fit, with panel-aware defaults:

- `cov_type="cluster"` — clusters by cross-section (`cid`).
- `cov_type="hac-groupsum"` / `"nw-groupsum"` — Driscoll-Kraay, using the `real_date` periods with the standard automatic lag choice and normal-based inference (the group-summed HAC estimators have no small-sample t degrees-of-freedom correction, which otherwise yields NaN p-values).
- `cov_kwds` overrides any of these defaults.

`ols_table` now also returns the fitted results object (in addition to printing the summary), so the covariance choice can be inspected programmatically. The default path (`cov_type=None`, i.i.d. standard errors) and the printed output are unchanged. `cov_type` is only valid with `type="pool"`; combining it with `type="re"` raises `ValueError`.

Clustered and Driscoll-Kraay standard errors are the standard correction for cross-sectional and serial dependence in macro panels (Petersen 2009; Driscoll-Kraay via Hoechle 2007), so the classic i.i.d. errors this currently defaults to can be materially over-confident on persistent panels.

**Tests.** Adds tests that the returned results match a direct statsmodels fit, that the robust options change the standard errors but not the coefficients (and yield finite p-values), that the cluster default matches a direct clustered fit, and that `type="re"` + `cov_type` raises.
