### PR TITLE
chore: strip non-ASCII characters from source, tests, docs and CI

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -56,10 +56,10 @@ jobs:
     - name: Autobuild
       uses: github/codeql-action/autobuild@v2
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
+    #  Command-line programs to run using the OS shell.
+    #  https://git.io/JvXDl
 
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+    #  If the Autobuild fails above, remove it and uncomment the following three lines
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language
 

--- a/docs/release_notes.py
+++ b/docs/release_notes.py
@@ -55,7 +55,7 @@ def format_chg_log(strx: str) -> str:
     findstr = (
         "**Full Changelog**: https://github.com/macrosynergy/macrosynergy/compare/"
     )
-    comp_str = strx.replace(findstr, "").replace("...", "←")
+    comp_str = strx.replace(findstr, "").replace("...", "<-")
     comp_str = f"**Full Changelog**: [{comp_str}]({strx.split(' ')[-1]})"
     return comp_str
 

--- a/docs/source/contribution_guide.rst
+++ b/docs/source/contribution_guide.rst
@@ -20,7 +20,7 @@ tracker <https://github.com/macrosynergy/macrosynergy/issues/new/choose>`__.
 
 If you are reporting a bug, please include as much information as
 possible to help us reproduce the issue. This includes environment
-details (e.g. operating system, Python version, dependency versions
+details (e.g. operating system, Python version, dependency versions
 (``pip freeze``)) error messages, and a minimal reproducible example.
 
 Feature Requests
@@ -43,16 +43,16 @@ The package has the 3 primary branches:
 
 ::
 
-   develop ← feature/<feature_name>
-           ← bugfix/<bugfix_name>
+   develop <- feature/<feature_name>
+           <- bugfix/<bugfix_name>
 
-   test ← develop
+   test <- develop
 
-   main ← hotfix/<hotfix_name>
-        ← test
+   main <- hotfix/<hotfix_name>
+        <- test
 
    ...
-   develop ← version++ ← main
+   develop <- version++ <- main
 
 New Features
 ~~~~~~~~~~~~
@@ -62,7 +62,7 @@ created from the ``develop`` branch. The feature branch should be named
 
 ::
 
-   develop ← feature/<feature_name>
+   develop <- feature/<feature_name>
 
 Once the feature is complete, a pull request should be raised against
 the ``develop`` branch. See the `Pull Requests
@@ -75,7 +75,7 @@ Bugfixes also be made against the ``develop`` branch.
 
 ::
 
-   develop ← bugfix/<bugfix_name>
+   develop <- bugfix/<bugfix_name>
 
 Hotfixes
 ~~~~~~~~
@@ -92,7 +92,7 @@ release.**
 
 ::
 
-   main ← hotfix/<hotfix_name>
+   main <- hotfix/<hotfix_name>
 
 CI/CD related changes
 ~~~~~~~~~~~~~~~~~~~~~
@@ -104,7 +104,7 @@ tasks:
 
    chore/<chore_name>
 
-Make sure to use “Chore” as the type of the pull request. (See `Pull
+Make sure to use "Chore" as the type of the pull request. (See `Pull
 Requests/Title Conventions <#title-conventions>`__)
 
 Pull Requests
@@ -230,7 +230,7 @@ The following apply to contributors outside the Macrosynergy team:
 
 5. Contributors may not make any modifications to the unit tests,
    integration tests, dependencies, or any CI/CD configuration
-   (e.g. GitHub Actions, Codecov, etc.)
+   (e.g. GitHub Actions, Codecov, etc.)
 
 6. Contributors may not modify any static files such as the static
    documentation pages, the ``README.md`` file, and the ``LICENSE``

--- a/docs/source/faqs.rst
+++ b/docs/source/faqs.rst
@@ -15,7 +15,7 @@ If you find that the package raises an
 proxy settings. In scenarios where an error is raised while running
 ``check_connection()`` (or another download), the error is raised with
 context to the OAuth token request (to
-“https://authe.jpmchase.com/as/token.oauth2”).
+"https://authe.jpmchase.com/as/token.oauth2").
 
 You would most likely need to pass your proxy settings to the
 ``JPMaQSDownload`` object, as shown in the `Connecting via a proxy
@@ -55,7 +55,7 @@ I have a feature request
 
 Please `raise an
 issue <https://github.com/macrosynergy/macrosynergy/issues/new/choose>`__,
-and title it “Feature Request: [your feature request]”.
+and title it "Feature Request: [your feature request]".
 
 Contributing or creating a pull request
 ---------------------------------------

--- a/macrosynergy/download/datastream/connection.py
+++ b/macrosynergy/download/datastream/connection.py
@@ -31,7 +31,7 @@ except ImportError as _exc:  # pragma: no cover
 
 logger: logging.Logger = logging.getLogger(__name__)
 
-# Ticker used only for connection testing — a liquid, always-available instrument.
+# Ticker used only for connection testing - a liquid, always-available instrument.
 _TEST_TICKER: str = "U:IBM"
 _TEST_FIELD: str = "P"
 
@@ -107,7 +107,7 @@ class DatastreamConnection:
         ConnectionError
             If ``DatastreamPy`` raises any exception during instantiation.
         """
-        logger.info("Connecting to Datastream Web Service as '%s' …", self._username)
+        logger.info("Connecting to Datastream Web Service as '%s' ...", self._username)
         try:
             self.ds = dsweb.DataClient(None, self._username, self._password)
             self._is_connected = True
@@ -158,7 +158,7 @@ class DatastreamConnection:
         """
         if not self.is_connected():
             logger.debug(
-                "No active connection found — calling connect() automatically."
+                "No active connection found - calling connect() automatically."
             )
             self.connect()
         return self.ds  # type: ignore[return-value]  # guaranteed non-None after connect
@@ -175,7 +175,7 @@ class DatastreamConnection:
             ``True`` if the test request returns a non-empty DataFrame, ``False``
             otherwise.
         """
-        logger.info("Testing DSWS connection with a trivial request …")
+        logger.info("Testing DSWS connection with a trivial request ...")
         try:
             ds = self.get_connection()
             result = ds.get_data(
@@ -187,7 +187,7 @@ class DatastreamConnection:
                 logger.info("Connection test passed.")
                 return True
             logger.warning(
-                "Connection test returned an empty DataFrame — treating as failure."
+                "Connection test returned an empty DataFrame - treating as failure."
             )
             return False
         except Exception as exc:
@@ -216,7 +216,7 @@ class DatastreamConnection:
         Returns
         -------
         bool
-            Always ``False`` — exceptions are never suppressed.
+            Always ``False`` - exceptions are never suppressed.
         """
         self.disconnect()
         return False

--- a/macrosynergy/download/datastream/data_manager.py
+++ b/macrosynergy/download/datastream/data_manager.py
@@ -8,7 +8,7 @@ high-level methods for:
 * Fetching index / list constituents.
 * Retrieving static / snapshot metadata for a set of instruments.
 * Downloading time-series data with automatic request chunking that respects the
-  official DSWS API limits (≤ 50 instruments, ≤ 50 datatypes, ≤ 100 items per call).
+  official DSWS API limits (<= 50 instruments, <= 50 datatypes, <= 100 items per call).
 * Post-processing the raw DataFrames returned by ``DatastreamPy`` into tidy formats
   suitable for downstream analysis.
 
@@ -16,7 +16,7 @@ API limits (enforced by this module)
 -------------------------------------
 * ``MAX_INSTRUMENTS_PER_REQUEST = 50``
 * ``MAX_DATATYPES_PER_REQUEST  = 50``
-* ``MAX_ITEMS_PER_REQUEST      = 100``   (instruments × datatypes)
+* ``MAX_ITEMS_PER_REQUEST      = 100``   (instruments x datatypes)
 
 Typical usage::
 
@@ -134,7 +134,7 @@ class DatastreamDataManager:
             self._connection = connection
         elif username and password:
             logger.debug(
-                "No DatastreamConnection supplied — creating one from credentials."
+                "No DatastreamConnection supplied - creating one from credentials."
             )
             self._connection = DatastreamConnection(
                 username=username, password=password
@@ -213,7 +213,7 @@ class DatastreamDataManager:
                 f"Datastream returned an error for list '{list_code}': {error_sample}"
             )
 
-        # Parse the specified identifier column — handle three possible shapes:
+        # Parse the specified identifier column - handle three possible shapes:
         #   1. A column with one identifier per row.
         #   2. A single 'Value' column with one identifier per row.
         #   3. A 'Value' cell containing comma-separated identifiers.
@@ -422,7 +422,7 @@ class DatastreamDataManager:
         metadata : pd.DataFrame
             Raw DataFrame as returned by :meth:`get_metadata`.
         static_fields_map : dict, optional
-            Mapping of datatype code → description used for documentation
+            Mapping of datatype code -> description used for documentation
             purposes only.  Defaults to :data:`DEFAULT_STATIC_FIELDS`.
 
         Returns
@@ -476,7 +476,7 @@ class DatastreamDataManager:
         df = df[~df["value"].str.startswith("$$ER:")]
 
         # Drop rows where currency is NaN only when the API actually provided
-        # currency data — otherwise every row would be dropped.
+        # currency data - otherwise every row would be dropped.
         if has_currency:
             df = df.dropna(subset=["currency"])
 
@@ -541,11 +541,11 @@ class DatastreamDataManager:
         # Standardise column names regardless of MultiIndex depth.
         n_cols = len(long.columns)
         if n_cols == 4:
-            # (Dates, Instrument, Field, value) — no Currency level.
+            # (Dates, Instrument, Field, value) - no Currency level.
             long.columns = ["real_date", "ticker", "field", "value"]
             long["currency"] = pd.NA
         elif n_cols == 5:
-            # (Dates, Instrument, Field, Currency, value) — full MultiIndex.
+            # (Dates, Instrument, Field, Currency, value) - full MultiIndex.
             long.columns = ["real_date", "ticker", "field", "currency", "value"]
         else:
             logger.warning(
@@ -709,9 +709,9 @@ class DatastreamDataManager:
 
         Rules (from DSWS documentation):
 
-        * Single ticker, single field  → plain string ``'VOD'``.
-        * Single ticker, multiple fields → angle-bracket wrapped ``'<VOD>'``.
-        * Multiple tickers             → comma-separated ``'VOD,BP,HSBA'``
+        * Single ticker, single field  -> plain string ``'VOD'``.
+        * Single ticker, multiple fields -> angle-bracket wrapped ``'<VOD>'``.
+        * Multiple tickers             -> comma-separated ``'VOD,BP,HSBA'``
           (regardless of field count).
 
         Parameters
@@ -738,9 +738,9 @@ class DatastreamDataManager:
         Parameters
         ----------
         date : None, str, or datetime
-            * ``None``     → ``'0D'`` (today).
-            * ``datetime`` → ``'YYYY-MM-DD'``.
-            * ``str``      → returned unchanged.
+            * ``None``     -> ``'0D'`` (today).
+            * ``datetime`` -> ``'YYYY-MM-DD'``.
+            * ``str``      -> returned unchanged.
 
         Returns
         -------
@@ -758,9 +758,9 @@ class DatastreamDataManager:
         """Compute chunk sizes that maximise request size within DSWS limits.
 
         Limits enforced:
-        * tickers ≤ :data:`MAX_INSTRUMENTS_PER_REQUEST` (50)
-        * fields  ≤ :data:`MAX_DATATYPES_PER_REQUEST`   (50)
-        * tickers × fields ≤ :data:`MAX_ITEMS_PER_REQUEST` (100)
+        * tickers <= :data:`MAX_INSTRUMENTS_PER_REQUEST` (50)
+        * fields  <= :data:`MAX_DATATYPES_PER_REQUEST`   (50)
+        * tickers x fields <= :data:`MAX_ITEMS_PER_REQUEST` (100)
 
         Parameters
         ----------
@@ -772,7 +772,7 @@ class DatastreamDataManager:
         Returns
         -------
         tuple of (int, int)
-            ``(ticker_chunk_size, field_chunk_size)`` — both guaranteed ≥ 1.
+            ``(ticker_chunk_size, field_chunk_size)`` - both guaranteed >= 1.
         """
         max_t = min(n_tickers, MAX_INSTRUMENTS_PER_REQUEST)
         max_f = min(n_fields, MAX_DATATYPES_PER_REQUEST)
@@ -780,7 +780,7 @@ class DatastreamDataManager:
         if max_t * max_f <= MAX_ITEMS_PER_REQUEST:
             return max_t, max_f
 
-        # Product exceeds 100 — shrink the smaller dimension first.
+        # Product exceeds 100 - shrink the smaller dimension first.
         if n_fields <= n_tickers:
             # More tickers than fields: hold fields constant, reduce tickers.
             f_chunk = max_f
@@ -800,7 +800,7 @@ class DatastreamDataManager:
                     return t_chunk, f_chunk
                 t_chunk -= 1
 
-        # Absolute fallback — should never be reached in practice.
+        # Absolute fallback - should never be reached in practice.
         logger.warning(
             "_compute_chunk_sizes fell through to fallback (1, 1) for "
             "n_tickers=%d, n_fields=%d.",
@@ -833,7 +833,7 @@ class DatastreamDataManager:
             len(tickers), len(fields)
         )
         logger.debug(
-            "_build_chunks: %d tickers / %d fields → chunk sizes (%d, %d).",
+            "_build_chunks: %d tickers / %d fields -> chunk sizes (%d, %d).",
             len(tickers),
             len(fields),
             t_size,

--- a/macrosynergy/learning/forecasting/linear_model/sur.py
+++ b/macrosynergy/learning/forecasting/linear_model/sur.py
@@ -138,7 +138,7 @@ class LinearMultiTargetRegression(BaseEstimator, RegressorMixin):
 
             # Fit OLS jointly and store coefficients
             lr = LinearRegression(fit_intercept=False).fit(X, y)
-            W = lr.coef_.T  # shape (n_features × n_assets)
+            W = lr.coef_.T  # shape (n_features x n_assets)
             self.initial_coefs = {
                 asset: W[:, idx] for idx, asset in enumerate(self.assets)
             }

--- a/macrosynergy/management/utils/df_utils.py
+++ b/macrosynergy/management/utils/df_utils.py
@@ -1723,7 +1723,7 @@ def forward_fill_wide_df(df, blacklist=None, n=1):
 
 def _long_to_wide(df: pd.DataFrame, value_col: str) -> pd.DataFrame:
     """
-    Pivot a long-format panel to wide format (dates × cids).
+    Pivot a long-format panel to wide format (dates x cids).
 
     Parameters
     ----------
@@ -1796,7 +1796,7 @@ def rotate_cid_xcat(
     - "to_xcats": for each row, replaces "cid" with a per-stock xcat derived
       from xcat_template (substituting the cid value into the "{cid}"
       placeholder) and sets "cid" to fixed_value.
-    - "to_cids": the inverse — extracts the stock identifier from "xcat"
+    - "to_cids": the inverse - extracts the stock identifier from "xcat"
       using the template as a regex, writes it into "cid", and replaces "xcat"
       with fixed_value.
 

--- a/macrosynergy/panel/extend_history.py
+++ b/macrosynergy/panel/extend_history.py
@@ -24,7 +24,7 @@ def extend_history(
 
     .. deprecated::
         `extend_history` is deprecated and will be removed in a future release. Use
-        `merge_categories` instead — it provides per-date hierarchy fill plus the same
+        `merge_categories` instead - it provides per-date hierarchy fill plus the same
         `backfill`/`start` options.
 
     Parameters

--- a/macrosynergy/panel/return_beta.py
+++ b/macrosynergy/panel/return_beta.py
@@ -349,7 +349,7 @@ def return_beta(
         raise ValueError(min_obs_error)
 
     if not isinstance(max_obs, int) or max_obs < min_obs:
-        raise ValueError(f"`max_obs` must be an integer ≫ `min_obs`.")
+        raise ValueError(f"`max_obs` must be an integer >> `min_obs`.")
 
     # Information on hedge return and potential panel adjustment.
 

--- a/macrosynergy/pnl/sharpe_stability_ratio.py
+++ b/macrosynergy/pnl/sharpe_stability_ratio.py
@@ -86,7 +86,7 @@ def sharpe_stability_ratio(
     roll = ret_s.rolling(window=window, min_periods=_min_p)
     z_series = (roll.mean() / roll.std()) * np.sqrt(annualization_factor)
     z = z_series.values.astype(float)
-    z = z[np.isfinite(z)]  # drop NaN and ±inf (e.g. from zero-variance windows)
+    z = z[np.isfinite(z)]  # drop NaN and +/-inf (e.g. from zero-variance windows)
 
     N = len(z)
     if N < 3:
@@ -140,7 +140,7 @@ def _newey_west_heuristic_bandwidth(N: int) -> int:
 
 
 def _andrews_ar1_bandwidth(z: np.ndarray) -> int:
-    """Andrews (1991) AR(1) plug-in bandwidth — adapts to series persistence."""
+    """Andrews (1991) AR(1) plug-in bandwidth - adapts to series persistence."""
     N = len(z)
     if N < 3:
         return 1

--- a/macrosynergy/securities/index.py
+++ b/macrosynergy/securities/index.py
@@ -231,7 +231,7 @@ def compute_daily_weights(
                 )
             else:
                 logger.info(
-                    "Blacklist cid '%s' not found in constituent universe — skipped.",
+                    "Blacklist cid '%s' not found in constituent universe - skipped.",
                     cid,
                 )
         bl_effective = _build_reconstitution_membership(

--- a/macrosynergy/signal/signal_return_relations.py
+++ b/macrosynergy/signal/signal_return_relations.py
@@ -1609,17 +1609,17 @@ class SignalReturnRelations:
             ``xcats``. Internally split by membership in ``self.sigs`` /
             ``self.rets`` and routed through ``signal_name_dict`` /
             ``return_name_dict``; xcats not listed in the dict are kept
-            verbatim. Mutually exclusive with the two legacy kwargs — pass
+            verbatim. Mutually exclusive with the two legacy kwargs - pass
             either ``xcat_labels`` or ``signal_name_dict`` /
             ``return_name_dict``, not both. Default is None (no rename).
         freq_labels : dict, optional
-            Mapping from frequency code (``"M"``, ``"Q"``, …) to the
+            Mapping from frequency code (``"M"``, ``"Q"``, ...) to the
             display label used on the heatmap and in the auto axis label
             produced by the constant-level collapse. Frequencies not
             listed in the dict are kept verbatim. Default is None
             (raw codes are shown).
         agg_sigs_labels : dict, optional
-            Mapping from aggregation code (``"last"``, ``"mean"``, …) to
+            Mapping from aggregation code (``"last"``, ``"mean"``, ...) to
             the display label used on the heatmap and in the auto axis
             label produced by the constant-level collapse. Aggregations
             not listed in the dict are kept verbatim. Default is None
@@ -1631,7 +1631,7 @@ class SignalReturnRelations:
             colour); a plain list is treated as ``{xcat: "black"}``.
             Requires ``"xcat"`` in ``rows``; raises ``ValueError`` if set
             without it, if a name is not among ``sigs``, or if a colour is
-            invalid. Boxing does not reorder the table — use
+            invalid. Boxing does not reorder the table - use
             ``xcat_row_order`` for that. Default is None.
         xcat_row_order : List[str], optional
             Signal xcats (as passed to ``sigs``) giving the desired
@@ -1655,7 +1655,7 @@ class SignalReturnRelations:
             number of decimals to round the primary statistic to in the heatmap
             annotations. Default is 3.
         pval_stat : str, optional
-            name of a p-value statistic — typically ``"kendall_pval"``,
+            name of a p-value statistic - typically ``"kendall_pval"``,
             ``"pearson_pval"`` or ``"map_pval"`` (the Macrosynergy Panel
             test). When set, each heatmap cell shows the **probability of
             significance**, ``1 - pval_stat``, in brackets beneath the
@@ -2123,15 +2123,15 @@ class SignalReturnRelations:
             ``xcats``. Internally split by membership in ``self.sigs`` /
             ``self.rets`` and routed through ``signal_name_dict`` /
             ``return_name_dict``; xcats not listed in the dict are kept
-            verbatim. Mutually exclusive with the two legacy kwargs — pass
+            verbatim. Mutually exclusive with the two legacy kwargs - pass
             either ``xcat_labels`` or ``signal_name_dict`` /
             ``return_name_dict``, not both. Default is None (no rename).
         freq_labels : dict, optional
-            Mapping from frequency code (``"M"``, ``"Q"``, …) to its
+            Mapping from frequency code (``"M"``, ``"Q"``, ...) to its
             display label. Frequencies not listed in the dict are kept
             verbatim. Default is None.
         agg_sigs_labels : dict, optional
-            Mapping from aggregation code (``"last"``, ``"mean"``, …) to
+            Mapping from aggregation code (``"last"``, ``"mean"``, ...) to
             its display label. Aggregations not listed in the dict are
             kept verbatim. Default is None.
         min_color : float, optional
@@ -2148,7 +2148,7 @@ class SignalReturnRelations:
             number of decimals to round the primary statistic to in the heatmap
             annotations. Default is 3.
         pval_stat : str, optional
-            name of a p-value statistic — typically ``"kendall_pval"``,
+            name of a p-value statistic - typically ``"kendall_pval"``,
             ``"pearson_pval"`` or ``"map_pval"`` (the Macrosynergy Panel
             test). When set, each heatmap cell shows the **probability of
             significance**, ``1 - pval_stat``, in brackets beneath the
@@ -2233,15 +2233,15 @@ class SignalReturnRelations:
             ``xcats``. Internally split by membership in ``self.sigs`` /
             ``self.rets`` and routed through ``signal_name_dict`` /
             ``return_name_dict``; xcats not listed in the dict are kept
-            verbatim. Mutually exclusive with the two legacy kwargs — pass
+            verbatim. Mutually exclusive with the two legacy kwargs - pass
             either ``xcat_labels`` or ``signal_name_dict`` /
             ``return_name_dict``, not both. Default is None (no rename).
         freq_labels : dict, optional
-            Mapping from frequency code (``"M"``, ``"Q"``, …) to its
+            Mapping from frequency code (``"M"``, ``"Q"``, ...) to its
             display label. Frequencies not listed in the dict are kept
             verbatim. Default is None.
         agg_sigs_labels : dict, optional
-            Mapping from aggregation code (``"last"``, ``"mean"``, …) to
+            Mapping from aggregation code (``"last"``, ``"mean"``, ...) to
             its display label. Aggregations not listed in the dict are
             kept verbatim. Default is None.
         min_color : float, optional
@@ -2258,7 +2258,7 @@ class SignalReturnRelations:
             number of decimals to round the primary statistic to in the heatmap
             annotations. Default is 3.
         pval_stat : str, optional
-            name of a p-value statistic — typically ``"kendall_pval"``,
+            name of a p-value statistic - typically ``"kendall_pval"``,
             ``"pearson_pval"`` or ``"map_pval"`` (the Macrosynergy Panel
             test). When set, each heatmap cell shows the **probability of
             significance**, ``1 - pval_stat``, in brackets beneath the
@@ -2340,7 +2340,7 @@ class SignalReturnRelations:
             ``display_labels`` is a list of tick labels with constant levels
             removed, joined by ``" · "`` when more than one level survives.
             It is ``None`` when no collapse applies (plain ``Index``, single
-            level, no constant levels, or all levels constant — in which
+            level, no constant levels, or all levels constant - in which
             case the existing tick labels are kept). ``constant_pairs`` is
             an ordered list of ``(level_name, value)`` for each collapsed
             level, suitable for filtering and joining into an auto axis

--- a/macrosynergy/visuals/score_visualisers.py
+++ b/macrosynergy/visuals/score_visualisers.py
@@ -157,7 +157,7 @@ class ScoreVisualisers:
             )
             if source_name == "Composite":
                 warnings.warn(
-                    f"'{source_name}' found in df — using pre-computed composite instead of "
+                    f"'{source_name}' found in df - using pre-computed composite instead of "
                     "recalculating it."
                 )
             composite_df = df[df["xcat"] == source_name].copy()

--- a/tests/unit/learning/preprocessing/imputers/test_gaussian_conditional_imputer.py
+++ b/tests/unit/learning/preprocessing/imputers/test_gaussian_conditional_imputer.py
@@ -269,7 +269,7 @@ class TestFallbackBehaviour:
             [["AUD", "AUD"], pd.date_range("2020-01-01", periods=2, freq="D")],
             names=["cid", "real_date"],
         )
-        # Both rows have NaNs in different cols — no complete rows
+        # Both rows have NaNs in different cols - no complete rows
         df = pd.DataFrame(
             {"f0": [np.nan, 1.0], "f1": [1.0, np.nan]},
             index=idx,

--- a/tests/unit/learning/preprocessing/panel_selectors/test_factor_availability_selector.py
+++ b/tests/unit/learning/preprocessing/panel_selectors/test_factor_availability_selector.py
@@ -92,10 +92,10 @@ class TestDetermineFeatures:
         dates = pd.date_range("2000-01-01", periods=36, freq="M")
         n = len(cids) * len(dates)
 
-        # xcat1: fully populated — should pass
+        # xcat1: fully populated - should pass
         xcat1 = np.random.randn(n)
 
-        # xcat2: only one cid has data — should fail with min_cids=2
+        # xcat2: only one cid has data - should fail with min_cids=2
         xcat2 = np.full(n, np.nan)
         xcat2[: len(dates)] = np.random.randn(len(dates))  # only "US"
 
@@ -122,7 +122,7 @@ class TestDetermineFeatures:
             cids=cids,
             dates=dates,
         )
-        # min_periods=100 but only 10 dates exist — should still pass
+        # min_periods=100 but only 10 dates exist - should still pass
         selector = FactorAvailabilitySelector(min_cids=2, min_periods=100)
         mask = selector.determine_features(df, y=None)
 
@@ -256,10 +256,10 @@ class TestFit:
         dates = pd.date_range("2000-01-01", periods=36, freq="M")
         n = len(cids) * len(dates)
 
-        # xcat1: fully populated — should pass
+        # xcat1: fully populated - should pass
         xcat1 = np.random.randn(n)
 
-        # xcat2: only one cid has data — should fail with min_cids=2
+        # xcat2: only one cid has data - should fail with min_cids=2
         xcat2 = np.full(n, np.nan)
         xcat2[: len(dates)] = np.random.randn(len(dates))  # only "US"
 
@@ -286,7 +286,7 @@ class TestFit:
             cids=cids,
             dates=dates,
         )
-        # min_periods=100 but only 10 dates exist — should still pass
+        # min_periods=100 but only 10 dates exist - should still pass
         selector = FactorAvailabilitySelector(min_cids=2, min_periods=100)
         selector.fit(X=df, y=None)
 

--- a/tests/unit/management/test_utils.py
+++ b/tests/unit/management/test_utils.py
@@ -966,7 +966,7 @@ class TestFunctions(unittest.TestCase):
 
         # Test Case 1
 
-        # for every unique cid, xcat pair add a column "vx" which is just an integer 0→n ,
+        # for every unique cid, xcat pair add a column "vx" which is just an integer 0->n ,
         # where n is the number of unique dates for that cid, xcat pair
         df["vx"] = (
             df.groupby(["cid", "xcat"])["real_date"].rank(method="dense").astype(int)

--- a/tests/unit/panel/test_category_relations.py
+++ b/tests/unit/panel/test_category_relations.py
@@ -564,7 +564,7 @@ class TestAll(unittest.TestCase):
 
         # Test Case 1
 
-        # for every unique cid, xcat pair add a column "vx" which is just an integer 0→n ,
+        # for every unique cid, xcat pair add a column "vx" which is just an integer 0->n ,
         # where n is the number of unique dates for that cid, xcat pair
         df["vx"] = (
             df.groupby(["cid", "xcat"])["real_date"].rank(method="dense").astype(int)

--- a/tests/unit/panel/test_historic_vol.py
+++ b/tests/unit/panel/test_historic_vol.py
@@ -94,7 +94,7 @@ class TestEstimationMethods(unittest.TestCase):
         arr = np.array([0, 0, 7, 0, 0])
         w = expo_weights(len(arr), 3)
         result = sq_std(arr, w, True)
-        self.assertEqual(result, 0.0)  # only one non-zero → std = 0
+        self.assertEqual(result, 0.0)  # only one non-zero -> std = 0
 
 
 class TestAll(unittest.TestCase):
@@ -499,8 +499,8 @@ class TestAll(unittest.TestCase):
         # Daily and monthly should produce the same value whenever they
         # look at the same N most-recent observations. The last data
         # date is always a trigger, so both paths emit a value there.
-        # We compare at that single date per cid — late enough that
-        # warm-up effects are gone — and require exact agreement.
+        # We compare at that single date per cid - late enough that
+        # warm-up effects are gone - and require exact agreement.
         dfd = self._dataframe_with_holiday_gaps()
         common = dict(
             xcat="XR",

--- a/tests/unit/pnl/test_contract_signals.py
+++ b/tests/unit/pnl/test_contract_signals.py
@@ -225,9 +225,9 @@ class TestContractSignals(unittest.TestCase):
         np.testing.assert_allclose(result["GBP_FX_CSIG"].values, -3.0, atol=1e-10)
         np.testing.assert_allclose(result["EUR_FX_CSIG"].values, 0.0, atol=1e-10)
 
-        # Two ctypes — each computed independently
-        # FX: AUD=8, GBP=2 → mean=5 → RV: 3, -3
-        # IRS: AUD=-1, GBP=-3 → mean=-2 → RV: 1, -1
+        # Two ctypes - each computed independently
+        # FX: AUD=8, GBP=2 -> mean=5 -> RV: 3, -3
+        # IRS: AUD=-1, GBP=-3 -> mean=-2 -> RV: 1, -1
         df2 = pd.DataFrame(
             {
                 "AUD_FX_CSIG": 8.0,
@@ -248,8 +248,8 @@ class TestContractSignals(unittest.TestCase):
         np.testing.assert_allclose(result2["GBP_IRS_CSIG"].values, -1.0, atol=1e-10)
 
         # NaN excludes cid from the mean for that date
-        # date 0: AUD=8, GBP=NaN, EUR=4 → mean=(8+4)/2=6 → AUD=2, EUR=-2
-        # date 1: AUD=8, GBP=2, EUR=4   → mean=(8+2+4)/3≈4.667
+        # date 0: AUD=8, GBP=NaN, EUR=4 -> mean=(8+4)/2=6 -> AUD=2, EUR=-2
+        # date 1: AUD=8, GBP=2, EUR=4   -> mean=(8+2+4)/3~=4.667
         df3 = pd.DataFrame(
             {
                 "AUD_FX_CSIG": [8.0, 8.0],
@@ -273,7 +273,7 @@ class TestContractSignals(unittest.TestCase):
         self.assertAlmostEqual(result3["GBP_FX_CSIG"].iloc[1], 2.0 - mean_d1, places=10)
         self.assertAlmostEqual(result3["EUR_FX_CSIG"].iloc[1], 4.0 - mean_d1, places=10)
 
-        # Single tradable cid → position = 0
+        # Single tradable cid -> position = 0
         df4 = pd.DataFrame(
             {
                 "AUD_FX_CSIG": [7.0],
@@ -790,7 +790,7 @@ class TestRelativeValueBasket(unittest.TestCase):
             relative_value=True,
         )
 
-        # Dates 0-1: only AUD tradable → position = 0
+        # Dates 0-1: only AUD tradable -> position = 0
         for date in dates[:2]:
             aud_val = dfc.loc[
                 (dfc["cid"] == "AUD") & (dfc["real_date"] == date), "value"

--- a/tests/unit/pnl/test_sharpe_stability_ratio.py
+++ b/tests/unit/pnl/test_sharpe_stability_ratio.py
@@ -72,7 +72,7 @@ class TestSharpeStabilityRatio(unittest.TestCase):
         self.assertTrue(np.isnan(result))
 
     def test_constant_returns_returns_nan(self):
-        # Constant returns → rolling std = 0 → rolling SR = NaN/inf
+        # Constant returns -> rolling std = 0 -> rolling SR = NaN/inf
         constant = pd.Series(np.full(600, 0.001))
         result = sharpe_stability_ratio(constant)
         self.assertTrue(np.isnan(result))

--- a/tests/unit/securities/test_index.py
+++ b/tests/unit/securities/test_index.py
@@ -107,9 +107,9 @@ class TestBuildReconstitutionMembership(unittest.TestCase):
         bdays = mem_wide.index
         jan_bdays = bdays[bdays.month == 1]
         feb_bdays = bdays[bdays.month == 2]
-        # BBB was 0 on Jan 2 (first bday of Jan) → 0 for all January
+        # BBB was 0 on Jan 2 (first bday of Jan) -> 0 for all January
         self.assertTrue((result.loc[jan_bdays, "BBB"] == 0).all())
-        # BBB was 1 on Feb 3 (first bday of Feb) → 1 for all February
+        # BBB was 1 on Feb 3 (first bday of Feb) -> 1 for all February
         self.assertTrue((result.loc[feb_bdays, "BBB"] == 1).all())
 
     def test_result_has_same_shape_and_index(self):
@@ -122,7 +122,7 @@ class TestBuildReconstitutionMembership(unittest.TestCase):
     def test_always_member_unchanged(self):
         mem_wide = self._make_membership_wide()
         result = _build_reconstitution_membership(mem_wide, "M")
-        # AAA is 1 on every first bday → stays 1 for every day
+        # AAA is 1 on every first bday -> stays 1 for every day
         self.assertTrue((result["AAA"] == 1).all())
 
     def test_all_days_in_period_get_same_value(self):
@@ -372,12 +372,12 @@ class TestComputeExcessReturns(unittest.TestCase):
         returns, index_returns = self._single_stock_data()
         daily = compute_excess_returns(returns, index_returns)
         monthly = compute_excess_returns(returns, index_returns, output_freq="M")
-        # Jan–Mar 2020 → 3 monthly rows vs ~65 daily rows
+        # Jan-Mar 2020 -> 3 monthly rows vs ~65 daily rows
         self.assertEqual(len(monthly), 3)
         self.assertLess(len(monthly), len(daily))
 
     def test_output_freq_compounds_correctly(self):
-        # One month, constant returns → verify ratio compounding over N business days.
+        # One month, constant returns -> verify ratio compounding over N business days.
         bdays = pd.bdate_range("2020-01-01", "2020-01-31")
         n = len(bdays)
         returns, index_returns = self._single_stock_data(

--- a/tests/unit/signal/test_signal_return_relations.py
+++ b/tests/unit/signal/test_signal_return_relations.py
@@ -414,7 +414,7 @@ class TestAll(unittest.TestCase):
 
         # Test Case 1
 
-        # for every unique cid, xcat pair add a column "vx" which is just an integer 0→n ,
+        # for every unique cid, xcat pair add a column "vx" which is just an integer 0->n ,
         # where n is the number of unique dates for that cid, xcat pair
         df["vx"] = (
             df.groupby(["cid", "xcat"])["real_date"].rank(method="dense").astype(int)
@@ -1299,7 +1299,7 @@ class TestAll(unittest.TestCase):
                 self.assertEqual(call_kwargs.get("ylabel"), "CRY · last")
 
             # Default (collapse_constant_levels=False): byte-identical
-            # to the historical rendering — no auto y-label, no tick
+            # to the historical rendering - no auto y-label, no tick
             # collapse passed to ``view_table``.
             with patch("macrosynergy.visuals.view_table") as mock_view_table:
                 sr.single_statistic_table(
@@ -1383,7 +1383,7 @@ class TestAll(unittest.TestCase):
                 self.assertIsNone(call_kwargs.get("ylabel"))
                 self.assertIsNone(call_kwargs.get("yticklabels"))
 
-            # The returned DataFrame keeps its original MultiIndex — the
+            # The returned DataFrame keeps its original MultiIndex - the
             # collapse is display-only.
             df_returned = sr.single_statistic_table(
                 stat="kendall",
@@ -1637,7 +1637,7 @@ class TestAll(unittest.TestCase):
                 sorted(df_full.index.get_level_values("Aggregation").unique().tolist()),
                 ["Last", "Mean"],
             )
-            # Values are unchanged — only the labels move.
+            # Values are unchanged - only the labels move.
             np.testing.assert_array_equal(
                 np.sort(df_default.values.ravel()),
                 np.sort(df_full.values.ravel()),

--- a/tests/unit/visual/test_plot_availability.py
+++ b/tests/unit/visual/test_plot_availability.py
@@ -168,7 +168,7 @@ class TestPlotAvailability(unittest.TestCase):
             self.fail(f"view_availability raised {e} for all-zeros ticker")
 
     # ------------------------------------------------------------------
-    # Validation — df
+    # Validation - df
     # ------------------------------------------------------------------
 
     def test_invalid_df_not_qdf(self):
@@ -196,7 +196,7 @@ class TestPlotAvailability(unittest.TestCase):
             view_availability(df)
 
     # ------------------------------------------------------------------
-    # Validation — n_ticks
+    # Validation - n_ticks
     # ------------------------------------------------------------------
 
     def test_invalid_n_ticks_zero(self):
@@ -216,7 +216,7 @@ class TestPlotAvailability(unittest.TestCase):
             view_availability(self.df, n_ticks="ten")
 
     # ------------------------------------------------------------------
-    # Validation — kwargs dicts
+    # Validation - kwargs dicts
     # ------------------------------------------------------------------
 
     def test_invalid_kwargs_dict_type(self):


### PR DESCRIPTION
## Summary

Strips non-keyboard-typable / special characters from the codebase, replacing them with ASCII equivalents so source, docstrings, comments, docs and CI config are pure ASCII. Prompted by review feedback that unprintable characters were leaking into PR text and files.

Scope: 24 files, 131 characters. No logic changes - edits are confined to comments, docstrings, doc files, and a few log/display strings that are not asserted by any test.

## Replacements

| Character | Replaced with |
| --- | --- |
| em dash / en dash | `-` |
| rightwards / leftwards arrow | `->` / `<-` |
| horizontal ellipsis | `...` |
| less-than-or-equal / greater-than-or-equal / much-greater-than | `<=` / `>=` / `>>` |
| multiplication sign | `x` |
| plus-minus sign / almost-equal | `+/-` / `~=` |
| smart double / single quotes | straight `"` / `'` |
| no-break space | regular space |
| decorative emoji (books, pencil, info) | removed (CodeQL workflow comments) |

## Deliberately preserved

- **Middle dot (U+00B7)** is kept. It is a live plot axis-label separator in `signal_return_relations.py` (`" . ".join(...)` for x/y axis labels) and is asserted by tests. Replacing it would change rendered plot output, so it was left untouched by design.

## Verification

- Every changed source module byte-compiles.
- Repo-wide re-scan: zero remaining non-ASCII characters except the intentionally-preserved middle dot.
- Tests for all affected modules pass (signal_return_relations, contract_signals, sharpe_stability_ratio, securities/index, historic_vol, return_beta, extend_history, category_relations, datastream data_manager, and the touched test files).

## Notes

- Separate from PR #2708 (frequency-aware annualization); that PR's body text was also cleaned of mojibake but its source files were already ASCII.

Generated with [Claude Code](https://claude.com/claude-code)
